### PR TITLE
release: @echecs/swiss@3.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [3.0.3] - 2026-04-17
+
+### Fixed
+
+- Added top-level `types` field to `package.json` for TypeScript configs that
+  don't resolve types through `exports` conditions.
+
 ## [Unreleased]
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -105,5 +105,5 @@
     "test:watch": "pnpm run test --watch"
   },
   "type": "module",
-  "version": "3.0.2"
+  "version": "3.0.3"
 }


### PR DESCRIPTION
bumps to 3.0.3. the actual fix (`types` field) is already on `main`. this PR adds the version bump and changelog entry so CI can publish.