### PR TITLE
chore: add packageManager field

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "access": "public"
   },
   "name": "@echecs/swiss",
+  "packageManager": "pnpm@10.33.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/echecsjs/swiss.git"


### PR DESCRIPTION
adds packageManager to package.json — helps dependabot detect the pnpm ecosystem