### PR TITLE
chore: remove misleading sonneborn-berger keyword

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,6 @@
     "lim",
     "no-dependencies",
     "pairings",
-    "sonneborn-berger",
     "swiss",
     "team",
     "tournament",


### PR DESCRIPTION
## Summary

- removed `sonneborn-berger` keyword from `package.json` -- it's an internal implementation detail, not a user-facing concept