### PR TITLE
fix: add top-level types field for moduleResolution node

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "engines": {
     "node": ">=20"
   },
+  "types": "./dist/index.d.ts",
   "exports": {
     ".": {
       "import": "./dist/index.js",


### PR DESCRIPTION
the top-level `types` field was missing from `package.json`. some TypeScript setups that don't resolve types through `exports` conditions can't find the type declarations.

replicates echecsjs/fen#3.