### PR TITLE
feat: structured trace system + matching correctness fixes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,6 +46,8 @@ pnpm run build          # bundle TypeScript → dist/ via tsdown
 pnpm run test                          # run all tests once
 pnpm run test:watch                    # watch mode
 pnpm run test:coverage                 # with coverage report
+pnpm run test:fide                     # RTG comparison vs bbpPairings (50 tournaments)
+pnpm run test:fide 200                 # RTG comparison with custom count
 
 # Run a single test file
 pnpm run test src/__tests__/index.spec.ts
@@ -53,6 +55,11 @@ pnpm run test src/__tests__/index.spec.ts
 # Run a single test by name (substring match)
 pnpm run test -- --reporter=verbose -t "dutch"
 ```
+
+> **Note:** `test:fide` requires bbpPairings built at
+> `/tmp/bbpPairings/build/bbpPairings.exe`. It generates random tournaments with
+> bbpPairings' RTG, then compares our round-by-round pairings against what
+> bbpPairings produced.
 
 ### Lint & Format
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,6 +104,42 @@ pnpm lint && pnpm test && pnpm build
 
 ---
 
+## Trace System
+
+All `pair()` functions accept an optional third parameter
+`options?: PairOptions` with a `trace` callback for structured observability:
+
+```ts
+import { pair } from '@echecs/swiss/dutch';
+import type { TraceEvent } from '@echecs/swiss/dutch';
+
+const events: TraceEvent[] = [];
+const result = pair(players, games, { trace: (e) => events.push(e) });
+
+// filter by layer
+const blossomEvents = events.filter((e) => e.type.startsWith('blossom:'));
+const dutchEvents = events.filter(
+  (e) => e.type.startsWith('dutch:') || e.type.startsWith('pairing:'),
+);
+```
+
+### Event types
+
+**Blossom layer** (`blossom:*`): `stage-start`, `augmenting-path`, `formed`,
+`expanded`, `dual-update`, `delta`, `complete`.
+
+**Pairing layer** (`pairing:*`): `score-groups`, `bye-assigned`,
+`blossom-invoked`, `blossom-result`, `edge-weights`, `pair-finalized`,
+`color-allocated`.
+
+**Dutch-specific** (`dutch:*`): `bracket-enter`, `mdp-selected`, `weight-boost`,
+`fallback`.
+
+When no callback is provided, zero overhead — no event objects are constructed.
+The trace does not affect pairing results.
+
+---
+
 ## Unified Pairing Interface
 
 All pairing systems consumed by `@echecs/tournament` must conform to:

--- a/docs/superpowers/plans/2026-04-19-incremental-matching-computer.md
+++ b/docs/superpowers/plans/2026-04-19-incremental-matching-computer.md
@@ -1,0 +1,557 @@
+# Incremental Matching Computer Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Port bbpPairings' `matching::Computer` to TypeScript — a stateful,
+incremental maximum-weight matching computer that preserves dual variables and
+matching state across `setEdgeWeight` + `computeMatching` calls.
+
+**Architecture:** Direct port of bbpPairings' C++ implementation into a single
+TypeScript file (`src/matching-computer.ts`). Uses object references (not flat
+arrays) to match the C++ pointer-based design. Each `Vertex`, `RootBlossom`, and
+`ParentBlossom` is a class instance. The `Graph` class owns all vertices and
+blossom pools. `MatchingComputer` wraps `Graph` with the public API.
+
+**Tech Stack:** TypeScript, `DynamicUint` (existing arbitrary-precision unsigned
+integer)
+
+---
+
+## Why this approach
+
+Previous attempts failed because:
+
+1. A wrapper around the stateless blossom doesn't replicate incremental
+   dual-variable optimization
+2. Reimagining the algorithm with flat arrays lost the pointer semantics that
+   make blossom formation/dissolution work
+
+The bbpPairings C++ uses pointer-based linked lists extensively. The most
+faithful port uses JS object references the same way — each blossom/vertex is an
+object, cross-references are direct object properties. This avoids
+index-management bugs that plagued the flat-array approach.
+
+## File structure
+
+```
+src/matching-computer.ts    — ~700 lines, single file containing:
+  - Label enum
+  - Blossom base class
+  - Vertex class (extends Blossom)
+  - ParentBlossom class (extends Blossom)
+  - RootBlossom class
+  - Graph class (container + algorithm)
+  - MatchingComputer class (public API wrapper)
+
+src/__tests__/matching-computer.spec.ts — tests
+```
+
+All types are internal to the module (not exported except `MatchingComputer`).
+
+## Reference source mapping
+
+Each function in the plan maps to a bbpPairings source location:
+
+| TypeScript                                      | bbpPairings source                                               |
+| ----------------------------------------------- | ---------------------------------------------------------------- |
+| `MatchingComputer.constructor`                  | `computer.cpp:Computer()`                                        |
+| `MatchingComputer.addVertex`                    | `computer.cpp:addVertex()`                                       |
+| `MatchingComputer.setEdgeWeight`                | `computer.cpp:setEdgeWeight()`                                   |
+| `MatchingComputer.computeMatching`              | `computer.cpp:computeMatching()` → `graph.cpp:computeMatching()` |
+| `MatchingComputer.getMatching`                  | `computer.cpp:getMatching()`                                     |
+| `Graph.augmentMatching`                         | `graph.cpp:augmentMatching()`                                    |
+| `Graph.initializeLabeling`                      | `graph.cpp:initializeLabeling()`                                 |
+| `Graph.initializeInnerOuterEdges`               | `graph.cpp:initializeInnerOuterEdges()`                          |
+| `Graph.initializeOuterOuterEdges`               | `graph.cpp:initializeOuterOuterEdges()`                          |
+| `Graph.updateInnerOuterEdges`                   | `graph.cpp:updateInnerOuterEdges()`                              |
+| `augmentToSource`                               | `rootblossom.cpp:augmentToSource()`                              |
+| `RootBlossom.prepareVertexForWeightAdjustments` | `rootblossomimpl.h:prepareVertexForWeightAdjustments()`          |
+| `RootBlossom.freeAncestorOfBase`                | `rootblossom.cpp:freeAncestorOfBase()`                           |
+| `RootBlossom.putVerticesInMatchingOrder`        | `rootblossom.cpp:putVerticesInMatchingOrder()`                   |
+| `ParentBlossom.connectChildren`                 | `parentblossom.cpp:connectChildren()`                            |
+
+---
+
+### Task 1: Data structures — Blossom, Vertex, ParentBlossom, RootBlossom
+
+**Files:**
+
+- Create: `src/matching-computer.ts`
+- Test: `src/__tests__/matching-computer.spec.ts`
+
+Port the four core data structures. Each is a class with the same fields as the
+C++ version but using object references instead of pointers. `null` replaces C++
+`nullptr`.
+
+Key fields per class:
+
+**Blossom** (abstract base):
+
+- `rootBlossom: RootBlossom`
+- `parentBlossom: ParentBlossom | null`
+- `vertexListHead: Vertex`, `vertexListTail: Vertex`
+- `vertexToPrevSibling: Vertex | null`, `vertexToNextSibling: Vertex | null`
+- `nextBlossom: Blossom | null`, `prevBlossom: Blossom | null`
+- `isVertex: boolean`
+
+**Vertex** (extends Blossom):
+
+- `edgeWeights: DynamicUint[]` — indexed by vertexIndex
+- `dualVariable: DynamicUint` — reference into graph.vertexDualVariables
+- `minOuterEdgeResistance: DynamicUint`
+- `minOuterEdge: Vertex | null`
+- `nextVertex: Vertex | null` — linked list within root blossom
+- `vertexIndex: number`
+- `resistance(other: Vertex): DynamicUint` —
+  `dual[this] + dual[other] - edgeWeight[this][other]`
+
+**ParentBlossom** (extends Blossom):
+
+- `dualVariable: DynamicUint`
+- `subblossom: Blossom | null`
+- `iterationStartsWithSubblossom: boolean`
+- `connectChildren(path: Vertex[])` — initializes circular sibling list
+
+**RootBlossom**:
+
+- `rootChild: Blossom`
+- `baseVertex: Vertex`
+- `baseVertexMatch: Vertex | null`
+- `label: Label`
+- `labelingVertex: Vertex | null`, `labeledVertex: Vertex | null`
+- `minOuterEdges: (Vertex | null)[]` — indexed by vertexIndex
+- `minOuterEdgeResistance: DynamicUint`
+- `prepareVertexForWeightAdjustments(vertex, graph)`
+- `freeAncestorOfBase(ancestor, graph)`
+- `putVerticesInMatchingOrder()`
+
+- [ ] **Step 1: Write tests for basic data structure creation**
+
+```typescript
+import { describe, expect, it } from 'vitest';
+import { MatchingComputer } from '../matching-computer.js';
+import { DynamicUint } from '../dynamic-uint.js';
+
+describe('MatchingComputer', () => {
+  it('starts with zero vertices', () => {
+    const mc = new MatchingComputer(10, DynamicUint.from(100));
+    expect(mc.size()).toBe(0);
+  });
+
+  it('addVertex increases size', () => {
+    const mc = new MatchingComputer(4, DynamicUint.from(100));
+    mc.addVertex();
+    mc.addVertex();
+    expect(mc.size()).toBe(2);
+  });
+
+  it('unmatched vertices match to themselves', () => {
+    const mc = new MatchingComputer(3, DynamicUint.from(100));
+    mc.addVertex();
+    mc.addVertex();
+    mc.addVertex();
+    mc.computeMatching();
+    expect(mc.getMatching()).toEqual([0, 1, 2]);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm test src/__tests__/matching-computer.spec.ts`
+
+- [ ] **Step 3: Implement data structures + MatchingComputer shell**
+
+Create `src/matching-computer.ts` with all four classes and the
+`MatchingComputer` wrapper. The `computeMatching` calls
+`graph.computeMatching()` which calls `while (augmentMatching()) {}` — but
+`augmentMatching` returns `false` (stub). `getMatching` walks root blossoms.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pnpm test src/__tests__/matching-computer.spec.ts`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/matching-computer.ts src/__tests__/matching-computer.spec.ts
+git commit -m "feat(matching): data structures for incremental matching computer"
+```
+
+---
+
+### Task 2: Graph algorithm — augmentMatching core loop
+
+**Files:**
+
+- Modify: `src/matching-computer.ts`
+- Modify: `src/__tests__/matching-computer.spec.ts`
+
+Port the `augmentMatching` method from `graph.cpp`. This is the main
+dual-variable adjustment loop. It calls:
+
+- `initializeLabeling()` — set labels based on matching state
+- `initializeInnerOuterEdges()` — compute min resistance from non-OUTER to OUTER
+- `initializeOuterOuterEdges()` — compute min resistance between OUTER pairs
+- Then the while loop: compute dual adjustment → apply → check condition
+
+The loop handles 5 conditions:
+
+1. `minOuterDualVariable = 0` → augment via `augmentToSource`
+2. `minInnerOuterResist = 0 && ZERO` → augment ZERO-to-OUTER
+3. `minOuterOuterResist = 0` → form blossom or augment
+4. `minInnerOuterResist = 0 && FREE` → label FREE→INNER, match→OUTER
+5. `minInnerDualVariable = 0` → dissolve inner blossom
+
+For this task, implement conditions 1, 2, and 4 (augmentation and labeling).
+Conditions 3 and 5 (blossom formation and dissolution) are Task 3.
+
+Also implement `augmentToSource` — the simple while loop from `rootblossom.cpp`:
+
+```typescript
+function augmentToSource(vertex: Vertex, newMatch: Vertex | null): void {
+  while (vertex.rootBlossom.baseVertexMatch) {
+    vertex.rootBlossom.baseVertex = vertex;
+    const originalMatch = vertex.rootBlossom.baseVertexMatch.rootBlossom;
+    vertex.rootBlossom.baseVertexMatch = newMatch;
+    originalMatch.baseVertex = originalMatch.labeledVertex!;
+    originalMatch.baseVertexMatch = originalMatch.labelingVertex!;
+    vertex = originalMatch.labelingVertex!;
+    newMatch = originalMatch.labeledVertex!;
+  }
+  vertex.rootBlossom.baseVertex = vertex;
+  vertex.rootBlossom.baseVertexMatch = newMatch;
+}
+```
+
+- [ ] **Step 1: Write tests for simple matching (no blossoms needed)**
+
+```typescript
+it('matches a simple 2-vertex graph', () => {
+  const mc = new MatchingComputer(2, DynamicUint.from(100));
+  mc.addVertex();
+  mc.addVertex();
+  mc.setEdgeWeight(0, 1, DynamicUint.from(10));
+  mc.computeMatching();
+  expect(mc.getMatching()).toEqual([1, 0]);
+});
+
+it('matches two independent pairs', () => {
+  const mc = new MatchingComputer(4, DynamicUint.from(100));
+  for (let i = 0; i < 4; i++) mc.addVertex();
+  mc.setEdgeWeight(0, 1, DynamicUint.from(10));
+  mc.setEdgeWeight(2, 3, DynamicUint.from(10));
+  mc.computeMatching();
+  expect(mc.getMatching()).toEqual([1, 0, 3, 2]);
+});
+
+it('matches a 4-vertex path maximizing cardinality', () => {
+  const mc = new MatchingComputer(4, DynamicUint.from(100));
+  for (let i = 0; i < 4; i++) mc.addVertex();
+  mc.setEdgeWeight(0, 1, DynamicUint.from(10));
+  mc.setEdgeWeight(1, 2, DynamicUint.from(20));
+  mc.setEdgeWeight(2, 3, DynamicUint.from(10));
+  mc.computeMatching();
+  const m = mc.getMatching();
+  // Max cardinality: 0-1 + 2-3 (total 20, same as 1-2 alone but 2 pairs vs 1)
+  expect(m[0]).toBe(1);
+  expect(m[1]).toBe(0);
+  expect(m[2]).toBe(3);
+  expect(m[3]).toBe(2);
+});
+
+it('supports incremental updates', () => {
+  const mc = new MatchingComputer(4, DynamicUint.from(100));
+  for (let i = 0; i < 4; i++) mc.addVertex();
+  mc.setEdgeWeight(0, 1, DynamicUint.from(10));
+  mc.setEdgeWeight(2, 3, DynamicUint.from(10));
+  mc.computeMatching();
+  expect(mc.getMatching()).toEqual([1, 0, 3, 2]);
+
+  mc.setEdgeWeight(1, 2, DynamicUint.from(50));
+  mc.computeMatching();
+  const m = mc.getMatching();
+  expect(m[1]).toBe(2);
+  expect(m[2]).toBe(1);
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+- [ ] **Step 3: Implement augmentMatching (conditions 1, 2, 4) +
+      augmentToSource + helper functions**
+
+Port directly from `graph.cpp:augmentMatching()`. For condition 3 (blossom
+formation), stub it to `continue` (skip). For condition 5 (blossom dissolution),
+stub it to `continue`.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/matching-computer.ts src/__tests__/matching-computer.spec.ts
+git commit -m "feat(matching): augmentMatching core loop with dual adjustment"
+```
+
+---
+
+### Task 3: Blossom formation and dissolution
+
+**Files:**
+
+- Modify: `src/matching-computer.ts`
+- Modify: `src/__tests__/matching-computer.spec.ts`
+
+Port the remaining two conditions from `augmentMatching`:
+
+- **Condition 3** (`minOuterOuterResist = 0`): build alternating path from both
+  vertices back to their root, check if same root blossom. If same → form new
+  blossom (odd cycle contraction via `ParentBlossom`). If different → augment.
+- **Condition 5** (`minInnerDualVariable = 0`): dissolve an INNER blossom back
+  into its sub-blossoms, creating new root blossoms for each child.
+
+Also port `freeAncestorOfBase` from `rootblossom.cpp` — needed by
+`prepareVertexForWeightAdjustments`.
+
+- [ ] **Step 1: Write tests that require blossom handling**
+
+```typescript
+it('matches a triangle correctly (requires blossom)', () => {
+  const mc = new MatchingComputer(3, DynamicUint.from(100));
+  for (let i = 0; i < 3; i++) mc.addVertex();
+  mc.setEdgeWeight(0, 1, DynamicUint.from(10));
+  mc.setEdgeWeight(1, 2, DynamicUint.from(20));
+  mc.setEdgeWeight(0, 2, DynamicUint.from(15));
+  mc.computeMatching();
+  const m = mc.getMatching();
+  expect(m[1]).toBe(2);
+  expect(m[2]).toBe(1);
+  expect(m[0]).toBe(0); // unmatched
+});
+
+it('handles a 5-vertex graph with blossom', () => {
+  // K5-like subgraph that forces blossom contraction
+  const mc = new MatchingComputer(5, DynamicUint.from(100));
+  for (let i = 0; i < 5; i++) mc.addVertex();
+  mc.setEdgeWeight(0, 1, DynamicUint.from(10));
+  mc.setEdgeWeight(1, 2, DynamicUint.from(10));
+  mc.setEdgeWeight(2, 0, DynamicUint.from(10)); // triangle
+  mc.setEdgeWeight(0, 3, DynamicUint.from(5));
+  mc.setEdgeWeight(2, 4, DynamicUint.from(5));
+  mc.computeMatching();
+  const m = mc.getMatching();
+  // Should find 2 pairs (max cardinality): e.g. 0-3, 1-2, 4 unmatched
+  // or 0-1, 2-4, 3 unmatched
+  let paired = 0;
+  for (let i = 0; i < 5; i++) if (m[i] !== i) paired++;
+  expect(paired).toBe(4); // 2 pairs = 4 matched vertices
+});
+
+it('handles blossom dissolution during incremental update', () => {
+  const mc = new MatchingComputer(6, DynamicUint.from(100));
+  for (let i = 0; i < 6; i++) mc.addVertex();
+  mc.setEdgeWeight(0, 1, DynamicUint.from(10));
+  mc.setEdgeWeight(1, 2, DynamicUint.from(10));
+  mc.setEdgeWeight(2, 0, DynamicUint.from(10));
+  mc.setEdgeWeight(3, 4, DynamicUint.from(10));
+  mc.setEdgeWeight(4, 5, DynamicUint.from(10));
+  mc.computeMatching();
+
+  // Now connect the triangle to the path
+  mc.setEdgeWeight(2, 3, DynamicUint.from(20));
+  mc.computeMatching();
+  const m = mc.getMatching();
+  // Should match 2-3 (weight 20) and find other pairs
+  expect(m[2]).toBe(3);
+  expect(m[3]).toBe(2);
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+- [ ] **Step 3: Implement blossom formation (condition 3)**
+
+Port the path-building logic from `graph.cpp` (lines starting at
+`std::deque path`):
+
+1. Build path from both vertices back to root
+2. If same root → trim common prefix → form ParentBlossom via `connectChildren`
+3. If different roots → augment
+
+- [ ] **Step 4: Implement blossom dissolution (condition 5)**
+
+Port from `graph.cpp` (the `!minInnerDualVariable` block):
+
+1. Hide the root blossom being dissolved
+2. Find rootChild and connectChild
+3. Walk the circular child list, creating new RootBlossoms with appropriate
+   labels
+4. Destroy the old ParentBlossom and RootBlossom
+
+- [ ] **Step 5: Implement freeAncestorOfBase**
+
+Port from `rootblossom.cpp`. This is needed when `setEdgeWeight` disrupts a
+vertex inside a non-trivial blossom.
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+- [ ] **Step 7: Run the full test suite**
+
+Run: `pnpm lint && pnpm test`
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/matching-computer.ts src/__tests__/matching-computer.spec.ts
+git commit -m "feat(matching): blossom formation and dissolution"
+```
+
+---
+
+### Task 4: computeMatching, getMatching, cross-validation
+
+**Files:**
+
+- Modify: `src/matching-computer.ts`
+- Modify: `src/__tests__/matching-computer.spec.ts`
+
+Port `computeMatching` (parity fixup) and `getMatching`
+(putVerticesInMatchingOrder). Add cross-validation tests against the existing
+`maxWeightMatching`.
+
+- [ ] **Step 1: Write cross-validation test**
+
+```typescript
+import { maxWeightMatching } from '../blossom.js';
+
+it('produces same total weight as maxWeightMatching on random graphs', () => {
+  for (let trial = 0; trial < 50; trial++) {
+    const n = 4 + Math.floor(Math.random() * 8);
+    const maxW = 100;
+    const mc = new MatchingComputer(n, DynamicUint.from(maxW));
+    const edges: [number, number, DynamicUint][] = [];
+    for (let i = 0; i < n; i++) mc.addVertex();
+    for (let i = 0; i < n; i++) {
+      for (let j = i + 1; j < n; j++) {
+        if (Math.random() < 0.5) {
+          const w = DynamicUint.from(1 + Math.floor(Math.random() * maxW));
+          mc.setEdgeWeight(i, j, w.clone());
+          edges.push([i, j, w]);
+        }
+      }
+    }
+    mc.computeMatching();
+    const mcM = mc.getMatching();
+    const blossomM = maxWeightMatching(edges, true);
+
+    let mcWeight = 0n,
+      blossomWeight = 0n;
+    for (const [u, v, w] of edges) {
+      if (mcM[u] === v) mcWeight += w.toBigInt();
+      if (blossomM[u] === v) blossomWeight += w.toBigInt();
+    }
+    expect(mcWeight).toBe(blossomWeight);
+  }
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails (if parity fixup is missing)**
+
+- [ ] **Step 3: Implement parity fixup in computeMatching**
+
+Port from `graph.cpp:computeMatching()` — the loop that ensures exposed vertex
+dual variables have even parity.
+
+- [ ] **Step 4: Implement putVerticesInMatchingOrder in getMatching**
+
+Port from `rootblossom.cpp`. This reorders the vertex linked list so matched
+vertices are consecutive, which `getMatching` needs to read internal matching
+pairs.
+
+- [ ] **Step 5: Run all tests**
+
+Run: `pnpm lint && pnpm test`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/matching-computer.ts src/__tests__/matching-computer.spec.ts
+git commit -m "feat(matching): computeMatching parity fixup and cross-validation"
+```
+
+---
+
+### Task 5: Integrate into dutch.ts
+
+**Files:**
+
+- Modify: `src/dutch.ts`
+- Modify: `src/__tests__/dutch.fixtures.spec.ts`
+
+Replace `EdgeWeightMatrix` + `buildCurrentEdges` + `runBlossom` + `finalizePair`
+with `MatchingComputer` calls.
+
+- [ ] **Step 1: Change `it.fails` to `it` for the exact pairings test**
+
+- [ ] **Step 2: Run test to verify RED**
+
+- [ ] **Step 3: Replace dutch.ts matching infrastructure**
+
+Key changes:
+
+- Create `MatchingComputer` once with `np` vertices and `maxEdgeWeight`
+- Replace `matrix.set(a, b, w)` → `computer.setEdgeWeight(a, b, w)`
+- Replace `runBlossom()` →
+  `computer.computeMatching(); stableMatching = computer.getMatching()`
+- Replace `finalizePair(v1, v2, ...)` →
+  `computer.setEdgeWeight(v1, v2, maxEdgeWeight)` + zero all other edges for v1
+  and v2
+- Remove `EdgeWeightMatrix`, `buildCurrentEdges`, `runBlossom`, `finalizePair`
+
+- [ ] **Step 4: Run all tests to verify GREEN**
+
+- [ ] **Step 5: Run full verification**
+
+Run: `pnpm lint && pnpm test && pnpm build`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/dutch.ts src/__tests__/dutch.fixtures.spec.ts
+git commit -m "feat(dutch): integrate incremental matching computer for FIDE compliance"
+```
+
+---
+
+### Task 6: Cleanup and performance
+
+**Files:**
+
+- Modify: `src/matching-computer.ts` (if optimization needed)
+- Modify: `src/dutch.ts` (remove dead code)
+
+- [ ] **Step 1: Check test timing**
+
+Run: `pnpm test -- --reporter=verbose`
+
+Verify `issue_15` (180 players) completes in < 30 seconds.
+
+- [ ] **Step 2: Remove dead code**
+
+Remove `EdgeWeightMatrix` if unused. Remove old `baseEdgeWeights` array if the
+matching computer handles it.
+
+- [ ] **Step 3: Full verification**
+
+Run: `pnpm lint && pnpm test && pnpm build`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add -A
+git commit -m "refactor(dutch): remove unused EdgeWeightMatrix and stateless blossom wrappers"
+```

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -65,7 +65,7 @@ export default typescript.config(
     files: ['**/*.{mts,ts,tsx}'],
     languageOptions: {
       parserOptions: {
-        project: ['./tsconfig.json'],
+        project: ['./tsconfig.json', './scripts/tsconfig.json'],
         tsconfigRootDir: import.meta.dirname,
       },
     },

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "lint-staged": "^16.4.0",
     "prettier": "^3.8.1",
     "tsdown": "^0.21.4",
+    "tsx": "^4.21.0",
     "typedoc": "^0.28.17",
     "typescript": "^6.0.2",
     "typescript-eslint": "^8.57.0",

--- a/package.json
+++ b/package.json
@@ -103,6 +103,7 @@
     "prepare": "husky && pnpm run build",
     "test": "vitest run",
     "test:coverage": "pnpm run test --coverage",
+    "test:fide": "tsx scripts/rtg-compare.mts",
     "test:watch": "pnpm run test --watch"
   },
   "type": "module",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,34 +10,34 @@ importers:
     devDependencies:
       '@echecs/trf':
         specifier: ^3.1.1
-        version: 3.4.0
+        version: 3.1.1
       '@eslint/js':
         specifier: ^10.0.1
-        version: 10.0.1(eslint@10.2.1)
+        version: 10.0.1(eslint@10.0.3)
       '@typescript-eslint/parser':
         specifier: ^8.57.0
-        version: 8.59.0(eslint@10.2.1)(typescript@6.0.3)
+        version: 8.57.0(eslint@10.0.3)(typescript@6.0.2)
       '@vitest/coverage-v8':
         specifier: ^4.1.0
-        version: 4.1.0(vitest@4.1.0(@types/node@25.5.0)(vite@8.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.5.0)(yaml@2.8.3)))
+        version: 4.1.0(vitest@4.1.0(@types/node@25.5.0)(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.8.2)))
       '@vitest/eslint-plugin':
         specifier: ^1.6.12
-        version: 1.6.16(@typescript-eslint/eslint-plugin@8.59.0(@typescript-eslint/parser@8.59.0(eslint@10.2.1)(typescript@6.0.3))(eslint@10.2.1)(typescript@6.0.3))(eslint@10.2.1)(typescript@6.0.3)(vitest@4.1.0(@types/node@25.5.0)(vite@8.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.5.0)(yaml@2.8.3)))
+        version: 1.6.12(eslint@10.0.3)(typescript@6.0.2)(vitest@4.1.0(@types/node@25.5.0)(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.8.2)))
       eslint:
         specifier: ^10.0.3
-        version: 10.2.1
+        version: 10.0.3
       eslint-config-prettier:
         specifier: ^10.1.8
-        version: 10.1.8(eslint@10.2.1)
+        version: 10.1.8(eslint@10.0.3)
       eslint-import-resolver-typescript:
         specifier: ^4.4.4
-        version: 4.4.4(eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.59.0(eslint@10.2.1)(typescript@6.0.3))(eslint@10.2.1))(eslint@10.2.1)
+        version: 4.4.4(eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.57.0(eslint@10.0.3)(typescript@6.0.2))(eslint@10.0.3))(eslint@10.0.3)
       eslint-plugin-import-x:
         specifier: ^4.16.2
-        version: 4.16.2(@typescript-eslint/utils@8.59.0(eslint@10.2.1)(typescript@6.0.3))(eslint@10.2.1)
+        version: 4.16.2(@typescript-eslint/utils@8.57.0(eslint@10.0.3)(typescript@6.0.2))(eslint@10.0.3)
       eslint-plugin-unicorn:
         specifier: ^64.0.0
-        version: 64.0.0(eslint@10.2.1)
+        version: 64.0.0(eslint@10.0.3)
       husky:
         specifier: ^9.1.7
         version: 9.1.7
@@ -46,27 +46,30 @@ importers:
         version: 16.4.0
       prettier:
         specifier: ^3.8.1
-        version: 3.8.3
+        version: 3.8.1
       tsdown:
         specifier: ^0.21.4
-        version: 0.21.10(typescript@6.0.3)
+        version: 0.21.4(typescript@6.0.2)
+      tsx:
+        specifier: ^4.21.0
+        version: 4.21.0
       typedoc:
         specifier: ^0.28.17
-        version: 0.28.19(typescript@6.0.3)
+        version: 0.28.17(typescript@6.0.2)
       typescript:
         specifier: ^6.0.2
-        version: 6.0.3
+        version: 6.0.2
       typescript-eslint:
         specifier: ^8.57.0
-        version: 8.59.0(eslint@10.2.1)(typescript@6.0.3)
+        version: 8.57.0(eslint@10.0.3)(typescript@6.0.2)
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@types/node@25.5.0)(vite@8.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.5.0)(yaml@2.8.3))
+        version: 4.1.0(@types/node@25.5.0)(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.8.2))
 
 packages:
 
-  '@babel/generator@8.0.0-rc.3':
-    resolution: {integrity: sha512-em37/13/nR320G4jab/nIIHZgc2Wz2y/D39lxnTyxB4/D/omPQncl/lSdlnJY1OhQcRGugTSIF2l/69o31C9dA==}
+  '@babel/generator@8.0.0-rc.2':
+    resolution: {integrity: sha512-oCQ1IKPwkzCeJzAPb7Fv8rQ9k5+1sG8mf2uoHiMInPYvkRfrDJxbTIbH51U+jstlkghus0vAi3EBvkfvEsYNLQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
 
   '@babel/helper-string-parser@7.27.1':
@@ -81,8 +84,8 @@ packages:
     resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-validator-identifier@8.0.0-rc.3':
-    resolution: {integrity: sha512-8AWCJ2VJJyDFlGBep5GpaaQ9AAaE/FjAcrqI7jyssYhtL7WGV0DOKpJsQqM037xDbpRLHXsY8TwU7zDma7coOw==}
+  '@babel/helper-validator-identifier@8.0.0-rc.2':
+    resolution: {integrity: sha512-xExUBkuXWJjVuIbO7z6q7/BA9bgfJDEhVL0ggrggLMbg0IzCUWGT1hZGE8qUH7Il7/RD/a6cZ3AAFrrlp1LF/A==}
     engines: {node: ^20.19.0 || >=22.12.0}
 
   '@babel/parser@7.29.0':
@@ -90,8 +93,8 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
-  '@babel/parser@8.0.0-rc.3':
-    resolution: {integrity: sha512-B20dvP3MfNc/XS5KKCHy/oyWl5IA6Cn9YjXRdDlCjNmUFrjvLXMNUfQq/QUy9fnG2gYkKKcrto2YaF9B32ToOQ==}
+  '@babel/parser@8.0.0-rc.2':
+    resolution: {integrity: sha512-29AhEtcq4x8Dp3T72qvUMZHx0OMXCj4Jy/TEReQa+KWLln524Cj1fWb3QFi0l/xSpptQBR6y9RNEXuxpFvwiUQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
@@ -99,26 +102,182 @@ packages:
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/types@8.0.0-rc.3':
-    resolution: {integrity: sha512-mOm5ZrYmphGfqVWoH5YYMTITb3cDXsFgmvFlvkvWDMsR9X8RFnt7a0Wb6yNIdoFsiMO9WjYLq+U/FMtqIYAF8Q==}
+  '@babel/types@8.0.0-rc.2':
+    resolution: {integrity: sha512-91gAaWRznDwSX4E2tZ1YjBuIfnQVOFDCQ2r0Toby0gu4XEbyF623kXLMA8d4ZbCu+fINcrudkmEcwSUHgDDkNw==}
     engines: {node: ^20.19.0 || >=22.12.0}
 
   '@bcoe/v8-coverage@1.0.2':
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
     engines: {node: '>=18'}
 
-  '@echecs/trf@3.4.0':
-    resolution: {integrity: sha512-JEhN16qTjU8xZpDzKaILRpn/8BldqaYKiY9qhXcyr3mMYeuk65LAbiCPDDpO9Oe+2TQiNjP3HQfidObUnyuk1w==}
+  '@echecs/trf@3.1.1':
+    resolution: {integrity: sha512-CRlMCMlHoi4w6U3q1Uz3Fi5ZJmMvJjSWicxV+F3mZXcJqzAscQcBmmDYTdiocqNdFXgjV+IOL83/IDThM3eZ9Q==}
     engines: {node: '>=20'}
 
-  '@emnapi/core@1.10.0':
-    resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
+  '@emnapi/core@1.9.0':
+    resolution: {integrity: sha512-0DQ98G9ZQZOxfUcQn1waV2yS8aWdZ6kJMbYCJB3oUBecjWYO1fqJ+a1DRfPF3O5JEkwqwP1A9QEN/9mYm2Yd0w==}
 
-  '@emnapi/runtime@1.10.0':
-    resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
+  '@emnapi/runtime@1.9.0':
+    resolution: {integrity: sha512-QN75eB0IH2ywSpRpNddCRfQIhmJYBCJ1x5Lb3IscKAL8bMnVAKnRg8dCoXbHzVLLH7P38N2Z3mtulB7W0J0FKw==}
 
-  '@emnapi/wasi-threads@1.2.1':
-    resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
+  '@emnapi/wasi-threads@1.2.0':
+    resolution: {integrity: sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==}
+
+  '@esbuild/aix-ppc64@0.27.7':
+    resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.27.7':
+    resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.27.7':
+    resolution: {integrity: sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.27.7':
+    resolution: {integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.27.7':
+    resolution: {integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.27.7':
+    resolution: {integrity: sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.27.7':
+    resolution: {integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.27.7':
+    resolution: {integrity: sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.27.7':
+    resolution: {integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.27.7':
+    resolution: {integrity: sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.27.7':
+    resolution: {integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.27.7':
+    resolution: {integrity: sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.27.7':
+    resolution: {integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.27.7':
+    resolution: {integrity: sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.27.7':
+    resolution: {integrity: sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.27.7':
+    resolution: {integrity: sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.27.7':
+    resolution: {integrity: sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.27.7':
+    resolution: {integrity: sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.27.7':
+    resolution: {integrity: sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.27.7':
+    resolution: {integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.27.7':
+    resolution: {integrity: sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.27.7':
+    resolution: {integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.27.7':
+    resolution: {integrity: sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.27.7':
+    resolution: {integrity: sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
 
   '@eslint-community/eslint-utils@4.9.1':
     resolution: {integrity: sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==}
@@ -130,16 +289,16 @@ packages:
     resolution: {integrity: sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==}
     engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
 
-  '@eslint/config-array@0.23.5':
-    resolution: {integrity: sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==}
+  '@eslint/config-array@0.23.3':
+    resolution: {integrity: sha512-j+eEWmB6YYLwcNOdlwQ6L2OsptI/LO6lNBuLIqe5R7RetD658HLoF+Mn7LzYmAWWNNzdC6cqP+L6r8ujeYXWLw==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
-  '@eslint/config-helpers@0.5.5':
-    resolution: {integrity: sha512-eIJYKTCECbP/nsKaaruF6LW967mtbQbsw4JTtSVkUQc9MneSkbrgPJAbKl9nWr0ZeowV8BfsarBmPpBzGelA2w==}
+  '@eslint/config-helpers@0.5.3':
+    resolution: {integrity: sha512-lzGN0onllOZCGroKJmRwY6QcEHxbjBw1gwB8SgRSqK8YbbtEXMvKynsXc3553ckIEBxsbMBU7oOZXKIPGZNeZw==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
-  '@eslint/core@1.2.1':
-    resolution: {integrity: sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==}
+  '@eslint/core@1.1.1':
+    resolution: {integrity: sha512-QUPblTtE51/7/Zhfv8BDwO0qkkzQL7P/aWWbqcf4xWLEYn1oKjdO0gglQBB4GAsu7u6wjijbCmzsUTy6mnk6oQ==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
   '@eslint/js@10.0.1':
@@ -151,27 +310,23 @@ packages:
       eslint:
         optional: true
 
-  '@eslint/object-schema@3.0.5':
-    resolution: {integrity: sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==}
+  '@eslint/object-schema@3.0.3':
+    resolution: {integrity: sha512-iM869Pugn9Nsxbh/YHRqYiqd23AmIbxJOcpUMOuWCVNdoQJ5ZtwL6h3t0bcZzJUlC3Dq9jCFCESBZnX0GTv7iQ==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
-  '@eslint/plugin-kit@0.7.1':
-    resolution: {integrity: sha512-rZAP3aVgB9ds9KOeUSL+zZ21hPmo8dh6fnIFwRQj5EAZl9gzR7wxYbYXYysAM8CTqGmUGyp2S4kUdV17MnGuWQ==}
+  '@eslint/plugin-kit@0.6.1':
+    resolution: {integrity: sha512-iH1B076HoAshH1mLpHMgwdGeTs0CYwL0SPMkGuSebZrwBp16v415e9NZXg2jtrqPVQjf6IANe2Vtlr5KswtcZQ==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
   '@gerrit0/mini-shiki@3.23.0':
     resolution: {integrity: sha512-bEMORlG0cqdjVyCEuU0cDQbORWX+kYCeo0kV1lbxF5bt4r7SID2l9bqsxJEM0zndaxpOUT7riCyIVEuqq/Ynxg==}
 
-  '@humanfs/core@0.19.2':
-    resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
+  '@humanfs/core@0.19.1':
+    resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
     engines: {node: '>=18.18.0'}
 
-  '@humanfs/node@0.16.8':
-    resolution: {integrity: sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==}
-    engines: {node: '>=18.18.0'}
-
-  '@humanfs/types@0.15.0':
-    resolution: {integrity: sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==}
+  '@humanfs/node@0.16.7':
+    resolution: {integrity: sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==}
     engines: {node: '>=18.18.0'}
 
   '@humanwhocodes/module-importer@1.0.1':
@@ -198,11 +353,8 @@ packages:
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
 
-  '@napi-rs/wasm-runtime@1.1.4':
-    resolution: {integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==}
-    peerDependencies:
-      '@emnapi/core': ^1.7.1
-      '@emnapi/runtime': ^1.7.1
+  '@napi-rs/wasm-runtime@1.1.1':
+    resolution: {integrity: sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==}
 
   '@oxc-project/runtime@0.115.0':
     resolution: {integrity: sha512-Rg8Wlt5dCbXhQnsXPrkOjL1DTSvXLgb2R/KYfnf1/K+R0k6UMLEmbQXPM+kwrWqSmWA2t0B1EtHy2/3zikQpvQ==}
@@ -211,20 +363,11 @@ packages:
   '@oxc-project/types@0.115.0':
     resolution: {integrity: sha512-4n91DKnebUS4yjUHl2g3/b2T+IUdCfmoZGhmwsovZCDaJSs+QkVAM+0AqqTxHSsHfeiMuueT75cZaZcT/m0pSw==}
 
-  '@oxc-project/types@0.127.0':
-    resolution: {integrity: sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==}
-
   '@package-json/types@0.0.12':
     resolution: {integrity: sha512-uu43FGU34B5VM9mCNjXCwLaGHYjXdNincqKLaraaCW+7S2+SmiBg1Nv8bPnmschrIfZmfKNY9f3fC376MRrObw==}
 
   '@quansync/fs@1.0.0':
     resolution: {integrity: sha512-4TJ3DFtlf1L5LDMaM6CanJ/0lckGNtJcMjQ1NAV6zDmA0tEHKZtxNKin8EgPaVX1YzljbxckyT2tJrpQKAtngQ==}
-
-  '@rolldown/binding-android-arm64@1.0.0-rc.17':
-    resolution: {integrity: sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [android]
 
   '@rolldown/binding-android-arm64@1.0.0-rc.9':
     resolution: {integrity: sha512-lcJL0bN5hpgJfSIz/8PIf02irmyL43P+j1pTCfbD1DbLkmGRuFIA4DD3B3ZOvGqG0XiVvRznbKtN0COQVaKUTg==}
@@ -232,22 +375,10 @@ packages:
     cpu: [arm64]
     os: [android]
 
-  '@rolldown/binding-darwin-arm64@1.0.0-rc.17':
-    resolution: {integrity: sha512-4ksWc9n0mhlZpZ9PMZgTGjeOPRu8MB1Z3Tz0Mo02eWfWCHMW1zN82Qz/pL/rC+yQa+8ZnutMF0JjJe7PjwasYw==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [darwin]
-
   '@rolldown/binding-darwin-arm64@1.0.0-rc.9':
     resolution: {integrity: sha512-J7Zk3kLYFsLtuH6U+F4pS2sYVzac0qkjcO5QxHS7OS7yZu2LRs+IXo+uvJ/mvpyUljDJ3LROZPoQfgBIpCMhdQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
-    os: [darwin]
-
-  '@rolldown/binding-darwin-x64@1.0.0-rc.17':
-    resolution: {integrity: sha512-SUSDOI6WwUVNcWxd02QEBjLdY1VPHvlEkw6T/8nYG322iYWCTxRb1vzk4E+mWWYehTp7ERibq54LSJGjmouOsw==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
     os: [darwin]
 
   '@rolldown/binding-darwin-x64@1.0.0-rc.9':
@@ -256,36 +387,17 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@rolldown/binding-freebsd-x64@1.0.0-rc.17':
-    resolution: {integrity: sha512-hwnz3nw9dbJ05EDO/PvcjaaewqqDy7Y1rn1UO81l8iIK1GjenME75dl16ajbvSSMfv66WXSRCYKIqfgq2KCfxw==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [freebsd]
-
   '@rolldown/binding-freebsd-x64@1.0.0-rc.9':
     resolution: {integrity: sha512-DLFYI78SCiZr5VvdEplsVC2Vx53lnA4/Ga5C65iyldMVaErr86aiqCoNBLl92PXPfDtUYjUh+xFFor40ueNs4Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.17':
-    resolution: {integrity: sha512-IS+W7epTcwANmFSQFrS1SivEXHtl1JtuQA9wlxrZTcNi6mx+FDOYrakGevvvTwgj2JvWiK8B29/qD9BELZPyXQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm]
-    os: [linux]
-
   '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.9':
     resolution: {integrity: sha512-CsjTmTwd0Hri6iTw/DRMK7kOZ7FwAkrO4h8YWKoX/kcj833e4coqo2wzIFywtch/8Eb5enQ/lwLM7w6JX1W5RQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
-
-  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.17':
-    resolution: {integrity: sha512-e6usGaHKW5BMNZOymS1UcEYGowQMWcgZ71Z17Sl/h2+ZziNJ1a9n3Zvcz6LdRyIW5572wBCTH/Z+bKuZouGk9Q==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.9':
     resolution: {integrity: sha512-2x9O2JbSPxpxMDhP9Z74mahAStibTlrBMW0520+epJH5sac7/LwZW5Bmg/E6CXuEF53JJFW509uP+lSedaUNxg==}
@@ -294,13 +406,6 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.17':
-    resolution: {integrity: sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [linux]
-    libc: [musl]
-
   '@rolldown/binding-linux-arm64-musl@1.0.0-rc.9':
     resolution: {integrity: sha512-JA1QRW31ogheAIRhIg9tjMfsYbglXXYGNPLdPEYrwFxdbkQCAzvpSCSHCDWNl4hTtrol8WeboCSEpjdZK8qrCg==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -308,24 +413,10 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.17':
-    resolution: {integrity: sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [ppc64]
-    os: [linux]
-    libc: [glibc]
-
   '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.9':
     resolution: {integrity: sha512-aOKU9dJheda8Kj8Y3w9gnt9QFOO+qKPAl8SWd7JPHP+Cu0EuDAE5wokQubLzIDQWg2myXq2XhTpOVS07qqvT+w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
-    os: [linux]
-    libc: [glibc]
-
-  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.17':
-    resolution: {integrity: sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
@@ -336,26 +427,12 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.17':
-    resolution: {integrity: sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [linux]
-    libc: [glibc]
-
   '@rolldown/binding-linux-x64-gnu@1.0.0-rc.9':
     resolution: {integrity: sha512-cVEl1vZtBsBZna3YMjGXNvnYYrOJ7RzuWvZU0ffvJUexWkukMaDuGhUXn0rjnV0ptzGVkvc+vW9Yqy6h8YX4pg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
-
-  '@rolldown/binding-linux-x64-musl@1.0.0-rc.17':
-    resolution: {integrity: sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-linux-x64-musl@1.0.0-rc.9':
     resolution: {integrity: sha512-UzYnKCIIc4heAKgI4PZ3dfBGUZefGCJ1TPDuLHoCzgrMYPb5Rv6TLFuYtyM4rWyHM7hymNdsg5ik2C+UD9VDbA==}
@@ -364,33 +441,16 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@rolldown/binding-openharmony-arm64@1.0.0-rc.17':
-    resolution: {integrity: sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [openharmony]
-
   '@rolldown/binding-openharmony-arm64@1.0.0-rc.9':
     resolution: {integrity: sha512-+6zoiF+RRyf5cdlFQP7nm58mq7+/2PFaY2DNQeD4B87N36JzfF/l9mdBkkmTvSYcYPE8tMh/o3cRlsx1ldLfog==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
 
-  '@rolldown/binding-wasm32-wasi@1.0.0-rc.17':
-    resolution: {integrity: sha512-LEXei6vo0E5wTGwpkJ4KoT3OZJRnglwldt5ziLzOlc6qqb55z4tWNq2A+PFqCJuvWWdP53CVhG1Z9NtToDPJrA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [wasm32]
-
   '@rolldown/binding-wasm32-wasi@1.0.0-rc.9':
     resolution: {integrity: sha512-rgFN6sA/dyebil3YTlL2evvi/M+ivhfnyxec7AccTpRPccno/rPoNlqybEZQBkcbZu8Hy+eqNJCqfBR8P7Pg8g==}
     engines: {node: '>=14.0.0'}
     cpu: [wasm32]
-
-  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.17':
-    resolution: {integrity: sha512-gUmyzBl3SPMa6hrqFUth9sVfcLBlYsbMzBx5PlexMroZStgzGqlZ26pYG89rBb45Mnia+oil6YAIFeEWGWhoZA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [win32]
 
   '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.9':
     resolution: {integrity: sha512-lHVNUG/8nlF1IQk1C0Ci574qKYyty2goMiPlRqkC5R+3LkXDkL5Dhx8ytbxq35m+pkHVIvIxviD+TWLdfeuadA==}
@@ -398,20 +458,11 @@ packages:
     cpu: [arm64]
     os: [win32]
 
-  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.17':
-    resolution: {integrity: sha512-3hkiolcUAvPB9FLb3UZdfjVVNWherN1f/skkGWJP/fgSQhYUZpSIRr0/I8ZK9TkF3F7kxvJAk0+IcKvPHk9qQg==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [win32]
-
   '@rolldown/binding-win32-x64-msvc@1.0.0-rc.9':
     resolution: {integrity: sha512-G0oA4+w1iY5AGi5HcDTxWsoxF509hrFIPB2rduV5aDqS9FtDg1CAfa7V34qImbjfhIcA8C+RekocJZA96EarwQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
-
-  '@rolldown/pluginutils@1.0.0-rc.17':
-    resolution: {integrity: sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==}
 
   '@rolldown/pluginutils@1.0.0-rc.9':
     resolution: {integrity: sha512-w6oiRWgEBl04QkFZgmW+jnU1EC9b57Oihi2ot3HNWIQRqgHp5PnYDia5iZ5FF7rpa4EQdiqMDXjlqKGXBhsoXw==}
@@ -464,67 +515,63 @@ packages:
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
 
-  '@typescript-eslint/eslint-plugin@8.59.0':
-    resolution: {integrity: sha512-HyAZtpdkgZwpq8Sz3FSUvCR4c+ScbuWa9AksK2Jweub7w4M3yTz4O11AqVJzLYjy/B9ZWPyc81I+mOdJU/bDQw==}
+  '@typescript-eslint/eslint-plugin@8.57.0':
+    resolution: {integrity: sha512-qeu4rTHR3/IaFORbD16gmjq9+rEs9fGKdX0kF6BKSfi+gCuG3RCKLlSBYzn/bGsY9Tj7KE/DAQStbp8AHJGHEQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      '@typescript-eslint/parser': ^8.59.0
+      '@typescript-eslint/parser': ^8.57.0
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
-      typescript: '>=4.8.4 <6.1.0'
+      typescript: '>=4.8.4 <6.0.0'
 
-  '@typescript-eslint/parser@8.59.0':
-    resolution: {integrity: sha512-TI1XGwKbDpo9tRW8UDIXCOeLk55qe9ZFGs8MTKU6/M08HWTw52DD/IYhfQtOEhEdPhLMT26Ka/x7p70nd3dzDg==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
-      typescript: '>=4.8.4 <6.1.0'
-
-  '@typescript-eslint/project-service@8.59.0':
-    resolution: {integrity: sha512-Lw5ITrR5s5TbC19YSvlr63ZfLaJoU6vtKTHyB0GQOpX0W7d5/Ir6vUahWi/8Sps/nOukZQ0IB3SmlxZnjaKVnw==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      typescript: '>=4.8.4 <6.1.0'
-
-  '@typescript-eslint/scope-manager@8.59.0':
-    resolution: {integrity: sha512-UzR16Ut8IpA3Mc4DbgAShlPPkVm8xXMWafXxB0BocaVRHs8ZGakAxGRskF7FId3sdk9lgGD73GSFaWmWFDE4dg==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@typescript-eslint/tsconfig-utils@8.59.0':
-    resolution: {integrity: sha512-91Sbl3s4Kb3SybliIY6muFBmHVv+pYXfybC4Oolp3dvk8BvIE3wOPc+403CWIT7mJNkfQRGtdqghzs2+Z91Tqg==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      typescript: '>=4.8.4 <6.1.0'
-
-  '@typescript-eslint/type-utils@8.59.0':
-    resolution: {integrity: sha512-3TRiZaQSltGqGeNrJzzr1+8YcEobKH9rHnqIp/1psfKFmhRQDNMGP5hBufanYTGznwShzVLs3Mz+gDN7HkWfXg==}
+  '@typescript-eslint/parser@8.57.0':
+    resolution: {integrity: sha512-XZzOmihLIr8AD1b9hL9ccNMzEMWt/dE2u7NyTY9jJG6YNiNthaD5XtUHVF2uCXZ15ng+z2hT3MVuxnUYhq6k1g==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
-      typescript: '>=4.8.4 <6.1.0'
+      typescript: '>=4.8.4 <6.0.0'
+
+  '@typescript-eslint/project-service@8.57.0':
+    resolution: {integrity: sha512-pR+dK0BlxCLxtWfaKQWtYr7MhKmzqZxuii+ZjuFlZlIGRZm22HnXFqa2eY+90MUz8/i80YJmzFGDUsi8dMOV5w==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.0.0'
+
+  '@typescript-eslint/scope-manager@8.57.0':
+    resolution: {integrity: sha512-nvExQqAHF01lUM66MskSaZulpPL5pgy5hI5RfrxviLgzZVffB5yYzw27uK/ft8QnKXI2X0LBrHJFr1TaZtAibw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/tsconfig-utils@8.57.0':
+    resolution: {integrity: sha512-LtXRihc5ytjJIQEH+xqjB0+YgsV4/tW35XKX3GTZHpWtcC8SPkT/d4tqdf1cKtesryHm2bgp6l555NYcT2NLvA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.0.0'
+
+  '@typescript-eslint/type-utils@8.57.0':
+    resolution: {integrity: sha512-yjgh7gmDcJ1+TcEg8x3uWQmn8ifvSupnPfjP21twPKrDP/pTHlEQgmKcitzF/rzPSmv7QjJ90vRpN4U+zoUjwQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.0.0'
 
   '@typescript-eslint/types@8.57.0':
     resolution: {integrity: sha512-dTLI8PEXhjUC7B9Kre+u0XznO696BhXcTlOn0/6kf1fHaQW8+VjJAVHJ3eTI14ZapTxdkOmc80HblPQLaEeJdg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@typescript-eslint/types@8.59.0':
-    resolution: {integrity: sha512-nLzdsT1gdOgFxxxwrlNVUBzSNBEEHJ86bblmk4QAS6stfig7rcJzWKqCyxFy3YRRHXDWEkb2NralA1nOYkkm/A==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@typescript-eslint/typescript-estree@8.59.0':
-    resolution: {integrity: sha512-O9Re9P1BmBLFJyikRbQpLku/QA3/AueZNO9WePLBwQrvkixTmDe8u76B6CYUAITRl/rHawggEqUGn5QIkVRLMw==}
+  '@typescript-eslint/typescript-estree@8.57.0':
+    resolution: {integrity: sha512-m7faHcyVg0BT3VdYTlX8GdJEM7COexXxS6KqGopxdtkQRvBanK377QDHr4W/vIPAR+ah9+B/RclSW5ldVniO1Q==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      typescript: '>=4.8.4 <6.1.0'
+      typescript: '>=4.8.4 <6.0.0'
 
-  '@typescript-eslint/utils@8.59.0':
-    resolution: {integrity: sha512-I1R/K7V07XsMJ12Oaxg/O9GfrysGTmCRhvZJBv0RE0NcULMzjqVpR5kRRQjHsz3J/bElU7HwCO7zkqL+MSUz+g==}
+  '@typescript-eslint/utils@8.57.0':
+    resolution: {integrity: sha512-5iIHvpD3CZe06riAsbNxxreP+MuYgVUsV0n4bwLH//VJmgtt54sQeY2GszntJ4BjYCpMzrfVh2SBnUQTtys2lQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
-      typescript: '>=4.8.4 <6.1.0'
+      typescript: '>=4.8.4 <6.0.0'
 
-  '@typescript-eslint/visitor-keys@8.59.0':
-    resolution: {integrity: sha512-/uejZt4dSere1bx12WLlPfv8GktzcaDtuJ7s42/HEZ5zGj9oxRaD4bj7qwSunXkf+pbAhFt2zjpHYUiT5lHf0Q==}
+  '@typescript-eslint/visitor-keys@8.57.0':
+    resolution: {integrity: sha512-zm6xx8UT/Xy2oSr2ZXD0pZo7Jx2XsCoID2IUh9YSTFRu7z+WdwYTRk6LhUftm1crwqbuoF6I8zAFeCMw0YjwDg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@unrs/resolver-binding-android-arm-eabi@1.11.1':
@@ -639,17 +686,14 @@ packages:
       '@vitest/browser':
         optional: true
 
-  '@vitest/eslint-plugin@1.6.16':
-    resolution: {integrity: sha512-2pBN1F1JXq6zTSaYC58CMJa7pGxXIRsLfOioeZM4cPE3pRdSh1ySTSoHPQlOTEF5WgoVzWZQxhGQ3ygT78hOVg==}
+  '@vitest/eslint-plugin@1.6.12':
+    resolution: {integrity: sha512-4kI47BJNFE+EQ5bmPbHzBF+ibNzx2Fj0Jo9xhWsTPxMddlHwIWl6YAxagefh461hrwx/W0QwBZpxGS404kBXyg==}
     engines: {node: '>=18'}
     peerDependencies:
-      '@typescript-eslint/eslint-plugin': '*'
       eslint: '>=8.57.0'
       typescript: '>=5.0.0'
       vitest: '*'
     peerDependenciesMeta:
-      '@typescript-eslint/eslint-plugin':
-        optional: true
       typescript:
         optional: true
       vitest:
@@ -694,8 +738,8 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
-  ajv@6.15.0:
-    resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
+  ajv@6.14.0:
+    resolution: {integrity: sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==}
 
   ansi-escapes@7.3.0:
     resolution: {integrity: sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==}
@@ -727,6 +771,9 @@ packages:
   ast-v8-to-istanbul@1.0.0:
     resolution: {integrity: sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==}
 
+  balanced-match@1.0.2:
+    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
@@ -739,12 +786,11 @@ packages:
   birpc@4.0.0:
     resolution: {integrity: sha512-LShSxJP0KTmd101b6DRyGBj57LZxSDYWKitQNW/mi8GRMvZb078Uf9+pveax1DrVL89vm7mWe+TovdI/UDOuPw==}
 
+  brace-expansion@2.0.2:
+    resolution: {integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==}
+
   brace-expansion@5.0.4:
     resolution: {integrity: sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==}
-    engines: {node: 18 || 20 || >=22}
-
-  brace-expansion@5.0.5:
-    resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
     engines: {node: 18 || 20 || >=22}
 
   browserslist@4.28.1:
@@ -819,8 +865,8 @@ packages:
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
-  defu@6.1.7:
-    resolution: {integrity: sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==}
+  defu@6.1.4:
+    resolution: {integrity: sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==}
 
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
@@ -855,6 +901,11 @@ packages:
 
   es-module-lexer@2.0.0:
     resolution: {integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==}
+
+  esbuild@0.27.7:
+    resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
@@ -927,8 +978,8 @@ packages:
     resolution: {integrity: sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
-  eslint@10.2.1:
-    resolution: {integrity: sha512-wiyGaKsDgqXvF40P8mDwiUp/KQjE1FdrIEJsM8PZ3XCiniTMXS3OHWWUe5FI5agoCnr8x4xPrTDZuxsBlNHl+Q==}
+  eslint@10.0.3:
+    resolution: {integrity: sha512-COV33RzXZkqhG9P2rZCFl9ZmJ7WL+gQSCRzE7RhkbclbQPtLAWReL7ysA0Sh4c8Im2U9ynybdR56PV0XcKvqaQ==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
     hasBin: true
     peerDependencies:
@@ -1001,8 +1052,8 @@ packages:
     resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
     engines: {node: '>=16'}
 
-  flatted@3.4.2:
-    resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
+  flatted@3.4.1:
+    resolution: {integrity: sha512-IxfVbRFVlV8V/yRaGzk0UVIcsKKHMSfYw66T/u4nTwlWteQePsxe//LjudR1AMX4tZW3WFCh3Zqa/sjlqpbURQ==}
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
@@ -1016,9 +1067,6 @@ packages:
   get-tsconfig@4.13.6:
     resolution: {integrity: sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==}
 
-  get-tsconfig@4.14.0:
-    resolution: {integrity: sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==}
-
   glob-parent@6.0.2:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
     engines: {node: '>=10.13.0'}
@@ -1031,8 +1079,8 @@ packages:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
 
-  hookable@6.1.1:
-    resolution: {integrity: sha512-U9LYDy1CwhMCnprUfeAZWZGByVbhd54hwepegYTK7Pi5NvqEj63ifz5z+xukznehT7i6NIZRu89Ay1AZmRsLEQ==}
+  hookable@6.1.0:
+    resolution: {integrity: sha512-ZoKZSJgu8voGK2geJS+6YtYjvIzu9AOM/KZXsBxr83uhLL++e9pEv/dlgwgy3dvHg06kTz6JOh1hk3C8Ceiymw==}
 
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
@@ -1050,8 +1098,8 @@ packages:
     resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
     engines: {node: '>= 4'}
 
-  import-without-cache@0.3.3:
-    resolution: {integrity: sha512-bDxwDdF04gm550DfZHgffvlX+9kUlcz32UD0AeBTmVPFiWkrexF2XVmiuFFbDhiFuP8fQkrkvI2KdSNPYWAXkQ==}
+  import-without-cache@0.2.5:
+    resolution: {integrity: sha512-B6Lc2s6yApwnD2/pMzFh/d5AVjdsDXjgkeJ766FmFuJELIGHNycKRj+l3A39yZPM4CchqNCB4RITEAYB1KUM6A==}
     engines: {node: '>=20.19.0'}
 
   imurmurhash@0.1.4:
@@ -1242,9 +1290,9 @@ packages:
     resolution: {integrity: sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==}
     engines: {node: 18 || 20 || >=22}
 
-  minimatch@10.2.5:
-    resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
-    engines: {node: 18 || 20 || >=22}
+  minimatch@9.0.9:
+    resolution: {integrity: sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==}
+    engines: {node: '>=16 || 14 >=14.17'}
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -1302,24 +1350,20 @@ packages:
     resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
     engines: {node: '>=12'}
 
-  picomatch@4.0.4:
-    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
-    engines: {node: '>=12'}
-
   pluralize@8.0.0:
     resolution: {integrity: sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==}
     engines: {node: '>=4'}
 
-  postcss@8.5.10:
-    resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
+  postcss@8.5.8:
+    resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
     engines: {node: ^10 || ^12 || >=14}
 
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
 
-  prettier@3.8.3:
-    resolution: {integrity: sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==}
+  prettier@3.8.1:
+    resolution: {integrity: sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==}
     engines: {node: '>=14'}
     hasBin: true
 
@@ -1352,14 +1396,14 @@ packages:
   rfdc@1.4.1:
     resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
 
-  rolldown-plugin-dts@0.23.2:
-    resolution: {integrity: sha512-PbSqLawLgZBGcOGT3yqWBGn4cX+wh2nt5FuBGdcMHyOhoukmjbhYAl8NT9sE4U38Cm9tqLOIQeOrvzeayM0DLQ==}
+  rolldown-plugin-dts@0.22.5:
+    resolution: {integrity: sha512-M/HXfM4cboo+jONx9Z0X+CUf3B5tCi7ni+kR5fUW50Fp9AlZk0oVLesibGWgCXDKFp5lpgQ9yhKoImUFjl3VZw==}
     engines: {node: '>=20.19.0'}
     peerDependencies:
       '@ts-macro/tsc': ^0.3.6
-      '@typescript/native-preview': '>=7.0.0-dev.20260325.1'
-      rolldown: ^1.0.0-rc.12
-      typescript: ^5.0.0 || ^6.0.0
+      '@typescript/native-preview': '>=7.0.0-dev.20250601.1'
+      rolldown: ^1.0.0-rc.3
+      typescript: ^5.0.0 || ^6.0.0-beta
       vue-tsc: ~3.2.0
     peerDependenciesMeta:
       '@ts-macro/tsc':
@@ -1370,11 +1414,6 @@ packages:
         optional: true
       vue-tsc:
         optional: true
-
-  rolldown@1.0.0-rc.17:
-    resolution: {integrity: sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    hasBin: true
 
   rolldown@1.0.0-rc.9:
     resolution: {integrity: sha512-9EbgWge7ZH+yqb4d2EnELAntgPTWbfL8ajiTW+SyhJEC4qhBbkCKbqFV4Ge4zmu5ziQuVbWxb/XwLZ+RIO7E8Q==}
@@ -1454,16 +1493,8 @@ packages:
     resolution: {integrity: sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==}
     engines: {node: '>=18'}
 
-  tinyexec@1.1.1:
-    resolution: {integrity: sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==}
-    engines: {node: '>=18'}
-
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
-    engines: {node: '>=12.0.0'}
-
-  tinyglobby@0.2.16:
-    resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
     engines: {node: '>=12.0.0'}
 
   tinyrainbow@3.1.0:
@@ -1474,23 +1505,23 @@ packages:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
     hasBin: true
 
-  ts-api-utils@2.5.0:
-    resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
+  ts-api-utils@2.4.0:
+    resolution: {integrity: sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA==}
     engines: {node: '>=18.12'}
     peerDependencies:
       typescript: '>=4.8.4'
 
-  tsdown@0.21.10:
-    resolution: {integrity: sha512-3wk73yBhZe/wX7REqSdivNQ84TDs1mJ+IlnzrrEREP70xlJ/AEIzqaI04l/TzMKVIdkTdC3CPaADn2Lk/0SkdA==}
+  tsdown@0.21.4:
+    resolution: {integrity: sha512-Q/kBi8SXkr4X6JI/NAZKZY1UuiEcbuXtIskL4tZCsgpDiEPM/2W6lC+OonNA31S+V3KsWedFvbFDBs23hvt+Aw==}
     engines: {node: '>=20.19.0'}
     hasBin: true
     peerDependencies:
       '@arethetypeswrong/core': ^0.18.1
-      '@tsdown/css': 0.21.10
-      '@tsdown/exe': 0.21.10
+      '@tsdown/css': 0.21.4
+      '@tsdown/exe': 0.21.4
       '@vitejs/devtools': '*'
       publint: ^0.3.0
-      typescript: ^5.0.0 || ^6.0.0
+      typescript: ^5.0.0
       unplugin-unused: ^0.5.0
     peerDependenciesMeta:
       '@arethetypeswrong/core':
@@ -1511,26 +1542,31 @@ packages:
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
+  tsx@4.21.0:
+    resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
 
-  typedoc@0.28.19:
-    resolution: {integrity: sha512-wKh+lhdmMFivMlc6vRRcMGXeGEHGU2g8a2CkPTJjJlwRf1iXbimWIPcFolCqe4E0d/FRtGszpIrsp3WLpDB8Pw==}
+  typedoc@0.28.17:
+    resolution: {integrity: sha512-ZkJ2G7mZrbxrKxinTQMjFqsCoYY6a5Luwv2GKbTnBCEgV2ihYm5CflA9JnJAwH0pZWavqfYxmDkFHPt4yx2oDQ==}
     engines: {node: '>= 18', pnpm: '>= 10'}
     hasBin: true
     peerDependencies:
-      typescript: 5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x || 5.7.x || 5.8.x || 5.9.x || 6.0.x
+      typescript: 5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x || 5.7.x || 5.8.x || 5.9.x
 
-  typescript-eslint@8.59.0:
-    resolution: {integrity: sha512-BU3ONW9X+v90EcCH9ZS6LMackcVtxRLlI3XrYyqZIwVSHIk7Qf7bFw1z0M9Q0IUxhTMZCf8piY9hTYaNEIASrw==}
+  typescript-eslint@8.57.0:
+    resolution: {integrity: sha512-W8GcigEMEeB07xEZol8oJ26rigm3+bfPHxHvwbYUlu1fUDsGuQ7Hiskx5xGW/xM4USc9Ephe3jtv7ZYPQntHeA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
-      typescript: '>=4.8.4 <6.1.0'
+      typescript: '>=4.8.4 <6.0.0'
 
-  typescript@6.0.3:
-    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
+  typescript@6.0.2:
+    resolution: {integrity: sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -1546,8 +1582,8 @@ packages:
   unrs-resolver@1.11.1:
     resolution: {integrity: sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg==}
 
-  unrun@0.2.37:
-    resolution: {integrity: sha512-AA7vDuYsgeSYVzJMm16UKA+aXFKhy7nFqW9z5l7q44K4ppFWZAMqYS58ePRZbugMLPH0fwwMzD5A8nP0avxwZQ==}
+  unrun@0.2.32:
+    resolution: {integrity: sha512-opd3z6791rf281JdByf0RdRQrpcc7WyzqittqIXodM/5meNWdTwrVxeyzbaCp4/Rgls/um14oUaif1gomO8YGg==}
     engines: {node: '>=20.19.0'}
     hasBin: true
     peerDependencies:
@@ -1666,21 +1702,16 @@ packages:
     engines: {node: '>= 14.6'}
     hasBin: true
 
-  yaml@2.8.3:
-    resolution: {integrity: sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==}
-    engines: {node: '>= 14.6'}
-    hasBin: true
-
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
 
 snapshots:
 
-  '@babel/generator@8.0.0-rc.3':
+  '@babel/generator@8.0.0-rc.2':
     dependencies:
-      '@babel/parser': 8.0.0-rc.3
-      '@babel/types': 8.0.0-rc.3
+      '@babel/parser': 8.0.0-rc.2
+      '@babel/types': 8.0.0-rc.2
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
       '@types/jsesc': 2.5.1
@@ -1692,78 +1723,156 @@ snapshots:
 
   '@babel/helper-validator-identifier@7.28.5': {}
 
-  '@babel/helper-validator-identifier@8.0.0-rc.3': {}
+  '@babel/helper-validator-identifier@8.0.0-rc.2': {}
 
   '@babel/parser@7.29.0':
     dependencies:
       '@babel/types': 7.29.0
 
-  '@babel/parser@8.0.0-rc.3':
+  '@babel/parser@8.0.0-rc.2':
     dependencies:
-      '@babel/types': 8.0.0-rc.3
+      '@babel/types': 8.0.0-rc.2
 
   '@babel/types@7.29.0':
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
 
-  '@babel/types@8.0.0-rc.3':
+  '@babel/types@8.0.0-rc.2':
     dependencies:
       '@babel/helper-string-parser': 8.0.0-rc.3
-      '@babel/helper-validator-identifier': 8.0.0-rc.3
+      '@babel/helper-validator-identifier': 8.0.0-rc.2
 
   '@bcoe/v8-coverage@1.0.2': {}
 
-  '@echecs/trf@3.4.0': {}
+  '@echecs/trf@3.1.1': {}
 
-  '@emnapi/core@1.10.0':
+  '@emnapi/core@1.9.0':
     dependencies:
-      '@emnapi/wasi-threads': 1.2.1
+      '@emnapi/wasi-threads': 1.2.0
       tslib: 2.8.1
     optional: true
 
-  '@emnapi/runtime@1.10.0':
-    dependencies:
-      tslib: 2.8.1
-    optional: true
-
-  '@emnapi/wasi-threads@1.2.1':
+  '@emnapi/runtime@1.9.0':
     dependencies:
       tslib: 2.8.1
     optional: true
 
-  '@eslint-community/eslint-utils@4.9.1(eslint@10.2.1)':
+  '@emnapi/wasi-threads@1.2.0':
     dependencies:
-      eslint: 10.2.1
+      tslib: 2.8.1
+    optional: true
+
+  '@esbuild/aix-ppc64@0.27.7':
+    optional: true
+
+  '@esbuild/android-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/android-arm@0.27.7':
+    optional: true
+
+  '@esbuild/android-x64@0.27.7':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/darwin-x64@0.27.7':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-arm@0.27.7':
+    optional: true
+
+  '@esbuild/linux-ia32@0.27.7':
+    optional: true
+
+  '@esbuild/linux-loong64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.27.7':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-s390x@0.27.7':
+    optional: true
+
+  '@esbuild/linux-x64@0.27.7':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/sunos-x64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-ia32@0.27.7':
+    optional: true
+
+  '@esbuild/win32-x64@0.27.7':
+    optional: true
+
+  '@eslint-community/eslint-utils@4.9.1(eslint@10.0.3)':
+    dependencies:
+      eslint: 10.0.3
       eslint-visitor-keys: 3.4.3
 
   '@eslint-community/regexpp@4.12.2': {}
 
-  '@eslint/config-array@0.23.5':
+  '@eslint/config-array@0.23.3':
     dependencies:
-      '@eslint/object-schema': 3.0.5
+      '@eslint/object-schema': 3.0.3
       debug: 4.4.3
-      minimatch: 10.2.5
+      minimatch: 10.2.4
     transitivePeerDependencies:
       - supports-color
 
-  '@eslint/config-helpers@0.5.5':
+  '@eslint/config-helpers@0.5.3':
     dependencies:
-      '@eslint/core': 1.2.1
+      '@eslint/core': 1.1.1
 
-  '@eslint/core@1.2.1':
+  '@eslint/core@1.1.1':
     dependencies:
       '@types/json-schema': 7.0.15
 
-  '@eslint/js@10.0.1(eslint@10.2.1)':
+  '@eslint/js@10.0.1(eslint@10.0.3)':
     optionalDependencies:
-      eslint: 10.2.1
+      eslint: 10.0.3
 
-  '@eslint/object-schema@3.0.5': {}
+  '@eslint/object-schema@3.0.3': {}
 
-  '@eslint/plugin-kit@0.7.1':
+  '@eslint/plugin-kit@0.6.1':
     dependencies:
-      '@eslint/core': 1.2.1
+      '@eslint/core': 1.1.1
       levn: 0.4.1
 
   '@gerrit0/mini-shiki@3.23.0':
@@ -1774,17 +1883,12 @@ snapshots:
       '@shikijs/types': 3.23.0
       '@shikijs/vscode-textmate': 10.0.2
 
-  '@humanfs/core@0.19.2':
-    dependencies:
-      '@humanfs/types': 0.15.0
+  '@humanfs/core@0.19.1': {}
 
-  '@humanfs/node@0.16.8':
+  '@humanfs/node@0.16.7':
     dependencies:
-      '@humanfs/core': 0.19.2
-      '@humanfs/types': 0.15.0
+      '@humanfs/core': 0.19.1
       '@humanwhocodes/retry': 0.4.3
-
-  '@humanfs/types@0.15.0': {}
 
   '@humanwhocodes/module-importer@1.0.1': {}
 
@@ -1806,15 +1910,15 @@ snapshots:
 
   '@napi-rs/wasm-runtime@0.2.12':
     dependencies:
-      '@emnapi/core': 1.10.0
-      '@emnapi/runtime': 1.10.0
+      '@emnapi/core': 1.9.0
+      '@emnapi/runtime': 1.9.0
       '@tybys/wasm-util': 0.10.1
     optional: true
 
-  '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
+  '@napi-rs/wasm-runtime@1.1.1':
     dependencies:
-      '@emnapi/core': 1.10.0
-      '@emnapi/runtime': 1.10.0
+      '@emnapi/core': 1.9.0
+      '@emnapi/runtime': 1.9.0
       '@tybys/wasm-util': 0.10.1
     optional: true
 
@@ -1822,114 +1926,58 @@ snapshots:
 
   '@oxc-project/types@0.115.0': {}
 
-  '@oxc-project/types@0.127.0': {}
-
   '@package-json/types@0.0.12': {}
 
   '@quansync/fs@1.0.0':
     dependencies:
       quansync: 1.0.0
 
-  '@rolldown/binding-android-arm64@1.0.0-rc.17':
-    optional: true
-
   '@rolldown/binding-android-arm64@1.0.0-rc.9':
-    optional: true
-
-  '@rolldown/binding-darwin-arm64@1.0.0-rc.17':
     optional: true
 
   '@rolldown/binding-darwin-arm64@1.0.0-rc.9':
     optional: true
 
-  '@rolldown/binding-darwin-x64@1.0.0-rc.17':
-    optional: true
-
   '@rolldown/binding-darwin-x64@1.0.0-rc.9':
-    optional: true
-
-  '@rolldown/binding-freebsd-x64@1.0.0-rc.17':
     optional: true
 
   '@rolldown/binding-freebsd-x64@1.0.0-rc.9':
     optional: true
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.17':
-    optional: true
-
   '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.9':
-    optional: true
-
-  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.17':
     optional: true
 
   '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.9':
     optional: true
 
-  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.17':
-    optional: true
-
   '@rolldown/binding-linux-arm64-musl@1.0.0-rc.9':
-    optional: true
-
-  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.17':
     optional: true
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.9':
     optional: true
 
-  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.17':
-    optional: true
-
   '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.9':
-    optional: true
-
-  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.17':
     optional: true
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-rc.9':
     optional: true
 
-  '@rolldown/binding-linux-x64-musl@1.0.0-rc.17':
-    optional: true
-
   '@rolldown/binding-linux-x64-musl@1.0.0-rc.9':
-    optional: true
-
-  '@rolldown/binding-openharmony-arm64@1.0.0-rc.17':
     optional: true
 
   '@rolldown/binding-openharmony-arm64@1.0.0-rc.9':
     optional: true
 
-  '@rolldown/binding-wasm32-wasi@1.0.0-rc.17':
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.9':
     dependencies:
-      '@emnapi/core': 1.10.0
-      '@emnapi/runtime': 1.10.0
-      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
-    optional: true
-
-  '@rolldown/binding-wasm32-wasi@1.0.0-rc.9(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
-    dependencies:
-      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
-    transitivePeerDependencies:
-      - '@emnapi/core'
-      - '@emnapi/runtime'
-    optional: true
-
-  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.17':
+      '@napi-rs/wasm-runtime': 1.1.1
     optional: true
 
   '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.9':
     optional: true
 
-  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.17':
-    optional: true
-
   '@rolldown/binding-win32-x64-msvc@1.0.0-rc.9':
     optional: true
-
-  '@rolldown/pluginutils@1.0.0-rc.17': {}
 
   '@rolldown/pluginutils@1.0.0-rc.9': {}
 
@@ -1986,97 +2034,95 @@ snapshots:
 
   '@types/unist@3.0.3': {}
 
-  '@typescript-eslint/eslint-plugin@8.59.0(@typescript-eslint/parser@8.59.0(eslint@10.2.1)(typescript@6.0.3))(eslint@10.2.1)(typescript@6.0.3)':
+  '@typescript-eslint/eslint-plugin@8.57.0(@typescript-eslint/parser@8.57.0(eslint@10.0.3)(typescript@6.0.2))(eslint@10.0.3)(typescript@6.0.2)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.59.0(eslint@10.2.1)(typescript@6.0.3)
-      '@typescript-eslint/scope-manager': 8.59.0
-      '@typescript-eslint/type-utils': 8.59.0(eslint@10.2.1)(typescript@6.0.3)
-      '@typescript-eslint/utils': 8.59.0(eslint@10.2.1)(typescript@6.0.3)
-      '@typescript-eslint/visitor-keys': 8.59.0
-      eslint: 10.2.1
+      '@typescript-eslint/parser': 8.57.0(eslint@10.0.3)(typescript@6.0.2)
+      '@typescript-eslint/scope-manager': 8.57.0
+      '@typescript-eslint/type-utils': 8.57.0(eslint@10.0.3)(typescript@6.0.2)
+      '@typescript-eslint/utils': 8.57.0(eslint@10.0.3)(typescript@6.0.2)
+      '@typescript-eslint/visitor-keys': 8.57.0
+      eslint: 10.0.3
       ignore: 7.0.5
       natural-compare: 1.4.0
-      ts-api-utils: 2.5.0(typescript@6.0.3)
-      typescript: 6.0.3
+      ts-api-utils: 2.4.0(typescript@6.0.2)
+      typescript: 6.0.2
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.59.0(eslint@10.2.1)(typescript@6.0.3)':
+  '@typescript-eslint/parser@8.57.0(eslint@10.0.3)(typescript@6.0.2)':
     dependencies:
-      '@typescript-eslint/scope-manager': 8.59.0
-      '@typescript-eslint/types': 8.59.0
-      '@typescript-eslint/typescript-estree': 8.59.0(typescript@6.0.3)
-      '@typescript-eslint/visitor-keys': 8.59.0
+      '@typescript-eslint/scope-manager': 8.57.0
+      '@typescript-eslint/types': 8.57.0
+      '@typescript-eslint/typescript-estree': 8.57.0(typescript@6.0.2)
+      '@typescript-eslint/visitor-keys': 8.57.0
       debug: 4.4.3
-      eslint: 10.2.1
-      typescript: 6.0.3
+      eslint: 10.0.3
+      typescript: 6.0.2
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/project-service@8.59.0(typescript@6.0.3)':
+  '@typescript-eslint/project-service@8.57.0(typescript@6.0.2)':
     dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.59.0(typescript@6.0.3)
-      '@typescript-eslint/types': 8.59.0
+      '@typescript-eslint/tsconfig-utils': 8.57.0(typescript@6.0.2)
+      '@typescript-eslint/types': 8.57.0
       debug: 4.4.3
-      typescript: 6.0.3
+      typescript: 6.0.2
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/scope-manager@8.59.0':
+  '@typescript-eslint/scope-manager@8.57.0':
     dependencies:
-      '@typescript-eslint/types': 8.59.0
-      '@typescript-eslint/visitor-keys': 8.59.0
+      '@typescript-eslint/types': 8.57.0
+      '@typescript-eslint/visitor-keys': 8.57.0
 
-  '@typescript-eslint/tsconfig-utils@8.59.0(typescript@6.0.3)':
+  '@typescript-eslint/tsconfig-utils@8.57.0(typescript@6.0.2)':
     dependencies:
-      typescript: 6.0.3
+      typescript: 6.0.2
 
-  '@typescript-eslint/type-utils@8.59.0(eslint@10.2.1)(typescript@6.0.3)':
+  '@typescript-eslint/type-utils@8.57.0(eslint@10.0.3)(typescript@6.0.2)':
     dependencies:
-      '@typescript-eslint/types': 8.59.0
-      '@typescript-eslint/typescript-estree': 8.59.0(typescript@6.0.3)
-      '@typescript-eslint/utils': 8.59.0(eslint@10.2.1)(typescript@6.0.3)
+      '@typescript-eslint/types': 8.57.0
+      '@typescript-eslint/typescript-estree': 8.57.0(typescript@6.0.2)
+      '@typescript-eslint/utils': 8.57.0(eslint@10.0.3)(typescript@6.0.2)
       debug: 4.4.3
-      eslint: 10.2.1
-      ts-api-utils: 2.5.0(typescript@6.0.3)
-      typescript: 6.0.3
+      eslint: 10.0.3
+      ts-api-utils: 2.4.0(typescript@6.0.2)
+      typescript: 6.0.2
     transitivePeerDependencies:
       - supports-color
 
   '@typescript-eslint/types@8.57.0': {}
 
-  '@typescript-eslint/types@8.59.0': {}
-
-  '@typescript-eslint/typescript-estree@8.59.0(typescript@6.0.3)':
+  '@typescript-eslint/typescript-estree@8.57.0(typescript@6.0.2)':
     dependencies:
-      '@typescript-eslint/project-service': 8.59.0(typescript@6.0.3)
-      '@typescript-eslint/tsconfig-utils': 8.59.0(typescript@6.0.3)
-      '@typescript-eslint/types': 8.59.0
-      '@typescript-eslint/visitor-keys': 8.59.0
+      '@typescript-eslint/project-service': 8.57.0(typescript@6.0.2)
+      '@typescript-eslint/tsconfig-utils': 8.57.0(typescript@6.0.2)
+      '@typescript-eslint/types': 8.57.0
+      '@typescript-eslint/visitor-keys': 8.57.0
       debug: 4.4.3
-      minimatch: 10.2.5
+      minimatch: 10.2.4
       semver: 7.7.4
-      tinyglobby: 0.2.16
-      ts-api-utils: 2.5.0(typescript@6.0.3)
-      typescript: 6.0.3
+      tinyglobby: 0.2.15
+      ts-api-utils: 2.4.0(typescript@6.0.2)
+      typescript: 6.0.2
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.59.0(eslint@10.2.1)(typescript@6.0.3)':
+  '@typescript-eslint/utils@8.57.0(eslint@10.0.3)(typescript@6.0.2)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@10.2.1)
-      '@typescript-eslint/scope-manager': 8.59.0
-      '@typescript-eslint/types': 8.59.0
-      '@typescript-eslint/typescript-estree': 8.59.0(typescript@6.0.3)
-      eslint: 10.2.1
-      typescript: 6.0.3
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.0.3)
+      '@typescript-eslint/scope-manager': 8.57.0
+      '@typescript-eslint/types': 8.57.0
+      '@typescript-eslint/typescript-estree': 8.57.0(typescript@6.0.2)
+      eslint: 10.0.3
+      typescript: 6.0.2
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/visitor-keys@8.59.0':
+  '@typescript-eslint/visitor-keys@8.57.0':
     dependencies:
-      '@typescript-eslint/types': 8.59.0
+      '@typescript-eslint/types': 8.57.0
       eslint-visitor-keys: 5.0.1
 
   '@unrs/resolver-binding-android-arm-eabi@1.11.1':
@@ -2138,7 +2184,7 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
     optional: true
 
-  '@vitest/coverage-v8@4.1.0(vitest@4.1.0(@types/node@25.5.0)(vite@8.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.5.0)(yaml@2.8.3)))':
+  '@vitest/coverage-v8@4.1.0(vitest@4.1.0(@types/node@25.5.0)(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.8.2)))':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
       '@vitest/utils': 4.1.0
@@ -2150,17 +2196,16 @@ snapshots:
       obug: 2.1.1
       std-env: 4.0.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.0(@types/node@25.5.0)(vite@8.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.5.0)(yaml@2.8.3))
+      vitest: 4.1.0(@types/node@25.5.0)(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.8.2))
 
-  '@vitest/eslint-plugin@1.6.16(@typescript-eslint/eslint-plugin@8.59.0(@typescript-eslint/parser@8.59.0(eslint@10.2.1)(typescript@6.0.3))(eslint@10.2.1)(typescript@6.0.3))(eslint@10.2.1)(typescript@6.0.3)(vitest@4.1.0(@types/node@25.5.0)(vite@8.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.5.0)(yaml@2.8.3)))':
+  '@vitest/eslint-plugin@1.6.12(eslint@10.0.3)(typescript@6.0.2)(vitest@4.1.0(@types/node@25.5.0)(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.8.2)))':
     dependencies:
-      '@typescript-eslint/scope-manager': 8.59.0
-      '@typescript-eslint/utils': 8.59.0(eslint@10.2.1)(typescript@6.0.3)
-      eslint: 10.2.1
+      '@typescript-eslint/scope-manager': 8.57.0
+      '@typescript-eslint/utils': 8.57.0(eslint@10.0.3)(typescript@6.0.2)
+      eslint: 10.0.3
     optionalDependencies:
-      '@typescript-eslint/eslint-plugin': 8.59.0(@typescript-eslint/parser@8.59.0(eslint@10.2.1)(typescript@6.0.3))(eslint@10.2.1)(typescript@6.0.3)
-      typescript: 6.0.3
-      vitest: 4.1.0(@types/node@25.5.0)(vite@8.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.5.0)(yaml@2.8.3))
+      typescript: 6.0.2
+      vitest: 4.1.0(@types/node@25.5.0)(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.8.2))
     transitivePeerDependencies:
       - supports-color
 
@@ -2173,13 +2218,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.0(vite@8.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.5.0)(yaml@2.8.3))':
+  '@vitest/mocker@4.1.0(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       '@vitest/spy': 4.1.0
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.5.0)(yaml@2.8.3)
+      vite: 8.0.0(@types/node@25.5.0)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.8.2)
 
   '@vitest/pretty-format@4.1.0':
     dependencies:
@@ -2211,7 +2256,7 @@ snapshots:
 
   acorn@8.16.0: {}
 
-  ajv@6.15.0:
+  ajv@6.14.0:
     dependencies:
       fast-deep-equal: 3.1.3
       fast-json-stable-stringify: 2.1.0
@@ -2234,7 +2279,7 @@ snapshots:
 
   ast-kit@3.0.0-beta.1:
     dependencies:
-      '@babel/parser': 8.0.0-rc.3
+      '@babel/parser': 8.0.0-rc.2
       estree-walker: 3.0.3
       pathe: 2.0.3
 
@@ -2244,17 +2289,19 @@ snapshots:
       estree-walker: 3.0.3
       js-tokens: 10.0.0
 
+  balanced-match@1.0.2: {}
+
   balanced-match@4.0.4: {}
 
   baseline-browser-mapping@2.10.8: {}
 
   birpc@4.0.0: {}
 
-  brace-expansion@5.0.4:
+  brace-expansion@2.0.2:
     dependencies:
-      balanced-match: 4.0.4
+      balanced-match: 1.0.2
 
-  brace-expansion@5.0.5:
+  brace-expansion@5.0.4:
     dependencies:
       balanced-match: 4.0.4
 
@@ -2315,7 +2362,7 @@ snapshots:
 
   deep-is@0.1.4: {}
 
-  defu@6.1.7: {}
+  defu@6.1.4: {}
 
   detect-libc@2.1.2: {}
 
@@ -2333,15 +2380,44 @@ snapshots:
 
   es-module-lexer@2.0.0: {}
 
+  esbuild@0.27.7:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.27.7
+      '@esbuild/android-arm': 0.27.7
+      '@esbuild/android-arm64': 0.27.7
+      '@esbuild/android-x64': 0.27.7
+      '@esbuild/darwin-arm64': 0.27.7
+      '@esbuild/darwin-x64': 0.27.7
+      '@esbuild/freebsd-arm64': 0.27.7
+      '@esbuild/freebsd-x64': 0.27.7
+      '@esbuild/linux-arm': 0.27.7
+      '@esbuild/linux-arm64': 0.27.7
+      '@esbuild/linux-ia32': 0.27.7
+      '@esbuild/linux-loong64': 0.27.7
+      '@esbuild/linux-mips64el': 0.27.7
+      '@esbuild/linux-ppc64': 0.27.7
+      '@esbuild/linux-riscv64': 0.27.7
+      '@esbuild/linux-s390x': 0.27.7
+      '@esbuild/linux-x64': 0.27.7
+      '@esbuild/netbsd-arm64': 0.27.7
+      '@esbuild/netbsd-x64': 0.27.7
+      '@esbuild/openbsd-arm64': 0.27.7
+      '@esbuild/openbsd-x64': 0.27.7
+      '@esbuild/openharmony-arm64': 0.27.7
+      '@esbuild/sunos-x64': 0.27.7
+      '@esbuild/win32-arm64': 0.27.7
+      '@esbuild/win32-ia32': 0.27.7
+      '@esbuild/win32-x64': 0.27.7
+
   escalade@3.2.0: {}
 
   escape-string-regexp@1.0.5: {}
 
   escape-string-regexp@4.0.0: {}
 
-  eslint-config-prettier@10.1.8(eslint@10.2.1):
+  eslint-config-prettier@10.1.8(eslint@10.0.3):
     dependencies:
-      eslint: 10.2.1
+      eslint: 10.0.3
 
   eslint-import-context@0.1.9(unrs-resolver@1.11.1):
     dependencies:
@@ -2350,10 +2426,10 @@ snapshots:
     optionalDependencies:
       unrs-resolver: 1.11.1
 
-  eslint-import-resolver-typescript@4.4.4(eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.59.0(eslint@10.2.1)(typescript@6.0.3))(eslint@10.2.1))(eslint@10.2.1):
+  eslint-import-resolver-typescript@4.4.4(eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.57.0(eslint@10.0.3)(typescript@6.0.2))(eslint@10.0.3))(eslint@10.0.3):
     dependencies:
       debug: 4.4.3
-      eslint: 10.2.1
+      eslint: 10.0.3
       eslint-import-context: 0.1.9(unrs-resolver@1.11.1)
       get-tsconfig: 4.13.6
       is-bun-module: 2.0.0
@@ -2361,17 +2437,17 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import-x: 4.16.2(@typescript-eslint/utils@8.59.0(eslint@10.2.1)(typescript@6.0.3))(eslint@10.2.1)
+      eslint-plugin-import-x: 4.16.2(@typescript-eslint/utils@8.57.0(eslint@10.0.3)(typescript@6.0.2))(eslint@10.0.3)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.59.0(eslint@10.2.1)(typescript@6.0.3))(eslint@10.2.1):
+  eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.57.0(eslint@10.0.3)(typescript@6.0.2))(eslint@10.0.3):
     dependencies:
       '@package-json/types': 0.0.12
       '@typescript-eslint/types': 8.57.0
       comment-parser: 1.4.5
       debug: 4.4.3
-      eslint: 10.2.1
+      eslint: 10.0.3
       eslint-import-context: 0.1.9(unrs-resolver@1.11.1)
       is-glob: 4.0.3
       minimatch: 10.2.4
@@ -2379,19 +2455,19 @@ snapshots:
       stable-hash-x: 0.2.0
       unrs-resolver: 1.11.1
     optionalDependencies:
-      '@typescript-eslint/utils': 8.59.0(eslint@10.2.1)(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.57.0(eslint@10.0.3)(typescript@6.0.2)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-unicorn@64.0.0(eslint@10.2.1):
+  eslint-plugin-unicorn@64.0.0(eslint@10.0.3):
     dependencies:
       '@babel/helper-validator-identifier': 7.28.5
-      '@eslint-community/eslint-utils': 4.9.1(eslint@10.2.1)
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.0.3)
       change-case: 5.4.4
       ci-info: 4.4.0
       clean-regexp: 1.0.0
       core-js-compat: 3.49.0
-      eslint: 10.2.1
+      eslint: 10.0.3
       find-up-simple: 1.0.1
       globals: 17.4.0
       indent-string: 5.0.0
@@ -2414,19 +2490,19 @@ snapshots:
 
   eslint-visitor-keys@5.0.1: {}
 
-  eslint@10.2.1:
+  eslint@10.0.3:
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@10.2.1)
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.0.3)
       '@eslint-community/regexpp': 4.12.2
-      '@eslint/config-array': 0.23.5
-      '@eslint/config-helpers': 0.5.5
-      '@eslint/core': 1.2.1
-      '@eslint/plugin-kit': 0.7.1
-      '@humanfs/node': 0.16.8
+      '@eslint/config-array': 0.23.3
+      '@eslint/config-helpers': 0.5.3
+      '@eslint/core': 1.1.1
+      '@eslint/plugin-kit': 0.6.1
+      '@humanfs/node': 0.16.7
       '@humanwhocodes/module-importer': 1.0.1
       '@humanwhocodes/retry': 0.4.3
       '@types/estree': 1.0.8
-      ajv: 6.15.0
+      ajv: 6.14.0
       cross-spawn: 7.0.6
       debug: 4.4.3
       escape-string-regexp: 4.0.0
@@ -2443,7 +2519,7 @@ snapshots:
       imurmurhash: 0.1.4
       is-glob: 4.0.3
       json-stable-stringify-without-jsonify: 1.0.1
-      minimatch: 10.2.5
+      minimatch: 10.2.4
       natural-compare: 1.4.0
       optionator: 0.9.4
     transitivePeerDependencies:
@@ -2481,9 +2557,9 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
-  fdir@6.5.0(picomatch@4.0.4):
+  fdir@6.5.0(picomatch@4.0.3):
     optionalDependencies:
-      picomatch: 4.0.4
+      picomatch: 4.0.3
 
   file-entry-cache@8.0.0:
     dependencies:
@@ -2498,10 +2574,10 @@ snapshots:
 
   flat-cache@4.0.1:
     dependencies:
-      flatted: 3.4.2
+      flatted: 3.4.1
       keyv: 4.5.4
 
-  flatted@3.4.2: {}
+  flatted@3.4.1: {}
 
   fsevents@2.3.3:
     optional: true
@@ -2509,10 +2585,6 @@ snapshots:
   get-east-asian-width@1.5.0: {}
 
   get-tsconfig@4.13.6:
-    dependencies:
-      resolve-pkg-maps: 1.0.0
-
-  get-tsconfig@4.14.0:
     dependencies:
       resolve-pkg-maps: 1.0.0
 
@@ -2524,7 +2596,7 @@ snapshots:
 
   has-flag@4.0.0: {}
 
-  hookable@6.1.1: {}
+  hookable@6.1.0: {}
 
   html-escaper@2.0.2: {}
 
@@ -2534,7 +2606,7 @@ snapshots:
 
   ignore@7.0.5: {}
 
-  import-without-cache@0.3.3: {}
+  import-without-cache@0.2.5: {}
 
   imurmurhash@0.1.4: {}
 
@@ -2708,9 +2780,9 @@ snapshots:
     dependencies:
       brace-expansion: 5.0.4
 
-  minimatch@10.2.5:
+  minimatch@9.0.9:
     dependencies:
-      brace-expansion: 5.0.5
+      brace-expansion: 2.0.2
 
   ms@2.1.3: {}
 
@@ -2755,11 +2827,9 @@ snapshots:
 
   picomatch@4.0.3: {}
 
-  picomatch@4.0.4: {}
-
   pluralize@8.0.0: {}
 
-  postcss@8.5.10:
+  postcss@8.5.8:
     dependencies:
       nanoid: 3.3.11
       picocolors: 1.1.1
@@ -2767,7 +2837,7 @@ snapshots:
 
   prelude-ls@1.2.1: {}
 
-  prettier@3.8.3: {}
+  prettier@3.8.1: {}
 
   punycode.js@2.3.1: {}
 
@@ -2790,46 +2860,24 @@ snapshots:
 
   rfdc@1.4.1: {}
 
-  rolldown-plugin-dts@0.23.2(rolldown@1.0.0-rc.17)(typescript@6.0.3):
+  rolldown-plugin-dts@0.22.5(rolldown@1.0.0-rc.9)(typescript@6.0.2):
     dependencies:
-      '@babel/generator': 8.0.0-rc.3
-      '@babel/helper-validator-identifier': 8.0.0-rc.3
-      '@babel/parser': 8.0.0-rc.3
-      '@babel/types': 8.0.0-rc.3
+      '@babel/generator': 8.0.0-rc.2
+      '@babel/helper-validator-identifier': 8.0.0-rc.2
+      '@babel/parser': 8.0.0-rc.2
+      '@babel/types': 8.0.0-rc.2
       ast-kit: 3.0.0-beta.1
       birpc: 4.0.0
       dts-resolver: 2.1.3
-      get-tsconfig: 4.14.0
+      get-tsconfig: 4.13.6
       obug: 2.1.1
-      picomatch: 4.0.4
-      rolldown: 1.0.0-rc.17
+      rolldown: 1.0.0-rc.9
     optionalDependencies:
-      typescript: 6.0.3
+      typescript: 6.0.2
     transitivePeerDependencies:
       - oxc-resolver
 
-  rolldown@1.0.0-rc.17:
-    dependencies:
-      '@oxc-project/types': 0.127.0
-      '@rolldown/pluginutils': 1.0.0-rc.17
-    optionalDependencies:
-      '@rolldown/binding-android-arm64': 1.0.0-rc.17
-      '@rolldown/binding-darwin-arm64': 1.0.0-rc.17
-      '@rolldown/binding-darwin-x64': 1.0.0-rc.17
-      '@rolldown/binding-freebsd-x64': 1.0.0-rc.17
-      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-rc.17
-      '@rolldown/binding-linux-arm64-gnu': 1.0.0-rc.17
-      '@rolldown/binding-linux-arm64-musl': 1.0.0-rc.17
-      '@rolldown/binding-linux-ppc64-gnu': 1.0.0-rc.17
-      '@rolldown/binding-linux-s390x-gnu': 1.0.0-rc.17
-      '@rolldown/binding-linux-x64-gnu': 1.0.0-rc.17
-      '@rolldown/binding-linux-x64-musl': 1.0.0-rc.17
-      '@rolldown/binding-openharmony-arm64': 1.0.0-rc.17
-      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.17
-      '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.17
-      '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.17
-
-  rolldown@1.0.0-rc.9(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0):
+  rolldown@1.0.0-rc.9:
     dependencies:
       '@oxc-project/types': 0.115.0
       '@rolldown/pluginutils': 1.0.0-rc.9
@@ -2846,12 +2894,9 @@ snapshots:
       '@rolldown/binding-linux-x64-gnu': 1.0.0-rc.9
       '@rolldown/binding-linux-x64-musl': 1.0.0-rc.9
       '@rolldown/binding-openharmony-arm64': 1.0.0-rc.9
-      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.9(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.9
       '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.9
       '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.9
-    transitivePeerDependencies:
-      - '@emnapi/core'
-      - '@emnapi/runtime'
 
   semver@7.7.4: {}
 
@@ -2910,46 +2955,39 @@ snapshots:
 
   tinyexec@1.0.4: {}
 
-  tinyexec@1.1.1: {}
-
   tinyglobby@0.2.15:
     dependencies:
-      fdir: 6.5.0(picomatch@4.0.4)
-      picomatch: 4.0.4
-
-  tinyglobby@0.2.16:
-    dependencies:
-      fdir: 6.5.0(picomatch@4.0.4)
-      picomatch: 4.0.4
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
 
   tinyrainbow@3.1.0: {}
 
   tree-kill@1.2.2: {}
 
-  ts-api-utils@2.5.0(typescript@6.0.3):
+  ts-api-utils@2.4.0(typescript@6.0.2):
     dependencies:
-      typescript: 6.0.3
+      typescript: 6.0.2
 
-  tsdown@0.21.10(typescript@6.0.3):
+  tsdown@0.21.4(typescript@6.0.2):
     dependencies:
       ansis: 4.2.0
       cac: 7.0.0
-      defu: 6.1.7
+      defu: 6.1.4
       empathic: 2.0.0
-      hookable: 6.1.1
-      import-without-cache: 0.3.3
+      hookable: 6.1.0
+      import-without-cache: 0.2.5
       obug: 2.1.1
-      picomatch: 4.0.4
-      rolldown: 1.0.0-rc.17
-      rolldown-plugin-dts: 0.23.2(rolldown@1.0.0-rc.17)(typescript@6.0.3)
+      picomatch: 4.0.3
+      rolldown: 1.0.0-rc.9
+      rolldown-plugin-dts: 0.22.5(rolldown@1.0.0-rc.9)(typescript@6.0.2)
       semver: 7.7.4
-      tinyexec: 1.1.1
-      tinyglobby: 0.2.16
+      tinyexec: 1.0.4
+      tinyglobby: 0.2.15
       tree-kill: 1.2.2
       unconfig-core: 7.5.0
-      unrun: 0.2.37
+      unrun: 0.2.32
     optionalDependencies:
-      typescript: 6.0.3
+      typescript: 6.0.2
     transitivePeerDependencies:
       - '@ts-macro/tsc'
       - '@typescript/native-preview'
@@ -2960,31 +2998,38 @@ snapshots:
   tslib@2.8.1:
     optional: true
 
+  tsx@4.21.0:
+    dependencies:
+      esbuild: 0.27.7
+      get-tsconfig: 4.13.6
+    optionalDependencies:
+      fsevents: 2.3.3
+
   type-check@0.4.0:
     dependencies:
       prelude-ls: 1.2.1
 
-  typedoc@0.28.19(typescript@6.0.3):
+  typedoc@0.28.17(typescript@6.0.2):
     dependencies:
       '@gerrit0/mini-shiki': 3.23.0
       lunr: 2.3.9
       markdown-it: 14.1.1
-      minimatch: 10.2.5
-      typescript: 6.0.3
-      yaml: 2.8.3
+      minimatch: 9.0.9
+      typescript: 6.0.2
+      yaml: 2.8.2
 
-  typescript-eslint@8.59.0(eslint@10.2.1)(typescript@6.0.3):
+  typescript-eslint@8.57.0(eslint@10.0.3)(typescript@6.0.2):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.59.0(@typescript-eslint/parser@8.59.0(eslint@10.2.1)(typescript@6.0.3))(eslint@10.2.1)(typescript@6.0.3)
-      '@typescript-eslint/parser': 8.59.0(eslint@10.2.1)(typescript@6.0.3)
-      '@typescript-eslint/typescript-estree': 8.59.0(typescript@6.0.3)
-      '@typescript-eslint/utils': 8.59.0(eslint@10.2.1)(typescript@6.0.3)
-      eslint: 10.2.1
-      typescript: 6.0.3
+      '@typescript-eslint/eslint-plugin': 8.57.0(@typescript-eslint/parser@8.57.0(eslint@10.0.3)(typescript@6.0.2))(eslint@10.0.3)(typescript@6.0.2)
+      '@typescript-eslint/parser': 8.57.0(eslint@10.0.3)(typescript@6.0.2)
+      '@typescript-eslint/typescript-estree': 8.57.0(typescript@6.0.2)
+      '@typescript-eslint/utils': 8.57.0(eslint@10.0.3)(typescript@6.0.2)
+      eslint: 10.0.3
+      typescript: 6.0.2
     transitivePeerDependencies:
       - supports-color
 
-  typescript@6.0.3: {}
+  typescript@6.0.2: {}
 
   uc.micro@2.1.0: {}
 
@@ -3020,9 +3065,9 @@ snapshots:
       '@unrs/resolver-binding-win32-ia32-msvc': 1.11.1
       '@unrs/resolver-binding-win32-x64-msvc': 1.11.1
 
-  unrun@0.2.37:
+  unrun@0.2.32:
     dependencies:
-      rolldown: 1.0.0-rc.17
+      rolldown: 1.0.0-rc.9
 
   update-browserslist-db@1.2.3(browserslist@4.28.1):
     dependencies:
@@ -3034,26 +3079,25 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
-  vite@8.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.5.0)(yaml@2.8.3):
+  vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
       '@oxc-project/runtime': 0.115.0
       lightningcss: 1.32.0
-      picomatch: 4.0.4
-      postcss: 8.5.10
-      rolldown: 1.0.0-rc.9(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
-      tinyglobby: 0.2.16
+      picomatch: 4.0.3
+      postcss: 8.5.8
+      rolldown: 1.0.0-rc.9
+      tinyglobby: 0.2.15
     optionalDependencies:
       '@types/node': 25.5.0
+      esbuild: 0.27.7
       fsevents: 2.3.3
-      yaml: 2.8.3
-    transitivePeerDependencies:
-      - '@emnapi/core'
-      - '@emnapi/runtime'
+      tsx: 4.21.0
+      yaml: 2.8.2
 
-  vitest@4.1.0(@types/node@25.5.0)(vite@8.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.5.0)(yaml@2.8.3)):
+  vitest@4.1.0(@types/node@25.5.0)(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.8.2)):
     dependencies:
       '@vitest/expect': 4.1.0
-      '@vitest/mocker': 4.1.0(vite@8.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.5.0)(yaml@2.8.3))
+      '@vitest/mocker': 4.1.0(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.8.2))
       '@vitest/pretty-format': 4.1.0
       '@vitest/runner': 4.1.0
       '@vitest/snapshot': 4.1.0
@@ -3070,7 +3114,7 @@ snapshots:
       tinyexec: 1.0.4
       tinyglobby: 0.2.15
       tinyrainbow: 3.1.0
-      vite: 8.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.5.0)(yaml@2.8.3)
+      vite: 8.0.0(@types/node@25.5.0)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.8.2)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.5.0
@@ -3095,7 +3139,5 @@ snapshots:
       strip-ansi: 7.2.0
 
   yaml@2.8.2: {}
-
-  yaml@2.8.3: {}
 
   yocto-queue@0.1.0: {}

--- a/scripts/rtg-compare.mts
+++ b/scripts/rtg-compare.mts
@@ -1,0 +1,251 @@
+/**
+ * RTG comparison: generate N random tournaments with bbpPairings RTG,
+ * then for each round, compare our pairing against what bbpPairings stored.
+ */
+import { parse } from '@echecs/trf';
+import { execSync } from 'node:child_process';
+import { readFileSync, unlinkSync } from 'node:fs';
+
+
+import { pair } from '../src/dutch.js';
+
+import type { Game, GameKind, Player } from '../src/types.js';
+
+const BBP = '/tmp/bbpPairings/build/bbpPairings.exe';
+const N = Number(process.argv[2]) || 50;
+
+interface TournamentData {
+  games: Game[][];
+  players: Player[];
+  totalRounds: number;
+}
+
+function trfToSwiss(raw: string): TournamentData | undefined {
+  const tournament = parse(raw);
+  if (!tournament) return undefined;
+
+  const players: Player[] = tournament.players.map((p) => ({
+    id: String(p.pairingNumber),
+    rating: p.rating,
+  }));
+
+  let maxRound = 0;
+  for (const player of tournament.players) {
+    for (const result of player.results) {
+      if (result.round > maxRound) maxRound = result.round;
+    }
+  }
+
+  const roundArrays: Game[][] = Array.from({ length: maxRound }, () => []);
+  for (const player of tournament.players) {
+    for (const result of player.results) {
+      const ri = result.round - 1;
+      if (!roundArrays[ri]) continue;
+      if (result.opponentId === undefined) {
+        const byeMap: Record<string, { kind: GameKind; result: 0 | 0.5 | 1 }> =
+          {
+            F: { kind: 'full-bye', result: 1 },
+            H: { kind: 'half-bye', result: 0.5 },
+            U: { kind: 'pairing-bye', result: 1 },
+            Z: { kind: 'zero-bye', result: 0 },
+          };
+        const bye = byeMap[result.result];
+        if (bye)
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+          roundArrays[ri]!.push({
+            black: '',
+            kind: bye.kind,
+            result: bye.result,
+            white: String(player.pairingNumber),
+          });
+        continue;
+      }
+      if (result.color !== 'w') continue;
+      let score: 0 | 0.5 | 1;
+      switch (result.result) {
+        case '1':
+        case '+': {
+          score = 1;
+          break;
+        }
+        case '0':
+        case '-': {
+          score = 0;
+          break;
+        }
+        case '=': {
+          score = 0.5;
+          break;
+        }
+        default: {
+          continue;
+        }
+      }
+      const game: Game = {
+        black: String(result.opponentId),
+        result: score,
+        white: String(player.pairingNumber),
+      };
+      if (result.result === '+') game.kind = 'forfeit-win';
+      else if (result.result === '-') game.kind = 'forfeit-loss';
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      roundArrays[ri]!.push(game);
+    }
+  }
+
+  return { games: roundArrays, players, totalRounds: maxRound };
+}
+
+/**
+ * Extract pairings for round `round` from the TRF data.
+ * Returns [white, black] pairs (excluding byes).
+ */
+function extractRoundPairings(raw: string, round: number): [string, string][] {
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+  const tournament = parse(raw)!;
+  const pairs: [string, string][] = [];
+  const seen = new Set<string>();
+
+  for (const player of tournament.players) {
+    const result = player.results.find((r) => r.round === round);
+    if (!result || result.opponentId === undefined) continue;
+
+    const key = [String(player.pairingNumber), String(result.opponentId)]
+      .toSorted()
+      .join('-');
+    if (seen.has(key)) continue;
+    seen.add(key);
+
+    if (result.color === 'w') {
+      pairs.push([String(player.pairingNumber), String(result.opponentId)]);
+    } else {
+      pairs.push([String(result.opponentId), String(player.pairingNumber)]);
+    }
+  }
+
+  return pairs;
+}
+
+// --- Main ---
+let totalTournaments = 0;
+let totalRoundsTested = 0;
+let totalPerfectRounds = 0;
+let totalPairings = 0;
+let totalMatching = 0;
+let crashes = 0;
+const failures: {
+  matching: number;
+  round: number;
+  seed: number;
+  total: number;
+}[] = [];
+
+for (let seed = 1; seed <= N; seed++) {
+  const trfPath = `/tmp/rtg_seed_${seed}.trf`;
+
+  // Generate
+  try {
+    execSync(`${BBP} --dutch -g -o "${trfPath}" -s ${seed} 2>/dev/null`, {
+      timeout: 30_000,
+    });
+  } catch {
+    process.stdout.write(`seed ${seed}: RTG generation failed\n`);
+    crashes++;
+    continue;
+  }
+
+  const raw = readFileSync(trfPath, 'utf8').replaceAll(/\r\n?/g, '\n');
+  const data = trfToSwiss(raw);
+  if (!data) {
+    process.stdout.write(`seed ${seed}: TRF parse failed\n`);
+    crashes++;
+    try {
+      unlinkSync(trfPath);
+    } catch {
+      // ignore cleanup errors
+    }
+    continue;
+  }
+
+  totalTournaments++;
+  let seedPerfect = true;
+
+  // For each round, compare our pairing against what's stored in the TRF
+  for (let round = 1; round <= data.totalRounds; round++) {
+    const priorGames = data.games.slice(0, round - 1);
+    const expectedPairs = extractRoundPairings(raw, round);
+    if (expectedPairs.length === 0) continue;
+
+    let result;
+    try {
+      result = pair(data.players, priorGames);
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : String(error);
+      process.stdout.write(`seed ${seed} round ${round}: CRASH — ${message}\n`);
+      crashes++;
+      seedPerfect = false;
+      break;
+    }
+
+    const expectedSet = new Set(
+      expectedPairs.map(([w, b]) => [w, b].toSorted().join('-')),
+    );
+    const actualSet = new Set(
+      result.pairings.map((p) => [p.white, p.black].toSorted().join('-')),
+    );
+
+    const missing = [...expectedSet].filter((x) => !actualSet.has(x));
+    const matching = expectedSet.size - missing.length;
+    const total = expectedSet.size;
+
+    totalRoundsTested++;
+    totalPairings += total;
+    totalMatching += matching;
+
+    if (matching === total) {
+      totalPerfectRounds++;
+    } else {
+      seedPerfect = false;
+      failures.push({ matching, round, seed, total });
+      if (failures.length <= 20) {
+        process.stdout.write(
+          `seed ${seed} round ${round}: ${matching}/${total} (${((matching / total) * 100).toFixed(0)}%) — ${data.players.length} players\n`,
+        );
+      }
+    }
+  }
+
+  if (seedPerfect) {
+    process.stdout.write(
+      `seed ${seed}: all ${data.totalRounds} rounds perfect\n`,
+    );
+  }
+
+  try {
+    unlinkSync(trfPath);
+  } catch {
+    // ignore cleanup errors
+  }
+}
+
+process.stdout.write(`\n=== RTG Comparison: ${N} tournaments ===\n`);
+process.stdout.write(
+  `tournaments: ${totalTournaments} (${crashes} generation failures)\n`,
+);
+process.stdout.write(
+  `rounds: ${totalPerfectRounds}/${totalRoundsTested} perfect\n`,
+);
+process.stdout.write(
+  `pairings: ${totalMatching}/${totalPairings} (${((totalMatching / totalPairings) * 100).toFixed(1)}%)\n`,
+);
+if (failures.length > 0) {
+  process.stdout.write(`\nfirst ${Math.min(failures.length, 20)} failures:\n`);
+  for (const f of failures.slice(0, 20)) {
+    process.stdout.write(
+      `  seed ${f.seed} round ${f.round}: ${f.matching}/${f.total}\n`,
+    );
+  }
+  if (failures.length > 20) {
+    process.stdout.write(`  ... and ${failures.length - 20} more\n`);
+  }
+}

--- a/scripts/rtg-compare.mts
+++ b/scripts/rtg-compare.mts
@@ -6,7 +6,6 @@ import { parse } from '@echecs/trf';
 import { execSync } from 'node:child_process';
 import { readFileSync, unlinkSync } from 'node:fs';
 
-
 import { pair } from '../src/dutch.js';
 
 import type { Game, GameKind, Player } from '../src/types.js';
@@ -41,7 +40,8 @@ function trfToSwiss(raw: string): TournamentData | undefined {
     for (const result of player.results) {
       const ri = result.round - 1;
       if (!roundArrays[ri]) continue;
-      if (result.opponentId === undefined) {
+       
+      if (result.opponentId === null) {
         const byeMap: Record<string, { kind: GameKind; result: 0 | 0.5 | 1 }> =
           {
             F: { kind: 'full-bye', result: 1 },
@@ -108,7 +108,8 @@ function extractRoundPairings(raw: string, round: number): [string, string][] {
 
   for (const player of tournament.players) {
     const result = player.results.find((r) => r.round === round);
-    if (!result || result.opponentId === undefined) continue;
+     
+    if (!result || result.opponentId === null) continue;
 
     const key = [String(player.pairingNumber), String(result.opponentId)]
       .toSorted()
@@ -178,7 +179,9 @@ for (let seed = 1; seed <= N; seed++) {
 
     let result;
     try {
-      result = pair(data.players, priorGames);
+      result = pair(data.players, priorGames, {
+        expectedRounds: data.totalRounds,
+      });
     } catch (error: unknown) {
       const message = error instanceof Error ? error.message : String(error);
       process.stdout.write(`seed ${seed} round ${round}: CRASH — ${message}\n`);

--- a/scripts/rtg-compare.mts
+++ b/scripts/rtg-compare.mts
@@ -40,7 +40,7 @@ function trfToSwiss(raw: string): TournamentData | undefined {
     for (const result of player.results) {
       const ri = result.round - 1;
       if (!roundArrays[ri]) continue;
-       
+
       if (result.opponentId === null) {
         const byeMap: Record<string, { kind: GameKind; result: 0 | 0.5 | 1 }> =
           {
@@ -86,8 +86,21 @@ function trfToSwiss(raw: string): TournamentData | undefined {
         result: score,
         white: String(player.pairingNumber),
       };
-      if (result.result === '+') game.kind = 'forfeit-win';
-      else if (result.result === '-') game.kind = 'forfeit-loss';
+      if (result.result === '+') {
+        game.kind = 'forfeit-win';
+      } else if (result.result === '-') {
+        // White forfeit-lost. Check if black also forfeit-lost (double forfeit).
+        const opponentResults = tournament.players
+          .find((p) => p.pairingNumber === result.opponentId)
+          ?.results.find((r) => r.round === result.round);
+        if (opponentResults?.result === '-') {
+          // Double forfeit: both get 0, no game was played. Skip entirely
+          // so both players fall into the "no game found" path in
+          // buildPlayerStates (unplayedRounds++, no score, no color).
+          continue;
+        }
+        game.kind = 'forfeit-loss';
+      }
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       roundArrays[ri]!.push(game);
     }
@@ -108,7 +121,7 @@ function extractRoundPairings(raw: string, round: number): [string, string][] {
 
   for (const player of tournament.players) {
     const result = player.results.find((r) => r.round === round);
-     
+
     if (!result || result.opponentId === null) continue;
 
     const key = [String(player.pairingNumber), String(result.opponentId)]
@@ -125,6 +138,30 @@ function extractRoundPairings(raw: string, round: number): [string, string][] {
   }
 
   return pairs;
+}
+
+/**
+ * Extract players that are absent for a given round (H, F, Z byes).
+ * These players should be excluded from the pairing input.
+ */
+function extractAbsentPlayers(raw: string, round: number): Set<string> {
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+  const tournament = parse(raw)!;
+  const absent = new Set<string>();
+  for (const player of tournament.players) {
+    const result = player.results.find((r) => r.round === round);
+    // Non-pairing byes: H (half), F (full), Z (zero). These are pre-assigned
+    // absences — bbpPairings excludes these players from the pairing.
+    // U (pairing-bye) is assigned BY the pairing algorithm, not pre-assigned.
+    if (
+      result &&
+      result.opponentId === null &&
+      (result.result === 'H' || result.result === 'F' || result.result === 'Z')
+    ) {
+      absent.add(String(player.pairingNumber));
+    }
+  }
+  return absent;
 }
 
 // --- Main ---
@@ -177,9 +214,16 @@ for (let seed = 1; seed <= N; seed++) {
     const expectedPairs = extractRoundPairings(raw, round);
     if (expectedPairs.length === 0) continue;
 
+    // Exclude players with non-pairing byes (H, F, Z) for this round.
+    const absentIds = extractAbsentPlayers(raw, round);
+    const roundPlayers =
+      absentIds.size > 0
+        ? data.players.filter((p) => !absentIds.has(p.id))
+        : data.players;
+
     let result;
     try {
-      result = pair(data.players, priorGames, {
+      result = pair(roundPlayers, priorGames, {
         expectedRounds: data.totalRounds,
       });
     } catch (error: unknown) {

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": ".."
+  },
+  "include": ["**/*", "../src/**/*"]
+}

--- a/src/__tests__/dutch.fixtures.spec.ts
+++ b/src/__tests__/dutch.fixtures.spec.ts
@@ -18,6 +18,7 @@ import dutchC9 from './fixtures/dutch_2025_C9.trf?raw';
 import issue15 from './fixtures/issue_15.trf?raw';
 import issue7 from './fixtures/issue_7.trf?raw';
 
+import type { TraceEvent } from '../trace.js';
 import type { Game, Player } from '../types.js';
 import type { Tournament } from '@echecs/trf';
 
@@ -103,6 +104,10 @@ function preAssignedIds(
     }
   }
   return ids;
+}
+
+function isRemainderPhase(phase: string): boolean {
+  return phase === 'bracket-remainder' || phase === 'bracket-ordering';
 }
 
 // ---------------------------------------------------------------------------
@@ -228,6 +233,50 @@ describe('dutch fixture: issue_7', () => {
         `rematch detected: ${pairing.white} vs ${pairing.black}`,
       ).toBe(false);
     }
+  });
+
+  it('does not spin the bracket loop when unmatched players remain', () => {
+    const events: TraceEvent[] = [];
+    pair(players, gamesBefore, { trace: (event) => events.push(event) });
+
+    const bracketEnters = events.filter(
+      (event) => event.type === 'dutch:bracket-enter',
+    );
+    expect(bracketEnters.length).toBeLessThan(50);
+  });
+
+  it('finalizes each remainder pair individually with blossom re-runs', () => {
+    const events: TraceEvent[] = [];
+    pair(players, gamesBefore, { trace: (event) => events.push(event) });
+
+    const remainderFinalizations = events.filter(
+      (event) =>
+        event.type === 'pairing:pair-finalized' &&
+        isRemainderPhase(event.phase),
+    );
+
+    expect(remainderFinalizations.length).toBeGreaterThan(0);
+
+    let blossomCountInRemainder = 0;
+    let finalizationCountInRemainder = 0;
+    for (const event of events) {
+      if (
+        event.type === 'pairing:blossom-invoked' &&
+        isRemainderPhase(event.phase)
+      ) {
+        blossomCountInRemainder++;
+      }
+      if (
+        event.type === 'pairing:pair-finalized' &&
+        isRemainderPhase(event.phase)
+      ) {
+        finalizationCountInRemainder++;
+      }
+    }
+
+    expect(blossomCountInRemainder).toBeGreaterThanOrEqual(
+      finalizationCountInRemainder,
+    );
   });
 
   it.fails('produces the exact FIDE-correct pairings for round 15', () => {

--- a/src/__tests__/dutch.fixtures.spec.ts
+++ b/src/__tests__/dutch.fixtures.spec.ts
@@ -19,7 +19,7 @@ import issue15 from './fixtures/issue_15.trf?raw';
 import issue7 from './fixtures/issue_7.trf?raw';
 
 import type { TraceEvent } from '../trace.js';
-import type { Game, Player } from '../types.js';
+import type { Game, GameKind, Player } from '../types.js';
 import type { Tournament } from '@echecs/trf';
 
 // ---------------------------------------------------------------------------
@@ -49,9 +49,34 @@ function toSwissGames(tournament: Tournament): Game[][] {
 
   for (const player of tournament.players) {
     for (const result of player.results) {
-      if (result.color !== 'w' || result.opponentId === null) {
+      const roundIndex = result.round - 1;
+      const roundGames = roundArrays[roundIndex];
+      if (roundGames === undefined) continue;
+
+      // Bye results (no opponent)
+      if (result.opponentId === null) {
+        const byeMap: Record<string, { kind: GameKind; result: 0 | 0.5 | 1 }> =
+          {
+            F: { kind: 'full-bye', result: 1 },
+            H: { kind: 'half-bye', result: 0.5 },
+            U: { kind: 'pairing-bye', result: 1 },
+            Z: { kind: 'zero-bye', result: 0 },
+          };
+        const bye = byeMap[result.result];
+        if (bye) {
+          roundGames.push({
+            black: '',
+            kind: bye.kind,
+            result: bye.result,
+            white: String(player.pairingNumber),
+          });
+        }
         continue;
       }
+
+      // Regular games — only record from white's perspective
+      if (result.color !== 'w') continue;
+
       let score: 0 | 0.5 | 1;
       switch (result.result) {
         case '1':
@@ -72,23 +97,20 @@ function toSwissGames(tournament: Tournament): Game[][] {
           continue;
         }
       }
-      const roundIndex = result.round - 1;
-      const roundGames = roundArrays[roundIndex];
-      if (roundGames !== undefined) {
-        const game: Game = {
-          black: String(result.opponentId),
-          result: score,
-          white: String(player.pairingNumber),
-        };
 
-        if (result.result === '+') {
-          game.kind = 'forfeit-win';
-        } else if (result.result === '-') {
-          game.kind = 'forfeit-loss';
-        }
+      const game: Game = {
+        black: String(result.opponentId),
+        result: score,
+        white: String(player.pairingNumber),
+      };
 
-        roundGames.push(game);
+      if (result.result === '+') {
+        game.kind = 'forfeit-win';
+      } else if (result.result === '-') {
+        game.kind = 'forfeit-loss';
       }
+
+      roundGames.push(game);
     }
   }
 

--- a/src/__tests__/dutch.fixtures.spec.ts
+++ b/src/__tests__/dutch.fixtures.spec.ts
@@ -75,11 +75,19 @@ function toSwissGames(tournament: Tournament): Game[][] {
       const roundIndex = result.round - 1;
       const roundGames = roundArrays[roundIndex];
       if (roundGames !== undefined) {
-        roundGames.push({
+        const game: Game = {
           black: String(result.opponentId),
           result: score,
           white: String(player.pairingNumber),
-        });
+        };
+
+        if (result.result === '+') {
+          game.kind = 'forfeit-win';
+        } else if (result.result === '-') {
+          game.kind = 'forfeit-loss';
+        }
+
+        roundGames.push(game);
       }
     }
   }

--- a/src/__tests__/dutch.fixtures.spec.ts
+++ b/src/__tests__/dutch.fixtures.spec.ts
@@ -312,7 +312,7 @@ describe('dutch fixture: issue_7', () => {
     );
   });
 
-  it.fails('produces the exact FIDE-correct pairings for round 15', () => {
+  it('produces the exact FIDE-correct pairings for round 15', () => {
     // Reference output from bbpPairings v6.0.0 (--dutch issue_7.trf -p).
     // Each entry is [white, black] as pairing numbers (strings).
     const expected: [string, string][] = [

--- a/src/__tests__/dutch.fixtures.spec.ts
+++ b/src/__tests__/dutch.fixtures.spec.ts
@@ -376,7 +376,7 @@ describe('dutch fixture: issue_15', () => {
   for (let round = 1; round <= 11; round++) {
     it(
       `pairs round ${round} without crashing (180 players)`,
-      { timeout: 60_000 },
+      { timeout: 120_000 },
       () => {
         // Games played before this round
         const gamesBefore = allGames.slice(0, round - 1);
@@ -392,7 +392,7 @@ describe('dutch fixture: issue_15', () => {
     );
   }
 
-  it('produces no rematches in round 11', { timeout: 60_000 }, () => {
+  it('produces no rematches in round 11', { timeout: 120_000 }, () => {
     const gamesBefore = allGames.slice(0, 10);
     const excluded = preAssignedIds(tournament, 11);
     const players = toSwissPlayers(tournament).filter(

--- a/src/__tests__/dutch.fixtures.spec.ts
+++ b/src/__tests__/dutch.fixtures.spec.ts
@@ -251,9 +251,12 @@ describe('dutch fixture: issue_7', () => {
 
   it('produces no rematches in round 15', () => {
     const result = pair(players, gamesBefore);
-    const flat = gamesBefore.flat();
+    // Forfeit games are not considered prior opponents per FIDE/bbpPairings
+    const played = gamesBefore
+      .flat()
+      .filter((g) => g.kind !== 'forfeit-win' && g.kind !== 'forfeit-loss');
     for (const pairing of result.pairings) {
-      const alreadyFaced = flat.some(
+      const alreadyFaced = played.some(
         (g) =>
           (g.white === pairing.white && g.black === pairing.black) ||
           (g.white === pairing.black && g.black === pairing.white),
@@ -396,9 +399,12 @@ describe('dutch fixture: issue_15', () => {
       (p) => !excluded.has(p.id),
     );
     const result = pair(players, gamesBefore);
-    const flat = gamesBefore.flat();
+    // Forfeit games are not considered prior opponents per FIDE/bbpPairings
+    const played = gamesBefore
+      .flat()
+      .filter((g) => g.kind !== 'forfeit-win' && g.kind !== 'forfeit-loss');
     for (const pairing of result.pairings) {
-      const alreadyFaced = flat.some(
+      const alreadyFaced = played.some(
         (g) =>
           (g.white === pairing.white && g.black === pairing.black) ||
           (g.white === pairing.black && g.black === pairing.white),

--- a/src/__tests__/dutch.fixtures.spec.ts
+++ b/src/__tests__/dutch.fixtures.spec.ts
@@ -376,7 +376,7 @@ describe('dutch fixture: issue_15', () => {
   for (let round = 1; round <= 11; round++) {
     it(
       `pairs round ${round} without crashing (180 players)`,
-      { timeout: 30_000 },
+      { timeout: 60_000 },
       () => {
         // Games played before this round
         const gamesBefore = allGames.slice(0, round - 1);
@@ -392,7 +392,7 @@ describe('dutch fixture: issue_15', () => {
     );
   }
 
-  it('produces no rematches in round 11', () => {
+  it('produces no rematches in round 11', { timeout: 60_000 }, () => {
     const gamesBefore = allGames.slice(0, 10);
     const excluded = preAssignedIds(tournament, 11);
     const players = toSwissPlayers(tournament).filter(

--- a/src/__tests__/dynamic-uint.spec.ts
+++ b/src/__tests__/dynamic-uint.spec.ts
@@ -3,396 +3,52 @@ import { describe, expect, it } from 'vitest';
 import { DynamicUint } from '../dynamic-uint.js';
 
 describe('DynamicUint', () => {
-  describe('construction', () => {
-    it('zero() creates a zero value with specified word count', () => {
-      const n = DynamicUint.zero(2);
-      expect(n.words).toBe(2);
-      expect(n.isZero()).toBe(true);
+  describe('gt', () => {
+    it('returns true when this > other', () => {
+      expect(DynamicUint.from(10).gt(DynamicUint.from(5))).toBe(true);
     });
-
-    it('from(0) creates a zero with 1 word', () => {
-      const n = DynamicUint.from(0);
-      expect(n.words).toBe(1);
-      expect(n.isZero()).toBe(true);
+    it('returns false when this < other', () => {
+      expect(DynamicUint.from(5).gt(DynamicUint.from(10))).toBe(false);
     });
-
-    it('from(42) creates a single-word value', () => {
-      const n = DynamicUint.from(42);
-      expect(n.words).toBe(1);
-      expect(n.isZero()).toBe(false);
-    });
-
-    it('from(0x1_0000_0000) creates a two-word value', () => {
-      // 2^32 doesn't fit in a single 32-bit word
-      const n = DynamicUint.from(0x1_00_00_00_00);
-      expect(n.words).toBe(2);
-      expect(n.isZero()).toBe(false);
-    });
-
-    it('from(Number.MAX_SAFE_INTEGER) creates a two-word value', () => {
-      const n = DynamicUint.from(Number.MAX_SAFE_INTEGER);
-      expect(n.words).toBe(2);
-      expect(n.isZero()).toBe(false);
+    it('returns false when equal', () => {
+      const a = DynamicUint.from(7);
+      expect(a.gt(a.clone())).toBe(false);
     });
   });
 
-  describe('compareTo', () => {
-    it('returns 0 for equal values', () => {
+  describe('lt', () => {
+    it('returns true when this < other', () => {
+      expect(DynamicUint.from(3).lt(DynamicUint.from(7))).toBe(true);
+    });
+    it('returns false when this > other', () => {
+      expect(DynamicUint.from(7).lt(DynamicUint.from(3))).toBe(false);
+    });
+    it('returns false when equal', () => {
+      const a = DynamicUint.from(7);
+      expect(a.lt(a.clone())).toBe(false);
+    });
+  });
+
+  describe('copyFrom', () => {
+    it('copies value in-place', () => {
       const a = DynamicUint.from(42);
-      const b = DynamicUint.from(42);
-      expect(a.compareTo(b)).toBe(0);
+      const b = DynamicUint.from(99);
+      a.copyFrom(b);
+      expect(a.toBigInt()).toBe(99n);
     });
-
-    it('returns -1 when less than', () => {
-      const a = DynamicUint.from(10);
-      const b = DynamicUint.from(20);
-      expect(a.compareTo(b)).toBe(-1);
-    });
-
-    it('returns 1 when greater than', () => {
-      const a = DynamicUint.from(20);
-      const b = DynamicUint.from(10);
-      expect(a.compareTo(b)).toBe(1);
-    });
-
-    it('compares multi-word values correctly', () => {
-      const a = DynamicUint.from(0x1_00_00_00_00); // 2^32
-      const b = DynamicUint.from(0xff_ff_ff_ff); // 2^32 - 1
-      expect(a.compareTo(b)).toBe(1);
-      expect(b.compareTo(a)).toBe(-1);
-    });
-
-    it('compares same-value multi-word correctly', () => {
-      const a = DynamicUint.from(0x1_00_00_00_01);
-      const b = DynamicUint.from(0x1_00_00_00_01);
-      expect(a.compareTo(b)).toBe(0);
-    });
-
-    it('handles different word counts (zero padded)', () => {
-      const a = DynamicUint.zero(2);
-      const b = DynamicUint.zero(1);
-      // both are zero
-      expect(a.compareTo(b)).toBe(0);
-    });
-
-    it('returns 0 for same value with different word counts', () => {
-      // [5, 0] (2 words) vs [5] (1 word) — numerically equal
-      const a = DynamicUint.zero(2);
-      a.or(5);
-      const b = DynamicUint.from(5);
-      expect(a.compareTo(b)).toBe(0);
-      expect(b.compareTo(a)).toBe(0);
-    });
-  });
-
-  describe('clone', () => {
-    it('returns an independent copy', () => {
+    it('produces an independent copy', () => {
       const a = DynamicUint.from(42);
-      const b = a.clone();
-      expect(a.compareTo(b)).toBe(0);
-      // mutate original, clone should be unaffected
-      a.add(1);
-      expect(b.compareTo(DynamicUint.from(42))).toBe(0);
+      const b = DynamicUint.from(99);
+      a.copyFrom(b);
+      b.add(1);
+      expect(a.toBigInt()).toBe(99n);
     });
-
-    it('clone has same word count', () => {
-      const a = DynamicUint.zero(3);
-      const b = a.clone();
-      expect(b.words).toBe(3);
-    });
-  });
-
-  describe('isZero', () => {
-    it('returns true for zero()', () => {
-      expect(DynamicUint.zero(2).isZero()).toBe(true);
-    });
-
-    it('returns true for from(0)', () => {
-      expect(DynamicUint.from(0).isZero()).toBe(true);
-    });
-
-    it('returns false for non-zero', () => {
-      expect(DynamicUint.from(1).isZero()).toBe(false);
-    });
-
-    it('returns false after adding to zero', () => {
-      const n = DynamicUint.zero(1);
-      n.add(5);
-      expect(n.isZero()).toBe(false);
-    });
-  });
-
-  describe('or(number)', () => {
-    it('sets bits in the lowest word', () => {
-      const n = DynamicUint.zero(2);
-      n.or(0b1010);
-      // should be non-zero
-      expect(n.isZero()).toBe(false);
-    });
-
-    it('combines bits with OR correctly', () => {
-      const a = DynamicUint.from(0b0101);
-      a.or(0b1010);
-      const expected = DynamicUint.from(0b1111);
-      expect(a.compareTo(expected)).toBe(0);
-    });
-
-    it('does not affect high words', () => {
-      const n = DynamicUint.zero(2);
-      n.or(0xff_ff_ff_ff); // all bits in lowest word
-      // high word still zero; value equals 0xffffffff
-      const expected = DynamicUint.from(0xff_ff_ff_ff);
-      expect(n.compareTo(expected)).toBe(0);
-    });
-
-    it('returns this for chaining', () => {
-      const n = DynamicUint.zero(1);
-      expect(n.or(1)).toBe(n);
-    });
-  });
-
-  describe('or(DynamicUint)', () => {
-    it('ORs all words', () => {
-      const a = DynamicUint.from(0x1_00_00_00_00); // word1=1, word0=0
-      const b = DynamicUint.from(0xff_ff_ff_ff); // word1=0, word0=0xffffffff
-      a.or(b);
-      // result should have word1=1 and word0=0xffffffff
-      const expected = DynamicUint.from(0x1_ff_ff_ff_ff);
-      expect(a.compareTo(expected)).toBe(0);
-    });
-
-    it('returns this for chaining', () => {
-      const a = DynamicUint.zero(2);
-      const b = DynamicUint.zero(2);
-      expect(a.or(b)).toBe(a);
-    });
-  });
-
-  describe('and(number)', () => {
-    it('masks the lowest word', () => {
-      const n = DynamicUint.from(0b1111);
-      n.and(0b0110);
-      const expected = DynamicUint.from(0b0110);
-      expect(n.compareTo(expected)).toBe(0);
-    });
-
-    it('clears all high words', () => {
-      const n = DynamicUint.from(0x1_ff_ff_ff_ff); // 2 words
-      n.and(0xff_ff_ff_ff);
-      // upper word should be zeroed; result = lower 32 bits of 0xffffffff
-      const expected = DynamicUint.from(0xff_ff_ff_ff);
-      // n now has 2 words but upper word is 0; compare should still work
-      expect(n.compareTo(expected)).toBe(0);
-    });
-
-    it('returns this for chaining', () => {
-      const n = DynamicUint.from(7);
-      expect(n.and(3)).toBe(n);
-    });
-  });
-
-  describe('shiftLeft', () => {
-    it('shifts within a single word', () => {
-      const n = DynamicUint.from(1);
-      n.shiftLeft(4);
-      expect(n.compareTo(DynamicUint.from(16))).toBe(0);
-    });
-
-    it('shifts across word boundary', () => {
-      // 1 << 32 = 0x1_0000_0000
-      const n = DynamicUint.zero(2);
-      n.or(1);
-      n.shiftLeft(32);
-      const expected = DynamicUint.from(0x1_00_00_00_00);
-      expect(n.compareTo(expected)).toBe(0);
-    });
-
-    it('shifts by exact 32', () => {
-      const n = DynamicUint.zero(2);
-      n.or(3);
-      n.shiftLeft(32);
-      // 3 << 32 = 0x3_0000_0000
-      const expected = DynamicUint.from(0x3_00_00_00_00);
-      expect(n.compareTo(expected)).toBe(0);
-    });
-
-    it('shifts with both wordShift and bitShift non-zero', () => {
-      // 1 << 35 = 0x8_0000_0000 (wordShift=1, bitShift=3)
-      const n = DynamicUint.zero(2);
-      n.or(1);
-      n.shiftLeft(35);
-      const expected = DynamicUint.from(0x8_00_00_00_00);
-      expect(n.compareTo(expected)).toBe(0);
-    });
-
-    it('returns this for chaining', () => {
-      const n = DynamicUint.from(1);
-      expect(n.shiftLeft(1)).toBe(n);
-    });
-  });
-
-  describe('shiftRight', () => {
-    it('shifts within a single word', () => {
-      const n = DynamicUint.from(16);
-      n.shiftRight(4);
-      expect(n.compareTo(DynamicUint.from(1))).toBe(0);
-    });
-
-    it('shifts across word boundary', () => {
-      // 0x1_0000_0000 >> 32 = 1
-      const n = DynamicUint.from(0x1_00_00_00_00);
-      n.shiftRight(32);
-      expect(n.compareTo(DynamicUint.from(1))).toBe(0);
-    });
-
-    it('shifts across word boundary with non-zero bit offset', () => {
-      // 0x6_0000_0000 >> 33 = 3 (wordShift=1, bitShift=1)
-      const n = DynamicUint.zero(2);
-      n.or(6); // word0 = 6
-      n.shiftGrow(32); // n = 0x6_0000_0000
-      n.shiftRight(33);
-      expect(n.compareTo(DynamicUint.from(3))).toBe(0);
-    });
-
-    it('shifts away all bits to zero', () => {
-      const n = DynamicUint.from(1);
-      n.shiftRight(1);
-      expect(n.isZero()).toBe(true);
-    });
-
-    it('returns this for chaining', () => {
-      const n = DynamicUint.from(4);
-      expect(n.shiftRight(1)).toBe(n);
-    });
-  });
-
-  describe('shiftGrow', () => {
-    it('fits without growing when result stays in bounds', () => {
-      const n = DynamicUint.from(1);
-      const wordsBefore = n.words;
-      n.shiftGrow(4);
-      expect(n.words).toBe(wordsBefore);
-      expect(n.compareTo(DynamicUint.from(16))).toBe(0);
-    });
-
-    it('grows by 1 word when needed', () => {
-      const n = DynamicUint.zero(1);
-      n.or(1);
-      // shifting 1 left by 32 bits needs 2 words
-      n.shiftGrow(32);
-      expect(n.words).toBeGreaterThanOrEqual(2);
-      expect(n.compareTo(DynamicUint.from(0x1_00_00_00_00))).toBe(0);
-    });
-
-    it('grows by multiple words when needed', () => {
-      const n = DynamicUint.zero(1);
-      n.or(1);
-      // shifting 1 left by 64 bits needs 3 words
-      n.shiftGrow(64);
-      expect(n.words).toBeGreaterThanOrEqual(3);
-    });
-
-    it('handles zero value correctly', () => {
-      const n = DynamicUint.zero(1);
-      n.shiftGrow(100);
-      expect(n.isZero()).toBe(true);
-    });
-
-    it('returns this for chaining', () => {
-      const n = DynamicUint.from(1);
-      expect(n.shiftGrow(1)).toBe(n);
-    });
-  });
-
-  describe('add(number)', () => {
-    it('adds a simple value', () => {
-      const n = DynamicUint.from(10);
-      n.add(5);
-      expect(n.compareTo(DynamicUint.from(15))).toBe(0);
-    });
-
-    it('handles carry across word boundary', () => {
-      // 0xffff_ffff + 1 = 0x1_0000_0000
-      const n = DynamicUint.zero(2);
-      n.or(0xff_ff_ff_ff);
-      n.add(1);
-      const expected = DynamicUint.from(0x1_00_00_00_00);
-      expect(n.compareTo(expected)).toBe(0);
-    });
-
-    it('returns this for chaining', () => {
-      const n = DynamicUint.from(1);
-      expect(n.add(1)).toBe(n);
-    });
-  });
-
-  describe('add(DynamicUint)', () => {
-    it('adds two multi-word values', () => {
-      const a = DynamicUint.from(0x1_00_00_00_00); // 2^32
-      const b = DynamicUint.from(0x1_00_00_00_00); // 2^32
-      a.add(b);
-      const expected = DynamicUint.from(0x2_00_00_00_00);
-      expect(a.compareTo(expected)).toBe(0);
-    });
-
-    it('handles carry from lower word to upper word', () => {
-      const a = DynamicUint.zero(2);
-      a.or(0xff_ff_ff_ff);
-      const b = DynamicUint.from(1);
-      a.add(b);
-      const expected = DynamicUint.from(0x1_00_00_00_00);
-      expect(a.compareTo(expected)).toBe(0);
-    });
-
-    it('returns this for chaining', () => {
-      const a = DynamicUint.zero(2);
-      const b = DynamicUint.zero(2);
-      expect(a.add(b)).toBe(a);
-    });
-  });
-
-  describe('subtract(number)', () => {
-    it('subtracts a simple value', () => {
-      const n = DynamicUint.from(10);
-      n.subtract(3);
-      expect(n.compareTo(DynamicUint.from(7))).toBe(0);
-    });
-
-    it('handles borrow across word boundary', () => {
-      // 0x1_0000_0000 - 1 = 0xffff_ffff
-      const n = DynamicUint.from(0x1_00_00_00_00);
-      n.subtract(1);
-      const expected = DynamicUint.from(0xff_ff_ff_ff);
-      expect(n.compareTo(expected)).toBe(0);
-    });
-
-    it('returns this for chaining', () => {
-      const n = DynamicUint.from(5);
-      expect(n.subtract(1)).toBe(n);
-    });
-  });
-
-  describe('subtract(DynamicUint)', () => {
-    it('subtracts multi-word values', () => {
-      const a = DynamicUint.from(0x2_00_00_00_00);
-      const b = DynamicUint.from(0x1_00_00_00_00);
-      a.subtract(b);
-      const expected = DynamicUint.from(0x1_00_00_00_00);
-      expect(a.compareTo(expected)).toBe(0);
-    });
-
-    it('handles borrow from upper word', () => {
-      const a = DynamicUint.from(0x1_00_00_00_00);
-      const b = DynamicUint.from(1);
-      a.subtract(b);
-      const expected = DynamicUint.from(0xff_ff_ff_ff);
-      expect(a.compareTo(expected)).toBe(0);
-    });
-
-    it('returns this for chaining', () => {
-      const a = DynamicUint.from(10);
-      const b = DynamicUint.from(5);
-      expect(a.subtract(b)).toBe(a);
+    it('handles different word sizes', () => {
+      const small = DynamicUint.from(1);
+      const big = DynamicUint.from(1);
+      big.shiftGrow(64); // force multi-word
+      small.copyFrom(big);
+      expect(small.toBigInt()).toBe(big.toBigInt());
     });
   });
 });

--- a/src/__tests__/iterable-pool.spec.ts
+++ b/src/__tests__/iterable-pool.spec.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+
+import { IterablePool } from '../matching/iterable-pool.js';
+
+describe('IterablePool', () => {
+  it('constructs elements and iterates in insertion order', () => {
+    const pool = new IterablePool<string>(10);
+    pool.construct('a');
+    pool.construct('b');
+    pool.construct('c');
+    expect([...pool]).toEqual(['a', 'b', 'c']);
+  });
+
+  it('destroy removes from iteration', () => {
+    const pool = new IterablePool<string>(10);
+    pool.construct('a');
+    const index1 = pool.construct('b');
+    pool.construct('c');
+    pool.destroy(index1);
+    expect([...pool]).toEqual(['a', 'c']);
+  });
+
+  it('destroyed slots are reused by next construct (LIFO)', () => {
+    const pool = new IterablePool<string>(10);
+    pool.construct('a');
+    const index1 = pool.construct('b');
+    pool.destroy(index1);
+    // Next construct reuses slot index1, but appears at END of iteration
+    const index2 = pool.construct('c');
+    expect(index2).toBe(index1); // same slot reused (LIFO)
+    expect([...pool]).toEqual(['a', 'c']); // 'c' at end, not at index1's old position
+  });
+
+  it('hide removes from iteration but keeps alive', () => {
+    const pool = new IterablePool<string>(10);
+    pool.construct('a');
+    const index1 = pool.construct('b');
+    pool.construct('c');
+    pool.hide(index1);
+    expect([...pool]).toEqual(['a', 'c']);
+    // The element is still accessible:
+    expect(pool.get(index1)).toBe('b');
+  });
+
+  it('destroy after hide works', () => {
+    const pool = new IterablePool<string>(5);
+    pool.construct('a');
+    const index1 = pool.construct('b');
+    pool.hide(index1);
+    pool.destroy(index1);
+    expect([...pool]).toEqual(['a']);
+    const index2 = pool.construct('c');
+    expect(index2).toBe(index1); // slot reused
+    expect([...pool]).toEqual(['a', 'c']);
+  });
+
+  it('construct appends to tail even after destroy+reuse', () => {
+    const pool = new IterablePool<string>(5);
+    pool.construct('a'); // slot 0
+    pool.construct('b'); // slot 1
+    pool.construct('c'); // slot 2
+    pool.destroy(0); // free slot 0
+    pool.construct('d'); // reuses slot 0, appends to tail
+    expect([...pool]).toEqual(['b', 'c', 'd']);
+  });
+
+  it('iteration order matches C++ IterablePool for create-destroy-create cycle', () => {
+    const pool = new IterablePool<number>(10);
+    pool.construct(0); // slot 0
+    pool.construct(1); // slot 1
+    pool.construct(2); // slot 2
+    pool.construct(3); // slot 3
+    pool.destroy(1); // free slot 1
+    pool.destroy(2); // free slot 2
+    pool.construct(4); // reuses slot 2 (LIFO), appends to tail
+    pool.construct(5); // reuses slot 1 (LIFO), appends to tail
+    expect([...pool]).toEqual([0, 3, 4, 5]);
+  });
+});

--- a/src/__tests__/matching-computer.spec.ts
+++ b/src/__tests__/matching-computer.spec.ts
@@ -7,6 +7,7 @@ import {
   getAncestorOfVertex,
   setPointersFromAncestor,
 } from '../matching/blossom.js';
+import { Graph } from '../matching/graph.js';
 import { Vertex } from '../matching/vertex.js';
 
 describe('Vertex', () => {
@@ -308,5 +309,180 @@ describe('setPointersFromAncestor', () => {
 
     expect(pb.subblossom).toBe(v);
     expect(pb.iterationStartsWithSubblossom).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Graph
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a Graph with `n` vertices and maximum edge weight `maxWeight`.
+ */
+function makeTestGraph(n: number, maxWeight: number): Graph {
+  const graph = new Graph(DynamicUint.from(maxWeight));
+  for (let index = 0; index < n; index++) graph.addVertex();
+  return graph;
+}
+
+/**
+ * Set a bidirectional edge weight between two vertices.
+ * Internally edge weights are stored doubled; user-visible weight is halved.
+ * Uses prepareVertexForWeightAdjustments to reset dual variables correctly.
+ */
+function setEdgeWeight(
+  graph: Graph,
+  u: number,
+  v: number,
+  weight: number,
+): void {
+  // Weights are stored doubled internally.
+  const doubled = DynamicUint.from(weight * 2);
+  const vu = graph.vertices[u]!;
+  const vv = graph.vertices[v]!;
+  vu.edgeWeights[v] = doubled.clone();
+  vv.edgeWeights[u] = doubled.clone();
+}
+
+/**
+ * Initialize dual variables for all exposed vertices.
+ * In bbpPairings, prepareVertexForWeightAdjustments sets dual = aboveMaxEdgeWeight >> 1.
+ * Here we use the same approach — call it on each vertex before computeMatching.
+ */
+function initializeDuals(graph: Graph): void {
+  for (const rb of graph.rootBlossoms) {
+    rb.prepareVertexForWeightAdjustments(rb.baseVertex, graph);
+  }
+}
+
+/**
+ * Read the matching result after putVerticesInMatchingOrder.
+ * Returns an array where result[i] = j means vertex i is matched to vertex j,
+ * and result[i] = i means vertex i is unmatched (self-loop).
+ */
+function getMatching(graph: Graph): number[] {
+  const result = Array.from<number>({ length: graph.vertices.length }).fill(-1);
+
+  for (const rb of graph.rootBlossoms) {
+    rb.putVerticesInMatchingOrder();
+    const baseIndex = rb.baseVertex.vertexIndex;
+    result[baseIndex] = rb.baseVertexMatch
+      ? rb.baseVertexMatch.vertexIndex
+      : baseIndex; // exposed → self
+    // Walk the vertex list for the remaining matched pairs.
+    let v = rb.rootChild.vertexListHead.nextVertex;
+    while (v !== undefined) {
+      const partner = v.nextVertex;
+      if (partner === undefined) break;
+      result[v.vertexIndex] = partner.vertexIndex;
+      result[partner.vertexIndex] = v.vertexIndex;
+      v = partner.nextVertex;
+    }
+  }
+
+  return result;
+}
+
+describe('Graph', () => {
+  describe('addVertex', () => {
+    it('creates a vertex with the correct index', () => {
+      const graph = makeTestGraph(0, 100);
+      graph.addVertex();
+      expect(graph.vertices.length).toBe(1);
+      expect(graph.vertices[0]!.vertexIndex).toBe(0);
+    });
+
+    it('expands edgeWeights for all vertices', () => {
+      const graph = makeTestGraph(0, 100);
+      graph.addVertex();
+      graph.addVertex();
+      // Each vertex should have 2 edge weight slots (one per vertex).
+      expect(graph.vertices[0]!.edgeWeights.length).toBe(2);
+      expect(graph.vertices[1]!.edgeWeights.length).toBe(2);
+    });
+
+    it('creates a RootBlossom for each vertex', () => {
+      const graph = makeTestGraph(3, 100);
+      expect(graph.rootBlossoms.length).toBe(3);
+    });
+
+    it('new vertex has a singleton RootBlossom', () => {
+      const graph = makeTestGraph(0, 100);
+      graph.addVertex();
+      const v = graph.vertices[0]!;
+      expect(v.rootBlossom).toBeDefined();
+      expect(v.rootBlossom!.rootChild).toBe(v);
+      expect(v.rootBlossom!.baseVertex).toBe(v);
+    });
+
+    it('dual variables start at zero', () => {
+      const graph = makeTestGraph(2, 100);
+      expect(graph.vertexDualVariables[0]!.isZero()).toBe(true);
+      expect(graph.vertexDualVariables[1]!.isZero()).toBe(true);
+    });
+
+    it('dual variable is aliased by vertex.dualVariable', () => {
+      const graph = makeTestGraph(1, 100);
+      // They must be the same object.
+      expect(graph.vertices[0]!.dualVariable).toBe(
+        graph.vertexDualVariables[0],
+      );
+    });
+
+    it('aboveMaxEdgeWeight is strictly greater than 4x maxEdgeWeight', () => {
+      const graph = makeTestGraph(0, 10);
+      // aboveMaxEdgeWeight = 10 * 4 + 1 = 41
+      expect(graph.aboveMaxEdgeWeight.toBigInt()).toBe(41n);
+    });
+  });
+
+  describe('computeMatching — simple cases', () => {
+    it('two vertices, one edge — produces a matching', () => {
+      const graph = makeTestGraph(2, 10);
+      setEdgeWeight(graph, 0, 1, 10);
+      initializeDuals(graph);
+      graph.computeMatching();
+
+      const matching = getMatching(graph);
+      // Either vertex 0 matched to 1 and vice versa, or both self (no match found).
+      // With weight 10 between 0 and 1, they should be matched.
+      expect(matching[0]).toBe(1);
+      expect(matching[1]).toBe(0);
+    });
+
+    it('single vertex — no matching', () => {
+      const graph = makeTestGraph(1, 10);
+      initializeDuals(graph);
+      graph.computeMatching();
+      expect(graph.rootBlossoms[0]!.baseVertexMatch).toBeUndefined();
+    });
+
+    it('three vertices, one strong edge — matches the strongest pair', () => {
+      const graph = makeTestGraph(3, 10);
+      setEdgeWeight(graph, 0, 1, 10);
+      setEdgeWeight(graph, 1, 2, 5);
+      initializeDuals(graph);
+      graph.computeMatching();
+
+      const matching = getMatching(graph);
+      // Vertices 0 and 1 should be matched (weight 10 vs 5).
+      expect(matching[0]).toBe(1);
+      expect(matching[1]).toBe(0);
+    });
+  });
+
+  describe('constructor', () => {
+    it('aboveMaxEdgeWeight is set correctly', () => {
+      const graph = new Graph(DynamicUint.from(100));
+      // aboveMaxEdgeWeight = 100 * 4 + 1 = 401
+      expect(graph.aboveMaxEdgeWeight.toBigInt()).toBe(401n);
+    });
+
+    it('starts with empty vertices and blossoms', () => {
+      const graph = new Graph(DynamicUint.from(10));
+      expect(graph.vertices.length).toBe(0);
+      expect(graph.rootBlossoms.length).toBe(0);
+      expect(graph.parentBlossoms.length).toBe(0);
+    });
   });
 });

--- a/src/__tests__/matching-computer.spec.ts
+++ b/src/__tests__/matching-computer.spec.ts
@@ -115,7 +115,7 @@ describe('RootBlossom', () => {
 
   const makeGraph = () => ({
     aboveMaxEdgeWeight: aboveMax,
-    parentBlossoms: [] as ParentBlossom[],
+    parentBlossomPool: new IterablePool<ParentBlossom>(8),
     rootBlossomPool: new IterablePool<RootBlossom>(16),
     vertexDualVariables: [] as DynamicUint[],
   });
@@ -237,7 +237,7 @@ describe('ParentBlossom', () => {
     const aboveMax = DynamicUint.from(100);
     const graph = {
       aboveMaxEdgeWeight: aboveMax,
-      parentBlossoms: [] as ParentBlossom[],
+      parentBlossomPool: new IterablePool<ParentBlossom>(8),
       rootBlossomPool: new IterablePool<RootBlossom>(16),
       vertexDualVariables: [] as DynamicUint[],
     };
@@ -252,7 +252,7 @@ describe('ParentBlossom', () => {
     const aboveMax = DynamicUint.from(100);
     const graph = {
       aboveMaxEdgeWeight: aboveMax,
-      parentBlossoms: [] as ParentBlossom[],
+      parentBlossomPool: new IterablePool<ParentBlossom>(8),
       rootBlossomPool: new IterablePool<RootBlossom>(16),
       vertexDualVariables: [] as DynamicUint[],
     };
@@ -268,7 +268,7 @@ describe('ParentBlossom', () => {
     const aboveMax = DynamicUint.from(100);
     const graph = {
       aboveMaxEdgeWeight: aboveMax,
-      parentBlossoms: [] as ParentBlossom[],
+      parentBlossomPool: new IterablePool<ParentBlossom>(8),
       rootBlossomPool: new IterablePool<RootBlossom>(16),
       vertexDualVariables: [] as DynamicUint[],
     };
@@ -301,7 +301,7 @@ describe('setPointersFromAncestor', () => {
     const aboveMax = DynamicUint.from(100);
     const graph = {
       aboveMaxEdgeWeight: aboveMax,
-      parentBlossoms: [] as ParentBlossom[],
+      parentBlossomPool: new IterablePool<ParentBlossom>(8),
       rootBlossomPool: new IterablePool<RootBlossom>(16),
       vertexDualVariables: [] as DynamicUint[],
     };
@@ -486,7 +486,7 @@ describe('Graph', () => {
       const graph = new Graph(0, DynamicUint.from(10));
       expect(graph.vertices.length).toBe(0);
       expect([...graph.rootBlossomPool].length).toBe(0);
-      expect(graph.parentBlossoms.length).toBe(0);
+      expect([...graph.parentBlossomPool].length).toBe(0);
     });
   });
 });

--- a/src/__tests__/matching-computer.spec.ts
+++ b/src/__tests__/matching-computer.spec.ts
@@ -732,4 +732,47 @@ describe('MatchingComputer', () => {
       );
     });
   });
+
+  describe('repeated setEdgeWeight + computeMatching cycles', () => {
+    it('survives repeated cycles (n=18)', () => {
+      const maxW = DynamicUint.from(0);
+      maxW.or(2);
+      for (let index = 0; index < 15; index++) maxW.shiftGrow(3);
+      for (let index = 0; index < 6; index++) maxW.shiftGrow(6);
+      maxW.shiftGrow(3);
+      maxW.shiftGrow(2);
+      maxW.shiftRight(1);
+      maxW.subtract(1);
+
+      const n = 18;
+      const mc = new MatchingComputer(maxW);
+      for (let index = 0; index < n; index++) mc.addVertex();
+
+      // Initial edges.
+      for (let index = 0; index < n; index++) {
+        for (let index_ = index + 1; index_ < n; index_++) {
+          mc.setEdgeWeight(
+            index,
+            index_,
+            maxW.clone().shiftRight(((index * 7 + index_ * 13) % 10) + 1),
+          );
+        }
+      }
+      mc.computeMatching();
+
+      // Three rounds of modifications + recompute.
+      for (let round = 0; round < 3; round++) {
+        for (let k = 0; k < 100; k++) {
+          const index = ((round + 2) * 7 + k * 3) % n;
+          const index_ = (index + 1 + k) % n;
+          mc.setEdgeWeight(index, index_, maxW.clone().shiftRight((k % 10) + 1));
+        }
+        mc.computeMatching();
+      }
+
+      const matching = mc.getMatching();
+      const matched = matching.filter((m, index) => m !== index && m !== -1).length;
+      expect(matched).toBeGreaterThan(0);
+    });
+  });
 });

--- a/src/__tests__/matching-computer.spec.ts
+++ b/src/__tests__/matching-computer.spec.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from 'vitest';
 
 import { DynamicUint } from '../dynamic-uint.js';
+import {
+  ParentBlossom,
+  RootBlossom,
+  getAncestorOfVertex,
+  setPointersFromAncestor,
+} from '../matching/blossom.js';
 import { Vertex } from '../matching/vertex.js';
 
 describe('Vertex', () => {
@@ -93,5 +99,214 @@ describe('Vertex', () => {
       a.edgeWeights.push(DynamicUint.from(5));
       expect(b.edgeWeights.length).toBe(0);
     });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// RootBlossom
+// ---------------------------------------------------------------------------
+
+describe('RootBlossom', () => {
+  const aboveMax = DynamicUint.from(100);
+
+  const makeGraph = () => ({
+    aboveMaxEdgeWeight: aboveMax,
+    parentBlossoms: [] as ParentBlossom[],
+    rootBlossoms: [] as RootBlossom[],
+    vertexDualVariables: [] as DynamicUint[],
+  });
+
+  describe('constructor', () => {
+    it('stores rootChild and baseVertex', () => {
+      const v = new Vertex(0, DynamicUint.zero(1));
+      const graph = makeGraph();
+      const root = new RootBlossom(v, v, undefined, graph);
+      expect(root.rootChild).toBe(v);
+      expect(root.baseVertex).toBe(v);
+    });
+
+    it('baseVertexMatch is undefined for an exposed blossom', () => {
+      const v = new Vertex(0, DynamicUint.zero(1));
+      const graph = makeGraph();
+      const root = new RootBlossom(v, v, undefined, graph);
+      expect(root.baseVertexMatch).toBeUndefined();
+    });
+
+    it('labeledVertex and labelingVertex default to undefined', () => {
+      const v = new Vertex(0, DynamicUint.zero(1));
+      const graph = makeGraph();
+      const root = new RootBlossom(v, v, undefined, graph);
+      expect(root.labeledVertex).toBeUndefined();
+      expect(root.labelingVertex).toBeUndefined();
+    });
+
+    it('minOuterEdges defaults to empty array', () => {
+      const v = new Vertex(0, DynamicUint.zero(1));
+      const graph = makeGraph();
+      const root = new RootBlossom(v, v, undefined, graph);
+      expect(root.minOuterEdges).toEqual([]);
+    });
+  });
+
+  describe('prepareVertexForWeightAdjustments', () => {
+    it('no-op case: single vertex, no match', () => {
+      const v = new Vertex(0, DynamicUint.zero(1));
+      v.dualVariable = DynamicUint.zero(1);
+      const graph = makeGraph();
+      const root = new RootBlossom(v, v, undefined, graph);
+      v.rootBlossom = root;
+      graph.rootBlossoms.push(root);
+
+      root.prepareVertexForWeightAdjustments(v, graph);
+
+      expect(root.baseVertex).toBe(v);
+      expect(root.baseVertexMatch).toBeUndefined();
+      // dual should be aboveMaxEdgeWeight >> 1 = 50
+      expect(v.dualVariable.toBigInt()).toBe(50n);
+    });
+
+    it('disconnects match on both sides', () => {
+      const zero = DynamicUint.zero(1);
+      const v0 = new Vertex(0, zero);
+      const v1 = new Vertex(1, zero);
+      v0.dualVariable = DynamicUint.zero(1);
+      v1.dualVariable = DynamicUint.zero(1);
+
+      const graph = makeGraph();
+      const root0 = new RootBlossom(v0, v0, undefined, graph);
+      const root1 = new RootBlossom(v1, v1, undefined, graph);
+      v0.rootBlossom = root0;
+      v1.rootBlossom = root1;
+
+      // Simulate a match between v0 and v1.
+      root0.baseVertexMatch = v1;
+      root1.baseVertexMatch = v0;
+
+      graph.rootBlossoms.push(root0, root1);
+
+      root0.prepareVertexForWeightAdjustments(v0, graph);
+
+      expect(root0.baseVertexMatch).toBeUndefined();
+      expect(root1.baseVertexMatch).toBeUndefined();
+    });
+
+    it('sets baseVertex to the provided vertex', () => {
+      const zero = DynamicUint.zero(1);
+      const v = new Vertex(3, zero);
+      v.dualVariable = DynamicUint.zero(1);
+      const graph = makeGraph();
+      const root = new RootBlossom(v, v, undefined, graph);
+      v.rootBlossom = root;
+      graph.rootBlossoms.push(root);
+
+      root.prepareVertexForWeightAdjustments(v, graph);
+
+      expect(root.baseVertex).toBe(v);
+    });
+  });
+
+  describe('putVerticesInMatchingOrder', () => {
+    it('no-op for single-vertex blossom', () => {
+      const v = new Vertex(0, DynamicUint.zero(1));
+      const graph = makeGraph();
+      const root = new RootBlossom(v, v, undefined, graph);
+      v.rootBlossom = root;
+
+      root.putVerticesInMatchingOrder();
+
+      expect(root.rootChild.vertexListHead).toBe(v);
+      expect(root.rootChild.vertexListTail).toBe(v);
+      expect(v.nextVertex).toBeUndefined();
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ParentBlossom
+// ---------------------------------------------------------------------------
+
+describe('ParentBlossom', () => {
+  it('isVertex is false', () => {
+    const zero = DynamicUint.zero(1);
+    const v = new Vertex(0, zero);
+    const aboveMax = DynamicUint.from(100);
+    const graph = {
+      aboveMaxEdgeWeight: aboveMax,
+      parentBlossoms: [] as ParentBlossom[],
+      rootBlossoms: [] as RootBlossom[],
+      vertexDualVariables: [] as DynamicUint[],
+    };
+    const root = new RootBlossom(v, v, undefined, graph);
+    const pb = new ParentBlossom(DynamicUint.from(4), root, v, v, v);
+    expect(pb.isVertex).toBe(false);
+  });
+
+  it('stores dualVariable', () => {
+    const zero = DynamicUint.zero(1);
+    const v = new Vertex(0, zero);
+    const aboveMax = DynamicUint.from(100);
+    const graph = {
+      aboveMaxEdgeWeight: aboveMax,
+      parentBlossoms: [] as ParentBlossom[],
+      rootBlossoms: [] as RootBlossom[],
+      vertexDualVariables: [] as DynamicUint[],
+    };
+    const root = new RootBlossom(v, v, undefined, graph);
+    const dual = DynamicUint.from(8);
+    const pb = new ParentBlossom(dual, root, v, v, v);
+    expect(pb.dualVariable.toBigInt()).toBe(8n);
+  });
+
+  it('subblossom and vertexListHead/Tail are set from constructor', () => {
+    const zero = DynamicUint.zero(1);
+    const v = new Vertex(0, zero);
+    const aboveMax = DynamicUint.from(100);
+    const graph = {
+      aboveMaxEdgeWeight: aboveMax,
+      parentBlossoms: [] as ParentBlossom[],
+      rootBlossoms: [] as RootBlossom[],
+      vertexDualVariables: [] as DynamicUint[],
+    };
+    const root = new RootBlossom(v, v, undefined, graph);
+    const pb = new ParentBlossom(DynamicUint.from(2), root, v, v, v);
+    expect(pb.subblossom).toBe(v);
+    expect(pb.vertexListHead).toBe(v);
+    expect(pb.vertexListTail).toBe(v);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Helper functions
+// ---------------------------------------------------------------------------
+
+describe('getAncestorOfVertex', () => {
+  it('returns the vertex itself when parentBlossom equals ancestor', () => {
+    const zero = DynamicUint.zero(1);
+    const v = new Vertex(0, zero);
+    // vertex.parentBlossom is undefined — ancestor is also undefined
+    const result = getAncestorOfVertex(v);
+    expect(result).toBe(v);
+  });
+});
+
+describe('setPointersFromAncestor', () => {
+  it('sets subblossom on a single-level parent', () => {
+    const zero = DynamicUint.zero(1);
+    const v = new Vertex(0, zero);
+    const aboveMax = DynamicUint.from(100);
+    const graph = {
+      aboveMaxEdgeWeight: aboveMax,
+      parentBlossoms: [] as ParentBlossom[],
+      rootBlossoms: [] as RootBlossom[],
+      vertexDualVariables: [] as DynamicUint[],
+    };
+    const root = new RootBlossom(v, v, undefined, graph);
+    const pb = new ParentBlossom(DynamicUint.from(2), root, v, v, v);
+    v.parentBlossom = pb;
+
+    setPointersFromAncestor(v, pb, true);
+
+    expect(pb.subblossom).toBe(v);
+    expect(pb.iterationStartsWithSubblossom).toBe(true);
   });
 });

--- a/src/__tests__/matching-computer.spec.ts
+++ b/src/__tests__/matching-computer.spec.ts
@@ -657,5 +657,79 @@ describe('MatchingComputer', () => {
       // Original pairs should be preserved (not rearranged).
       expect(mc.getMatching()).toEqual([1, 0, 3, 2]);
     });
+
+    it('sequential setEdgeWeight + computeMatching cycles — no infinite loop', () => {
+      // 6 vertices, multiple compute cycles with changing edge weights.
+      // This exercises the augmentMatching loop repeatedly to catch infinite loops.
+      const mc = new MatchingComputer(DynamicUint.from(100));
+      for (let index = 0; index < 6; index++) mc.addVertex();
+
+      // Round 1: simple disjoint pairs.
+      mc.setEdgeWeight(0, 1, DynamicUint.from(80));
+      mc.setEdgeWeight(2, 3, DynamicUint.from(70));
+      mc.setEdgeWeight(4, 5, DynamicUint.from(60));
+      mc.computeMatching();
+      const m1 = mc.getMatching();
+      expect(m1[0]).toBe(1);
+      expect(m1[1]).toBe(0);
+      expect(m1[2]).toBe(3);
+      expect(m1[3]).toBe(2);
+      expect(m1[4]).toBe(5);
+      expect(m1[5]).toBe(4);
+
+      // Round 2: add cross edges that compete with existing pairs.
+      mc.setEdgeWeight(0, 2, DynamicUint.from(30));
+      mc.setEdgeWeight(1, 3, DynamicUint.from(30));
+      mc.computeMatching();
+      const m2 = mc.getMatching();
+      // Total weight of m2 should equal that from reference algorithm.
+      const edgeWeights2 = new Map([
+        ['0-1', 80],
+        ['2-3', 70],
+        ['4-5', 60],
+        ['0-2', 30],
+        ['1-3', 30],
+      ]);
+      const referenceEdges2: [number, number, number][] = [
+        [0, 1, 80],
+        [2, 3, 70],
+        [4, 5, 60],
+        [0, 2, 30],
+        [1, 3, 30],
+      ];
+      const reference2 = maxWeightMatching(
+        referenceEdges2.map(([u, v, w]) => [u, v, DynamicUint.from(w)]),
+      );
+      expect(totalWeight(normalizeMatching(m2), edgeWeights2)).toBe(
+        totalWeight(reference2, edgeWeights2),
+      );
+
+      // Round 3: change a weight to reshape the optimal matching.
+      mc.setEdgeWeight(0, 5, DynamicUint.from(90));
+      mc.computeMatching();
+      const m3 = mc.getMatching();
+      const edgeWeights3 = new Map([
+        ['0-1', 80],
+        ['2-3', 70],
+        ['4-5', 60],
+        ['0-2', 30],
+        ['1-3', 30],
+        ['0-5', 90],
+      ]);
+      const referenceEdges3: [number, number, number][] = [
+        [0, 1, 80],
+        [2, 3, 70],
+        [4, 5, 60],
+        [0, 2, 30],
+        [1, 3, 30],
+        [0, 5, 90],
+      ];
+      const reference3 = maxWeightMatching(
+        referenceEdges3.map(([u, v, w]) => [u, v, DynamicUint.from(w)]),
+      );
+      expect(totalWeight(normalizeMatching(m3), edgeWeights3)).toBe(
+        totalWeight(reference3, edgeWeights3),
+      );
+    });
   });
 });

--- a/src/__tests__/matching-computer.spec.ts
+++ b/src/__tests__/matching-computer.spec.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'vitest';
+
+import { DynamicUint } from '../dynamic-uint.js';
+import { Vertex } from '../matching/vertex.js';
+
+describe('Vertex', () => {
+  const zero = DynamicUint.zero(1);
+
+  describe('constructor', () => {
+    it('initializes with the correct index', () => {
+      const v = new Vertex(42, zero);
+      expect(v.vertexIndex).toBe(42);
+    });
+
+    it('initializes with index 0', () => {
+      const v = new Vertex(0, zero);
+      expect(v.vertexIndex).toBe(0);
+    });
+
+    it('edgeWeights starts empty', () => {
+      const v = new Vertex(0, zero);
+      expect(v.edgeWeights).toEqual([]);
+      expect(v.edgeWeights.length).toBe(0);
+    });
+
+    it('vertexListHead points to self', () => {
+      const v = new Vertex(0, zero);
+      expect(v.vertexListHead).toBe(v);
+    });
+
+    it('vertexListTail points to self', () => {
+      const v = new Vertex(0, zero);
+      expect(v.vertexListTail).toBe(v);
+    });
+
+    it('nextVertex is undefined', () => {
+      const v = new Vertex(0, zero);
+      expect(v.nextVertex).toBeUndefined();
+    });
+
+    it('minOuterEdge is undefined', () => {
+      const v = new Vertex(0, zero);
+      expect(v.minOuterEdge).toBeUndefined();
+    });
+
+    it('rootBlossom is undefined', () => {
+      const v = new Vertex(0, zero);
+      expect(v.rootBlossom).toBeUndefined();
+    });
+
+    it('parentBlossom is undefined', () => {
+      const v = new Vertex(0, zero);
+      expect(v.parentBlossom).toBeUndefined();
+    });
+
+    it('minOuterEdgeResistance is a clone (independent copy) of zero', () => {
+      const v = new Vertex(0, zero);
+      expect(v.minOuterEdgeResistance.isZero()).toBe(true);
+      // Mutating zero does not affect the vertex's copy
+      zero.add(1);
+      expect(v.minOuterEdgeResistance.isZero()).toBe(true);
+      // Restore zero for other tests
+      zero.subtract(1);
+    });
+  });
+
+  describe('isVertex', () => {
+    it('returns true', () => {
+      const v = new Vertex(0, zero);
+      expect(v.isVertex).toBe(true);
+    });
+  });
+
+  describe('vertexIndex immutability', () => {
+    it('vertexIndex is readonly', () => {
+      const v = new Vertex(7, zero);
+      // TypeScript prevents assignment at compile time; verify the value is stable
+      expect(v.vertexIndex).toBe(7);
+    });
+  });
+
+  describe('separate instances are independent', () => {
+    it('two vertices have independent vertexListHead/Tail', () => {
+      const a = new Vertex(0, zero);
+      const b = new Vertex(1, zero);
+      expect(a.vertexListHead).toBe(a);
+      expect(b.vertexListHead).toBe(b);
+    });
+
+    it('two vertices have independent edgeWeights arrays', () => {
+      const a = new Vertex(0, zero);
+      const b = new Vertex(1, zero);
+      a.edgeWeights.push(DynamicUint.from(5));
+      expect(b.edgeWeights.length).toBe(0);
+    });
+  });
+});

--- a/src/__tests__/matching-computer.spec.ts
+++ b/src/__tests__/matching-computer.spec.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
+import { maxWeightMatching } from '../blossom.js';
 import { DynamicUint } from '../dynamic-uint.js';
 import {
   ParentBlossom,
@@ -9,6 +10,7 @@ import {
 } from '../matching/blossom.js';
 import { Graph } from '../matching/graph.js';
 import { Vertex } from '../matching/vertex.js';
+import { MatchingComputer } from '../matching-computer.js';
 
 describe('Vertex', () => {
   const zero = DynamicUint.zero(1);
@@ -483,6 +485,177 @@ describe('Graph', () => {
       expect(graph.vertices.length).toBe(0);
       expect(graph.rootBlossoms.length).toBe(0);
       expect(graph.parentBlossoms.length).toBe(0);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// MatchingComputer
+// ---------------------------------------------------------------------------
+
+/**
+ * Normalize a matching result for comparison.
+ * maxWeightMatching uses -1 for unmatched; MatchingComputer uses i (self).
+ * This converts the self-loop convention to -1.
+ */
+function normalizeMatching(matching: number[]): number[] {
+  return matching.map((m, index) => (m === index ? -1 : m));
+}
+
+/**
+ * Compute total weight of a matching given edges.
+ * Each pair (i, j) is counted once.
+ */
+function totalWeight(
+  matching: number[],
+  edgeWeights: Map<string, number>,
+): number {
+  let total = 0;
+  const counted = new Set<number>();
+  for (const [index, element] of matching.entries()) {
+    const partner = element!;
+    if (partner !== -1 && partner !== index && !counted.has(index)) {
+      const key =
+        index < partner ? `${index}-${partner}` : `${partner}-${index}`;
+      total += edgeWeights.get(key) ?? 0;
+      counted.add(index);
+      counted.add(partner);
+    }
+  }
+  return total;
+}
+
+/**
+ * Build a MatchingComputer, set edges, compute, and return
+ * the matching normalized to -1 for unmatched.
+ */
+function computeViaMatchingComputer(
+  vertexCount: number,
+  edgeList: [number, number, number][],
+): number[] {
+  const maxW = Math.max(...edgeList.map(([u, v, w]) => Math.max(u, v, w)), 1);
+  const mc = new MatchingComputer(DynamicUint.from(maxW));
+  for (let index = 0; index < vertexCount; index++) mc.addVertex();
+  for (const [u, v, w] of edgeList) {
+    mc.setEdgeWeight(u, v, DynamicUint.from(w));
+  }
+  mc.computeMatching();
+  return normalizeMatching(mc.getMatching());
+}
+
+describe('MatchingComputer', () => {
+  describe('constructor and addVertex', () => {
+    it('starts with zero vertices', () => {
+      const mc = new MatchingComputer(DynamicUint.from(100));
+      expect(mc.size).toBe(0);
+    });
+
+    it('addVertex increments size', () => {
+      const mc = new MatchingComputer(DynamicUint.from(100));
+      mc.addVertex();
+      mc.addVertex();
+      expect(mc.size).toBe(2);
+    });
+  });
+
+  describe('integration: matches maxWeightMatching results', () => {
+    it('4 vertices, 2 disjoint edges — unique optimal', () => {
+      // Edge 0-1 weight 10, edge 2-3 weight 10. Optimal: both matched.
+      const edgeList: [number, number, number][] = [
+        [0, 1, 10],
+        [2, 3, 10],
+      ];
+      const reference = maxWeightMatching(
+        edgeList.map(([u, v, w]) => [u, v, DynamicUint.from(w)]),
+      );
+      const result = computeViaMatchingComputer(4, edgeList);
+      expect(result).toEqual(reference);
+    });
+
+    it('4 vertices, complete graph — single optimal pair wins', () => {
+      // Strongest edge is 0-3 (weight 20); optimal leaves 1-2 matched (weight 5)
+      // or 0-3 with 1 and 2 unmatched. maxWeightMatching picks 0-3 + 1-2.
+      const edgeList: [number, number, number][] = [
+        [0, 1, 5],
+        [0, 2, 5],
+        [0, 3, 20],
+        [1, 2, 5],
+        [1, 3, 5],
+        [2, 3, 5],
+      ];
+      const reference = maxWeightMatching(
+        edgeList.map(([u, v, w]) => [u, v, DynamicUint.from(w)]),
+      );
+      const result = computeViaMatchingComputer(4, edgeList);
+      expect(result).toEqual(reference);
+    });
+
+    it('6 vertices, path graph — unique perfect matching', () => {
+      // Path 0-1-2-3-4-5, all weight 10. Optimal: (0,1),(2,3),(4,5).
+      const edgeList: [number, number, number][] = [
+        [0, 1, 10],
+        [1, 2, 10],
+        [2, 3, 10],
+        [3, 4, 10],
+        [4, 5, 10],
+      ];
+      const reference = maxWeightMatching(
+        edgeList.map(([u, v, w]) => [u, v, DynamicUint.from(w)]),
+      );
+      const result = computeViaMatchingComputer(6, edgeList);
+      // Both should produce the same total weight even if vertex ordering differs.
+      const edgeWeightMap = new Map<string, number>();
+      for (const [u, v, w] of edgeList) {
+        const key = u < v ? `${u}-${v}` : `${v}-${u}`;
+        edgeWeightMap.set(key, w);
+      }
+      expect(totalWeight(result, edgeWeightMap)).toBe(
+        totalWeight(reference, edgeWeightMap),
+      );
+    });
+
+    it('8 vertices, assorted weights — total weight equals maxWeightMatching', () => {
+      const edgeList: [number, number, number][] = [
+        [0, 1, 30],
+        [0, 2, 15],
+        [1, 3, 20],
+        [2, 3, 25],
+        [4, 5, 35],
+        [4, 6, 10],
+        [5, 7, 15],
+        [6, 7, 40],
+        [3, 4, 5],
+      ];
+      const reference = maxWeightMatching(
+        edgeList.map(([u, v, w]) => [u, v, DynamicUint.from(w)]),
+      );
+      const result = computeViaMatchingComputer(8, edgeList);
+
+      const edgeWeightMap = new Map<string, number>();
+      for (const [u, v, w] of edgeList) {
+        const key = u < v ? `${u}-${v}` : `${v}-${u}`;
+        edgeWeightMap.set(key, w);
+      }
+      expect(totalWeight(result, edgeWeightMap)).toBe(
+        totalWeight(reference, edgeWeightMap),
+      );
+    });
+  });
+
+  describe('persistence test', () => {
+    it('preserves matching after unrelated setEdgeWeight', () => {
+      const mc = new MatchingComputer(DynamicUint.from(100));
+      for (let index = 0; index < 4; index++) mc.addVertex();
+      mc.setEdgeWeight(0, 1, DynamicUint.from(50));
+      mc.setEdgeWeight(2, 3, DynamicUint.from(50));
+      mc.computeMatching();
+      expect(mc.getMatching()).toEqual([1, 0, 3, 2]);
+
+      // Modify edge 0-2 (unrelated to existing pairs).
+      mc.setEdgeWeight(0, 2, DynamicUint.from(5));
+      mc.computeMatching();
+      // Original pairs should be preserved (not rearranged).
+      expect(mc.getMatching()).toEqual([1, 0, 3, 2]);
     });
   });
 });

--- a/src/__tests__/matching-computer.spec.ts
+++ b/src/__tests__/matching-computer.spec.ts
@@ -733,6 +733,49 @@ describe('MatchingComputer', () => {
     });
   });
 
+  describe('stale baseVertexMatch regression', () => {
+    it('clears stale baseVertexMatch when neighbor edges are zeroed', () => {
+      // 4 vertices: 0, 1, 2, 3
+      // Initial: high weight edges 0-2 and 1-3 → match (0,2) and (1,3)
+      // Then: finalize pair 0-1 (zero all edges for 0 and 1 except 0-1=1)
+      //        set edge 2-3 to high weight
+      // Expected: computeMatching → 0 matched to 1, 2 matched to 3
+      // Bug: vertex 2 retains stale baseVertexMatch=0, labeled FREE, skipped
+
+      const mc = new MatchingComputer(DynamicUint.from(100));
+      mc.addVertex();
+      mc.addVertex();
+      mc.addVertex();
+      mc.addVertex();
+
+      // Phase 1: match 0-2 and 1-3
+      mc.setEdgeWeight(0, 2, DynamicUint.from(50));
+      mc.setEdgeWeight(1, 3, DynamicUint.from(50));
+      mc.computeMatching();
+      let matching = mc.getMatching();
+      expect(matching[0]).toBe(2);
+      expect(matching[2]).toBe(0);
+      expect(matching[1]).toBe(3);
+      expect(matching[3]).toBe(1);
+
+      // Phase 2: finalize pair 0-1
+      mc.setEdgeWeight(0, 2, DynamicUint.from(0));
+      mc.setEdgeWeight(0, 3, DynamicUint.from(0));
+      mc.setEdgeWeight(1, 2, DynamicUint.from(0));
+      mc.setEdgeWeight(1, 3, DynamicUint.from(0));
+      mc.setEdgeWeight(0, 1, DynamicUint.from(1));
+      mc.setEdgeWeight(2, 3, DynamicUint.from(50));
+
+      mc.computeMatching();
+      matching = mc.getMatching();
+
+      expect(matching[0]).toBe(1);
+      expect(matching[1]).toBe(0);
+      expect(matching[2]).toBe(3);
+      expect(matching[3]).toBe(2);
+    });
+  });
+
   describe('repeated setEdgeWeight + computeMatching cycles', () => {
     it('survives repeated cycles (n=18)', () => {
       const maxW = DynamicUint.from(0);

--- a/src/__tests__/matching-computer.spec.ts
+++ b/src/__tests__/matching-computer.spec.ts
@@ -9,6 +9,7 @@ import {
   setPointersFromAncestor,
 } from '../matching/blossom.js';
 import { Graph } from '../matching/graph.js';
+import { IterablePool } from '../matching/iterable-pool.js';
 import { Vertex } from '../matching/vertex.js';
 import { MatchingComputer } from '../matching-computer.js';
 
@@ -115,7 +116,7 @@ describe('RootBlossom', () => {
   const makeGraph = () => ({
     aboveMaxEdgeWeight: aboveMax,
     parentBlossoms: [] as ParentBlossom[],
-    rootBlossoms: [] as RootBlossom[],
+    rootBlossomPool: new IterablePool<RootBlossom>(16),
     vertexDualVariables: [] as DynamicUint[],
   });
 
@@ -158,7 +159,7 @@ describe('RootBlossom', () => {
       const graph = makeGraph();
       const root = new RootBlossom(v, v, undefined, graph);
       v.rootBlossom = root;
-      graph.rootBlossoms.push(root);
+      root.poolIndex = graph.rootBlossomPool.construct(root);
 
       root.prepareVertexForWeightAdjustments(v, graph);
 
@@ -185,7 +186,8 @@ describe('RootBlossom', () => {
       root0.baseVertexMatch = v1;
       root1.baseVertexMatch = v0;
 
-      graph.rootBlossoms.push(root0, root1);
+      root0.poolIndex = graph.rootBlossomPool.construct(root0);
+      root1.poolIndex = graph.rootBlossomPool.construct(root1);
 
       root0.prepareVertexForWeightAdjustments(v0, graph);
 
@@ -200,7 +202,7 @@ describe('RootBlossom', () => {
       const graph = makeGraph();
       const root = new RootBlossom(v, v, undefined, graph);
       v.rootBlossom = root;
-      graph.rootBlossoms.push(root);
+      root.poolIndex = graph.rootBlossomPool.construct(root);
 
       root.prepareVertexForWeightAdjustments(v, graph);
 
@@ -236,7 +238,7 @@ describe('ParentBlossom', () => {
     const graph = {
       aboveMaxEdgeWeight: aboveMax,
       parentBlossoms: [] as ParentBlossom[],
-      rootBlossoms: [] as RootBlossom[],
+      rootBlossomPool: new IterablePool<RootBlossom>(16),
       vertexDualVariables: [] as DynamicUint[],
     };
     const root = new RootBlossom(v, v, undefined, graph);
@@ -251,7 +253,7 @@ describe('ParentBlossom', () => {
     const graph = {
       aboveMaxEdgeWeight: aboveMax,
       parentBlossoms: [] as ParentBlossom[],
-      rootBlossoms: [] as RootBlossom[],
+      rootBlossomPool: new IterablePool<RootBlossom>(16),
       vertexDualVariables: [] as DynamicUint[],
     };
     const root = new RootBlossom(v, v, undefined, graph);
@@ -267,7 +269,7 @@ describe('ParentBlossom', () => {
     const graph = {
       aboveMaxEdgeWeight: aboveMax,
       parentBlossoms: [] as ParentBlossom[],
-      rootBlossoms: [] as RootBlossom[],
+      rootBlossomPool: new IterablePool<RootBlossom>(16),
       vertexDualVariables: [] as DynamicUint[],
     };
     const root = new RootBlossom(v, v, undefined, graph);
@@ -300,7 +302,7 @@ describe('setPointersFromAncestor', () => {
     const graph = {
       aboveMaxEdgeWeight: aboveMax,
       parentBlossoms: [] as ParentBlossom[],
-      rootBlossoms: [] as RootBlossom[],
+      rootBlossomPool: new IterablePool<RootBlossom>(16),
       vertexDualVariables: [] as DynamicUint[],
     };
     const root = new RootBlossom(v, v, undefined, graph);
@@ -322,7 +324,7 @@ describe('setPointersFromAncestor', () => {
  * Build a Graph with `n` vertices and maximum edge weight `maxWeight`.
  */
 function makeTestGraph(n: number, maxWeight: number): Graph {
-  const graph = new Graph(DynamicUint.from(maxWeight));
+  const graph = new Graph(n, DynamicUint.from(maxWeight));
   for (let index = 0; index < n; index++) graph.addVertex();
   return graph;
 }
@@ -352,7 +354,7 @@ function setEdgeWeight(
  * Here we use the same approach — call it on each vertex before computeMatching.
  */
 function initializeDuals(graph: Graph): void {
-  for (const rb of graph.rootBlossoms) {
+  for (const rb of graph.rootBlossomPool) {
     rb.prepareVertexForWeightAdjustments(rb.baseVertex, graph);
   }
 }
@@ -365,7 +367,7 @@ function initializeDuals(graph: Graph): void {
 function getMatching(graph: Graph): number[] {
   const result = Array.from<number>({ length: graph.vertices.length }).fill(-1);
 
-  for (const rb of graph.rootBlossoms) {
+  for (const rb of graph.rootBlossomPool) {
     rb.putVerticesInMatchingOrder();
     const baseIndex = rb.baseVertex.vertexIndex;
     result[baseIndex] = rb.baseVertexMatch
@@ -388,14 +390,14 @@ function getMatching(graph: Graph): number[] {
 describe('Graph', () => {
   describe('addVertex', () => {
     it('creates a vertex with the correct index', () => {
-      const graph = makeTestGraph(0, 100);
+      const graph = new Graph(1, DynamicUint.from(100));
       graph.addVertex();
       expect(graph.vertices.length).toBe(1);
       expect(graph.vertices[0]!.vertexIndex).toBe(0);
     });
 
     it('expands edgeWeights for all vertices', () => {
-      const graph = makeTestGraph(0, 100);
+      const graph = new Graph(2, DynamicUint.from(100));
       graph.addVertex();
       graph.addVertex();
       // Each vertex should have 2 edge weight slots (one per vertex).
@@ -405,11 +407,11 @@ describe('Graph', () => {
 
     it('creates a RootBlossom for each vertex', () => {
       const graph = makeTestGraph(3, 100);
-      expect(graph.rootBlossoms.length).toBe(3);
+      expect([...graph.rootBlossomPool].length).toBe(3);
     });
 
     it('new vertex has a singleton RootBlossom', () => {
-      const graph = makeTestGraph(0, 100);
+      const graph = new Graph(1, DynamicUint.from(100));
       graph.addVertex();
       const v = graph.vertices[0]!;
       expect(v.rootBlossom).toBeDefined();
@@ -432,7 +434,7 @@ describe('Graph', () => {
     });
 
     it('aboveMaxEdgeWeight is strictly greater than 4x maxEdgeWeight', () => {
-      const graph = makeTestGraph(0, 10);
+      const graph = new Graph(0, DynamicUint.from(10));
       // aboveMaxEdgeWeight = 10 * 4 + 1 = 41
       expect(graph.aboveMaxEdgeWeight.toBigInt()).toBe(41n);
     });
@@ -456,7 +458,7 @@ describe('Graph', () => {
       const graph = makeTestGraph(1, 10);
       initializeDuals(graph);
       graph.computeMatching();
-      expect(graph.rootBlossoms[0]!.baseVertexMatch).toBeUndefined();
+      expect([...graph.rootBlossomPool][0]!.baseVertexMatch).toBeUndefined();
     });
 
     it('three vertices, one strong edge — matches the strongest pair', () => {
@@ -475,15 +477,15 @@ describe('Graph', () => {
 
   describe('constructor', () => {
     it('aboveMaxEdgeWeight is set correctly', () => {
-      const graph = new Graph(DynamicUint.from(100));
+      const graph = new Graph(0, DynamicUint.from(100));
       // aboveMaxEdgeWeight = 100 * 4 + 1 = 401
       expect(graph.aboveMaxEdgeWeight.toBigInt()).toBe(401n);
     });
 
     it('starts with empty vertices and blossoms', () => {
-      const graph = new Graph(DynamicUint.from(10));
+      const graph = new Graph(0, DynamicUint.from(10));
       expect(graph.vertices.length).toBe(0);
-      expect(graph.rootBlossoms.length).toBe(0);
+      expect([...graph.rootBlossomPool].length).toBe(0);
       expect(graph.parentBlossoms.length).toBe(0);
     });
   });
@@ -534,7 +536,7 @@ function computeViaMatchingComputer(
   edgeList: [number, number, number][],
 ): number[] {
   const maxW = Math.max(...edgeList.map(([u, v, w]) => Math.max(u, v, w)), 1);
-  const mc = new MatchingComputer(DynamicUint.from(maxW));
+  const mc = new MatchingComputer(vertexCount, DynamicUint.from(maxW));
   for (let index = 0; index < vertexCount; index++) mc.addVertex();
   for (const [u, v, w] of edgeList) {
     mc.setEdgeWeight(u, v, DynamicUint.from(w));
@@ -546,12 +548,12 @@ function computeViaMatchingComputer(
 describe('MatchingComputer', () => {
   describe('constructor and addVertex', () => {
     it('starts with zero vertices', () => {
-      const mc = new MatchingComputer(DynamicUint.from(100));
+      const mc = new MatchingComputer(0, DynamicUint.from(100));
       expect(mc.size).toBe(0);
     });
 
     it('addVertex increments size', () => {
-      const mc = new MatchingComputer(DynamicUint.from(100));
+      const mc = new MatchingComputer(2, DynamicUint.from(100));
       mc.addVertex();
       mc.addVertex();
       expect(mc.size).toBe(2);
@@ -644,7 +646,7 @@ describe('MatchingComputer', () => {
 
   describe('persistence test', () => {
     it('preserves matching after unrelated setEdgeWeight', () => {
-      const mc = new MatchingComputer(DynamicUint.from(100));
+      const mc = new MatchingComputer(4, DynamicUint.from(100));
       for (let index = 0; index < 4; index++) mc.addVertex();
       mc.setEdgeWeight(0, 1, DynamicUint.from(50));
       mc.setEdgeWeight(2, 3, DynamicUint.from(50));
@@ -661,7 +663,7 @@ describe('MatchingComputer', () => {
     it('sequential setEdgeWeight + computeMatching cycles — no infinite loop', () => {
       // 6 vertices, multiple compute cycles with changing edge weights.
       // This exercises the augmentMatching loop repeatedly to catch infinite loops.
-      const mc = new MatchingComputer(DynamicUint.from(100));
+      const mc = new MatchingComputer(6, DynamicUint.from(100));
       for (let index = 0; index < 6; index++) mc.addVertex();
 
       // Round 1: simple disjoint pairs.
@@ -742,7 +744,7 @@ describe('MatchingComputer', () => {
       // Expected: computeMatching → 0 matched to 1, 2 matched to 3
       // Bug: vertex 2 retains stale baseVertexMatch=0, labeled FREE, skipped
 
-      const mc = new MatchingComputer(DynamicUint.from(100));
+      const mc = new MatchingComputer(4, DynamicUint.from(100));
       mc.addVertex();
       mc.addVertex();
       mc.addVertex();
@@ -788,7 +790,7 @@ describe('MatchingComputer', () => {
       maxW.subtract(1);
 
       const n = 18;
-      const mc = new MatchingComputer(maxW);
+      const mc = new MatchingComputer(n, maxW);
       for (let index = 0; index < n; index++) mc.addVertex();
 
       // Initial edges.
@@ -808,13 +810,19 @@ describe('MatchingComputer', () => {
         for (let k = 0; k < 100; k++) {
           const index = ((round + 2) * 7 + k * 3) % n;
           const index_ = (index + 1 + k) % n;
-          mc.setEdgeWeight(index, index_, maxW.clone().shiftRight((k % 10) + 1));
+          mc.setEdgeWeight(
+            index,
+            index_,
+            maxW.clone().shiftRight((k % 10) + 1),
+          );
         }
         mc.computeMatching();
       }
 
       const matching = mc.getMatching();
-      const matched = matching.filter((m, index) => m !== index && m !== -1).length;
+      const matched = matching.filter(
+        (m, index) => m !== index && m !== -1,
+      ).length;
       expect(matched).toBeGreaterThan(0);
     });
   });

--- a/src/__tests__/trace.spec.ts
+++ b/src/__tests__/trace.spec.ts
@@ -156,9 +156,6 @@ describe('dutch trace', () => {
     expect(types.has('pairing:blossom-result')).toBe(true);
     expect(types.has('pairing:pair-finalized')).toBe(true);
     expect(types.has('pairing:color-allocated')).toBe(true);
-    // Blossom internal events should also be present
-    expect(types.has('blossom:stage-start')).toBe(true);
-    expect(types.has('blossom:complete')).toBe(true);
   });
 
   it('produces the same pairings with and without trace', () => {

--- a/src/__tests__/trace.spec.ts
+++ b/src/__tests__/trace.spec.ts
@@ -1,0 +1,231 @@
+/**
+ * Integration tests for the trace system across blossom and all pairing
+ * systems.
+ */
+import { parse } from '@echecs/trf';
+import { describe, expect, it } from 'vitest';
+
+import { maxWeightMatching } from '../blossom.js';
+import { pair as bursteinPair } from '../burstein.js';
+import { pair as doublePair } from '../double-swiss.js';
+import { pair as dubovPair } from '../dubov.js';
+import { pair } from '../dutch.js';
+import { DynamicUint } from '../dynamic-uint.js';
+import { pair as limPair } from '../lim.js';
+import { pair as teamPair } from '../swiss-team.js';
+import dutchC5 from './fixtures/dutch_2025_C5.trf?raw';
+
+import type { TraceEvent } from '../trace.js';
+import type { Game, Player } from '../types.js';
+import type { Tournament } from '@echecs/trf';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function edges(
+  ...raw: [number, number, number][]
+): [number, number, DynamicUint][] {
+  return raw.map(([u, v, w]) => [u, v, DynamicUint.from(w)]);
+}
+
+function toSwissPlayers(tournament: Tournament): Player[] {
+  return tournament.players.map((p) => ({
+    id: String(p.pairingNumber),
+    rating: p.rating,
+  }));
+}
+
+function toSwissGames(tournament: Tournament): Game[][] {
+  let maxRound = 0;
+  for (const player of tournament.players) {
+    for (const result of player.results) {
+      if (result.round > maxRound) {
+        maxRound = result.round;
+      }
+    }
+  }
+
+  const roundArrays: Game[][] = Array.from({ length: maxRound }, () => []);
+
+  for (const player of tournament.players) {
+    for (const result of player.results) {
+      if (result.color !== 'w' || result.opponentId === null) {
+        continue;
+      }
+      let score: 0 | 0.5 | 1;
+      switch (result.result) {
+        case '1':
+        case '+': {
+          score = 1;
+          break;
+        }
+        case '0':
+        case '-': {
+          score = 0;
+          break;
+        }
+        case '=': {
+          score = 0.5;
+          break;
+        }
+        default: {
+          continue;
+        }
+      }
+      const roundIndex = result.round - 1;
+      const roundGames = roundArrays[roundIndex];
+      if (roundGames !== undefined) {
+        roundGames.push({
+          black: String(result.opponentId),
+          result: score,
+          white: String(player.pairingNumber),
+        });
+      }
+    }
+  }
+
+  return roundArrays;
+}
+
+// ---------------------------------------------------------------------------
+// Blossom trace tests
+// ---------------------------------------------------------------------------
+
+describe('blossom trace', () => {
+  it('emits stage-start and complete events', () => {
+    const events: TraceEvent[] = [];
+    maxWeightMatching(edges([0, 1, 10], [1, 2, 11]), false, (event) =>
+      events.push(event),
+    );
+
+    const types = events.map((event) => event.type);
+    expect(types).toContain('blossom:stage-start');
+    expect(types).toContain('blossom:complete');
+
+    const complete = events.find((event) => event.type === 'blossom:complete');
+    expect(complete).toBeDefined();
+    expect(complete?.type).toBe('blossom:complete');
+    expect(
+      complete?.type === 'blossom:complete' ? complete.matchedCount : undefined,
+    ).toBe(1);
+    expect(
+      complete?.type === 'blossom:complete' ? complete.vertexCount : undefined,
+    ).toBe(3);
+  });
+
+  it('emits blossom:formed for an odd cycle', () => {
+    const events: TraceEvent[] = [];
+    // Triangle with extra vertex — forces blossom formation
+    maxWeightMatching(
+      edges([0, 1, 10], [1, 2, 10], [2, 0, 10], [0, 3, 1]),
+      true,
+      (event) => events.push(event),
+    );
+
+    expect(events.some((event) => event.type === 'blossom:formed')).toBe(true);
+  });
+
+  it('emits no events when no trace callback is provided', () => {
+    // Should not throw and should produce correct result
+    const result = maxWeightMatching(edges([0, 1, 10], [1, 2, 11]));
+    expect(result).toBeDefined();
+    expect(result[1]).toBe(2);
+    expect(result[2]).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Dutch trace tests
+// ---------------------------------------------------------------------------
+
+describe('dutch trace', () => {
+  it('emits expected event types for C5 fixture', () => {
+    const tournament = parse(dutchC5);
+    const players = toSwissPlayers(tournament);
+    const allGames = toSwissGames(tournament);
+    const priorGames = allGames.slice(0, 2);
+
+    const events: TraceEvent[] = [];
+    pair(players, priorGames, { trace: (event) => events.push(event) });
+
+    const types = new Set(events.map((event) => event.type));
+
+    expect(types.has('pairing:score-groups')).toBe(true);
+    expect(types.has('pairing:blossom-invoked')).toBe(true);
+    expect(types.has('pairing:blossom-result')).toBe(true);
+    expect(types.has('pairing:pair-finalized')).toBe(true);
+    expect(types.has('pairing:color-allocated')).toBe(true);
+    // Blossom internal events should also be present
+    expect(types.has('blossom:stage-start')).toBe(true);
+    expect(types.has('blossom:complete')).toBe(true);
+  });
+
+  it('produces the same pairings with and without trace', () => {
+    const tournament = parse(dutchC5);
+    const players = toSwissPlayers(tournament);
+    const allGames = toSwissGames(tournament);
+    const priorGames = allGames.slice(0, 2);
+
+    const withoutTrace = pair(players, priorGames);
+    const events: TraceEvent[] = [];
+    const withTrace = pair(players, priorGames, {
+      trace: (event) => events.push(event),
+    });
+
+    expect(withTrace).toEqual(withoutTrace);
+    expect(events.length).toBeGreaterThan(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Smoke tests for all pairing systems
+// ---------------------------------------------------------------------------
+
+describe('trace smoke tests', () => {
+  const players: Player[] = [
+    { id: '1', rating: 2000 },
+    { id: '2', rating: 1900 },
+    { id: '3', rating: 1800 },
+    { id: '4', rating: 1700 },
+  ];
+
+  it('dubov emits trace events', () => {
+    const events: TraceEvent[] = [];
+    dubovPair(players, [], { trace: (event) => events.push(event) });
+    expect(events.length).toBeGreaterThan(0);
+    expect(
+      events.some((event) => event.type === 'pairing:blossom-invoked'),
+    ).toBe(true);
+  });
+
+  it('burstein emits trace events', () => {
+    const events: TraceEvent[] = [];
+    bursteinPair(players, [], { trace: (event) => events.push(event) });
+    expect(events.length).toBeGreaterThan(0);
+    expect(
+      events.some((event) => event.type === 'pairing:blossom-invoked'),
+    ).toBe(true);
+  });
+
+  it('lim emits trace events', () => {
+    const events: TraceEvent[] = [];
+    limPair(players, [], { trace: (event) => events.push(event) });
+    expect(events.length).toBeGreaterThan(0);
+    expect(
+      events.some((event) => event.type === 'pairing:blossom-invoked'),
+    ).toBe(true);
+  });
+
+  it('double-swiss emits trace events', () => {
+    const events: TraceEvent[] = [];
+    doublePair(players, [], { trace: (event) => events.push(event) });
+    expect(events.length).toBeGreaterThan(0);
+  });
+
+  it('swiss-team emits trace events', () => {
+    const events: TraceEvent[] = [];
+    teamPair(players, [], { trace: (event) => events.push(event) });
+    expect(events.length).toBeGreaterThan(0);
+  });
+});

--- a/src/__tests__/trace.spec.ts
+++ b/src/__tests__/trace.spec.ts
@@ -141,7 +141,7 @@ describe('blossom trace', () => {
 
 describe('dutch trace', () => {
   it('emits expected event types for C5 fixture', () => {
-    const tournament = parse(dutchC5);
+    const tournament = parse(dutchC5)!;
     const players = toSwissPlayers(tournament);
     const allGames = toSwissGames(tournament);
     const priorGames = allGames.slice(0, 2);
@@ -162,7 +162,7 @@ describe('dutch trace', () => {
   });
 
   it('produces the same pairings with and without trace', () => {
-    const tournament = parse(dutchC5);
+    const tournament = parse(dutchC5)!;
     const players = toSwissPlayers(tournament);
     const allGames = toSwissGames(tournament);
     const priorGames = allGames.slice(0, 2);

--- a/src/__tests__/utilities.spec.ts
+++ b/src/__tests__/utilities.spec.ts
@@ -97,8 +97,26 @@ describe('buildPlayerStates', () => {
       expect(states[0]?.score).toBe(0);
     });
 
-    it('skips byes when computing score', () => {
-      const byeGames: Game[][] = [[{ black: '', result: 1, white: 'A' }]];
+    it('counts pairing-bye score (1 point)', () => {
+      const byeGames: Game[][] = [
+        [{ black: '', kind: 'pairing-bye', result: 1, white: 'A' }],
+      ];
+      const states = buildPlayerStates([{ id: 'A' }], byeGames);
+      expect(states[0]?.score).toBe(1);
+    });
+
+    it('counts half-bye score (0.5 points)', () => {
+      const byeGames: Game[][] = [
+        [{ black: '', kind: 'half-bye', result: 0.5, white: 'A' }],
+      ];
+      const states = buildPlayerStates([{ id: 'A' }], byeGames);
+      expect(states[0]?.score).toBe(0.5);
+    });
+
+    it('counts zero-bye score (0 points)', () => {
+      const byeGames: Game[][] = [
+        [{ black: '', kind: 'zero-bye', result: 0, white: 'A' }],
+      ];
       const states = buildPlayerStates([{ id: 'A' }], byeGames);
       expect(states[0]?.score).toBe(0);
     });

--- a/src/__tests__/utilities.spec.ts
+++ b/src/__tests__/utilities.spec.ts
@@ -153,6 +153,54 @@ describe('buildPlayerStates', () => {
       const a = states.find((s) => s.id === 'A');
       expect(a?.colorHistory).toEqual([undefined]);
     });
+
+    it('returns undefined for forfeit-win rounds', () => {
+      const forfeitGames: Game[][] = [
+        [
+          {
+            black: 'B',
+            kind: 'forfeit-win',
+            result: 1,
+            white: 'A',
+          },
+        ],
+      ];
+      const states = buildPlayerStates(
+        [
+          { id: 'A', rating: 2000 },
+          { id: 'B', rating: 1900 },
+        ],
+        forfeitGames,
+      );
+      const a = states.find((s) => s.id === 'A');
+      expect(a?.colorHistory).toEqual([undefined]);
+      const b = states.find((s) => s.id === 'B');
+      expect(b?.colorHistory).toEqual([undefined]);
+    });
+
+    it('returns undefined for forfeit-loss rounds', () => {
+      const forfeitGames: Game[][] = [
+        [
+          {
+            black: 'B',
+            kind: 'forfeit-loss',
+            result: 0,
+            white: 'A',
+          },
+        ],
+      ];
+      const states = buildPlayerStates(
+        [
+          { id: 'A', rating: 2000 },
+          { id: 'B', rating: 1900 },
+        ],
+        forfeitGames,
+      );
+      const a = states.find((s) => s.id === 'A');
+      expect(a?.colorHistory).toEqual([undefined]);
+      const b = states.find((s) => s.id === 'B');
+      expect(b?.colorHistory).toEqual([undefined]);
+    });
   });
 
   describe('colorDiff', () => {
@@ -231,6 +279,20 @@ describe('buildPlayerStates', () => {
       // colorDiff = 1-0 = 1, |colorDiff|===1 → strong
       expect(a?.preferenceStrength).toBe('strong');
     });
+
+    it('returns "none" when only game was a forfeit', () => {
+      const games: Game[][] = [
+        [{ black: 'B', kind: 'forfeit-win', result: 1, white: 'A' }],
+      ];
+      const states = buildPlayerStates(
+        [
+          { id: 'A', rating: 2000 },
+          { id: 'B', rating: 1900 },
+        ],
+        games,
+      );
+      expect(states.find((s) => s.id === 'A')?.preferenceStrength).toBe('none');
+    });
   });
 
   describe('preferredColor', () => {
@@ -256,6 +318,20 @@ describe('buildPlayerStates', () => {
       const states = buildPlayerStates(PLAYERS, GAMES);
       const a = states.find((s) => s.id === 'A');
       expect(a?.preferredColor).toBe('white');
+    });
+
+    it('returns undefined when only game was a forfeit', () => {
+      const games: Game[][] = [
+        [{ black: 'B', kind: 'forfeit-win', result: 1, white: 'A' }],
+      ];
+      const states = buildPlayerStates(
+        [
+          { id: 'A', rating: 2000 },
+          { id: 'B', rating: 1900 },
+        ],
+        games,
+      );
+      expect(states.find((s) => s.id === 'A')?.preferredColor).toBeUndefined();
     });
   });
 
@@ -367,6 +443,126 @@ describe('buildPlayerStates', () => {
       );
       const a = states.find((s) => s.id === 'A');
       expect(a?.floatHistory[0]).toBe('down');
+    });
+
+    it('returns "down" for forfeit-win rounds', () => {
+      // Player A (score 0) beats B (score 1) by forfeit.
+      // bbpPairings: gameWasPlayed=false, points > pointsForLoss → FLOAT_DOWN.
+      // Without the fix, score comparison would say A floated UP (0 < 1).
+      const r1Games: Game[][] = [
+        [
+          { black: 'B', result: 0, white: 'A' }, // A loses R1 → A=0, B=1
+        ],
+      ];
+      const r2Games: Game[][] = [
+        ...r1Games,
+        [
+          {
+            black: 'B',
+            kind: 'forfeit-win',
+            result: 1,
+            white: 'A',
+          },
+        ],
+      ];
+      const states = buildPlayerStates(
+        [
+          { id: 'A', rating: 2000 },
+          { id: 'B', rating: 1900 },
+        ],
+        r2Games,
+      );
+      const a = states.find((s) => s.id === 'A');
+      expect(a?.floatHistory[1]).toBe('down');
+    });
+
+    it('returns undefined for forfeit-loss rounds', () => {
+      // Player A (score 1) loses to B (score 0) by forfeit.
+      // bbpPairings: gameWasPlayed=false, points = pointsForLoss → FLOAT_NONE.
+      // Without the fix, score comparison would say A floated DOWN (1 > 0).
+      const r1Games: Game[][] = [
+        [
+          { black: 'B', result: 1, white: 'A' }, // A wins R1 → A=1, B=0
+        ],
+      ];
+      const r2Games: Game[][] = [
+        ...r1Games,
+        [
+          {
+            black: 'B',
+            kind: 'forfeit-loss',
+            result: 0,
+            white: 'A',
+          },
+        ],
+      ];
+      const states = buildPlayerStates(
+        [
+          { id: 'A', rating: 2000 },
+          { id: 'B', rating: 1900 },
+        ],
+        r2Games,
+      );
+      const a = states.find((s) => s.id === 'A');
+      expect(a?.floatHistory[1]).toBeUndefined();
+    });
+
+    it('returns undefined for the loser in a forfeit-win game (black side)', () => {
+      const r1Games: Game[][] = [
+        [
+          { black: 'B', result: 0, white: 'A' }, // A loses R1 → A=0, B=1
+        ],
+      ];
+      const r2Games: Game[][] = [
+        ...r1Games,
+        [
+          {
+            black: 'B',
+            kind: 'forfeit-win',
+            result: 1,
+            white: 'A',
+          },
+        ],
+      ];
+      const states = buildPlayerStates(
+        [
+          { id: 'A', rating: 2000 },
+          { id: 'B', rating: 1900 },
+        ],
+        r2Games,
+      );
+      const b = states.find((s) => s.id === 'B');
+      // B is the loser (black side of forfeit-win = white won)
+      expect(b?.floatHistory[1]).toBeUndefined();
+    });
+
+    it('returns "down" for the winner in a forfeit-loss game (black side)', () => {
+      const r1Games: Game[][] = [
+        [
+          { black: 'B', result: 1, white: 'A' }, // A wins R1 → A=1, B=0
+        ],
+      ];
+      const r2Games: Game[][] = [
+        ...r1Games,
+        [
+          {
+            black: 'B',
+            kind: 'forfeit-loss',
+            result: 0,
+            white: 'A',
+          },
+        ],
+      ];
+      const states = buildPlayerStates(
+        [
+          { id: 'A', rating: 2000 },
+          { id: 'B', rating: 1900 },
+        ],
+        r2Games,
+      );
+      const b = states.find((s) => s.id === 'B');
+      // B is the winner (black side of forfeit-loss = white lost)
+      expect(b?.floatHistory[1]).toBe('down');
     });
   });
 });

--- a/src/__tests__/utilities.spec.ts
+++ b/src/__tests__/utilities.spec.ts
@@ -134,6 +134,21 @@ describe('buildPlayerStates', () => {
       const states = buildPlayerStates([{ id: 'A' }], byeGames);
       expect(states[0]?.opponents.size).toBe(0);
     });
+
+    it('does not include forfeit opponent', () => {
+      const games: Game[][] = [
+        [{ black: 'B', kind: 'forfeit-win', result: 1, white: 'A' }],
+      ];
+      const states = buildPlayerStates(
+        [
+          { id: 'A', rating: 2000 },
+          { id: 'B', rating: 1900 },
+        ],
+        games,
+      );
+      expect(states.find((s) => s.id === 'A')?.opponents.size).toBe(0);
+      expect(states.find((s) => s.id === 'B')?.opponents.size).toBe(0);
+    });
   });
 
   describe('colorHistory', () => {

--- a/src/blossom.ts
+++ b/src/blossom.ts
@@ -80,9 +80,12 @@
 
 import { DynamicUint } from './dynamic-uint.js';
 
+import type { TraceCallback } from './trace.js';
+
 function maxWeightMatching(
   edges: [number, number, DynamicUint][],
   maxCardinality = false,
+  trace?: TraceCallback,
 ): number[] {
   if (edges.length === 0) return [];
 
@@ -416,6 +419,14 @@ function maxWeightMatching(
       )
         bestEdge[newBlossom] = candidateEdge;
     }
+    if (trace) {
+      trace({
+        base,
+        blossomIndex: newBlossom,
+        childCount: blossomChildren[newBlossom]!.length,
+        type: 'blossom:formed',
+      });
+    }
   }
 
   /**
@@ -436,6 +447,14 @@ function maxWeightMatching(
    *    flipping of endpoint indices.
    */
   function expandBlossom(blossom: number, endstage: boolean): void {
+    if (trace) {
+      trace({
+        blossomIndex: blossom,
+        childCount: blossomChildren[blossom]!.length,
+        endstage,
+        type: 'blossom:expanded',
+      });
+    }
     for (const child of blossomChildren[blossom]!) {
       blossomParent[child] = -1;
       if (child < vertexCount) vertexTopBlossom[child] = child;
@@ -607,6 +626,13 @@ function maxWeightMatching(
    * After this function, the matching size has increased by one.
    */
   function augmentMatching(edgeIndex: number): void {
+    if (trace) {
+      trace({
+        edgeIndex,
+        type: 'blossom:augmenting-path',
+        vertices: [endpoints[2 * edgeIndex]!, endpoints[2 * edgeIndex + 1]!],
+      });
+    }
     const [vertexU, vertexW] = edges[edgeIndex]!;
     for (const [startVertex, startEndpoint] of [
       [vertexU, 2 * edgeIndex + 1],
@@ -884,6 +910,16 @@ function maxWeightMatching(
       if (match[v] === -1 && labels[vertexTopBlossom[v]!] === 0)
         assignLabel(v, 1, -1);
     let augmented: boolean;
+    if (trace) {
+      let unmatched = 0;
+      for (let v = 0; v < vertexCount; v++) if (match[v] === -1) unmatched++;
+      trace({
+        stage,
+        type: 'blossom:stage-start',
+        unmatchedCount: unmatched,
+        vertexCount,
+      });
+    }
 
     // ── Inner loop: alternate between scanning and dual updates ──
     while (true) {
@@ -891,9 +927,19 @@ function maxWeightMatching(
       if (augmented) break;
 
       const { deltaType, delta, deltaEdge, deltaBlossom } = computeDelta();
+      if (trace && deltaType !== -1) {
+        trace({
+          deltaType,
+          deltaValue: delta.toString(),
+          type: 'blossom:delta',
+        });
+      }
       if (deltaType === -1) break;
 
       applyDualUpdate(delta);
+      if (trace) {
+        trace({ delta: delta.toString(), type: 'blossom:dual-update' });
+      }
       handleDelta(deltaType, deltaEdge, deltaBlossom);
       if (deltaType === 1) break;
     }
@@ -926,6 +972,15 @@ function maxWeightMatching(
   const result: number[] = Array.from({ length: vertexCount }, () => -1);
   for (let v = 0; v < vertexCount; v++)
     if (match[v] !== -1) result[v] = endpoints[match[v]!]!;
+  if (trace) {
+    let matchedCount = 0;
+    for (let v = 0; v < vertexCount; v++) if (result[v] !== -1) matchedCount++;
+    trace({
+      matchedCount: matchedCount / 2,
+      type: 'blossom:complete',
+      vertexCount,
+    });
+  }
   return result;
 }
 

--- a/src/burstein-entry.ts
+++ b/src/burstein-entry.ts
@@ -2,8 +2,11 @@ export { pair } from './burstein.js';
 export type {
   Bye,
   Game,
+  PairOptions,
   Pairing,
   PairingResult,
   Player,
   Result,
+  TraceCallback,
+  TraceEvent,
 } from './types.js';

--- a/src/burstein.ts
+++ b/src/burstein.ts
@@ -22,10 +22,16 @@
  */
 
 import { maxWeightMatching } from './blossom.js';
-import { allocateColor, assignBye, buildPlayerStates } from './utilities.js';
+import {
+  allocateColor,
+  assignBye,
+  buildPlayerStates,
+  scoreGroups,
+} from './utilities.js';
 import { buildEdgeWeight } from './weights.js';
 
 import type { DynamicUint } from './dynamic-uint.js';
+import type { PairOptions, TraceCallback } from './trace.js';
 import type { Game, PairingResult, Player } from './types.js';
 import type { ColorRule, PlayerState } from './utilities.js';
 import type { BracketContext, Criterion } from './weights.js';
@@ -348,9 +354,19 @@ function runBlossom(
   players: PlayerState[],
   edges: [number, number, DynamicUint][],
   maxcardinality = true,
+  trace?: TraceCallback,
 ): Map<string, string> {
   if (players.length === 0) return new Map();
-  const matching = maxWeightMatching(edges, maxcardinality);
+  if (trace) {
+    trace({
+      edgeCount: edges.length,
+      phase: 'main',
+      system: 'burstein',
+      type: 'pairing:blossom-invoked',
+      vertexCount: players.length,
+    });
+  }
+  const matching = maxWeightMatching(edges, maxcardinality, trace);
   const result = new Map<string, string>();
   for (const [index, index_] of matching.entries()) {
     if (index_ !== undefined && index_ !== -1 && index_ > index) {
@@ -361,6 +377,19 @@ function runBlossom(
       result.set(b.id, a.id);
     }
   }
+  if (trace) {
+    const pairs: [string, string][] = [];
+    for (const [a, b] of result) {
+      if (a < b) pairs.push([a, b]);
+    }
+    trace({
+      pairs,
+      phase: 'main',
+      system: 'burstein',
+      type: 'pairing:blossom-result',
+      unmatchedCount: players.length - pairs.length * 2,
+    });
+  }
   return result;
 }
 
@@ -368,10 +397,16 @@ function runBlossom(
 // Main pair function
 // ---------------------------------------------------------------------------
 
-function pair(players: Player[], games: Game[][]): PairingResult {
+function pair(
+  players: Player[],
+  games: Game[][],
+  options?: PairOptions,
+): PairingResult {
   if (players.length < 2) {
     throw new RangeError('at least 2 players are required');
   }
+
+  const trace = options?.trace;
 
   const totalRounds = games.length + 1;
 
@@ -435,6 +470,15 @@ function pair(players: Player[], games: Game[][]): PairingResult {
 
   const byeId = byeState?.id;
 
+  if (trace && byeId !== undefined) {
+    trace({
+      playerId: byeId,
+      reason: 'lowest-score-no-prior-bye',
+      system: 'burstein',
+      type: 'pairing:bye-assigned',
+    });
+  }
+
   // Remove bye recipient from the pairing pool
   const pairedPool =
     byeId === undefined ? sorted : sorted.filter((s) => s.id !== byeId);
@@ -462,8 +506,17 @@ function pair(players: Player[], games: Game[][]): PairingResult {
     },
   };
 
+  if (trace) {
+    const sgMap = scoreGroups(pairedPool);
+    const groups: { playerIds: string[]; score: number }[] = [];
+    for (const [score, members] of sgMap) {
+      groups.push({ playerIds: members.map((m) => m.id), score });
+    }
+    trace({ groups, system: 'burstein', type: 'pairing:score-groups' });
+  }
+
   const edges = buildEdges(pairedPool, globalContext);
-  const matching = runBlossom(pairedPool, edges, true);
+  const matching = runBlossom(pairedPool, edges, true, trace);
 
   const allPairedTuples: [PlayerState, PlayerState][] = [];
   const seen = new Set<string>();
@@ -478,6 +531,15 @@ function pair(players: Player[], games: Game[][]): PairingResult {
       const b = stateById.get(partnerId);
       if (a === undefined || b === undefined) continue;
       allPairedTuples.push(a.tpn < b.tpn ? [a, b] : [b, a]);
+      if (trace) {
+        trace({
+          phase: 'main',
+          playerA: a.id,
+          playerB: b.id,
+          system: 'burstein',
+          type: 'pairing:pair-finalized',
+        });
+      }
     }
   }
 
@@ -492,6 +554,18 @@ function pair(players: Player[], games: Game[][]): PairingResult {
   const pairings = allPairedTuples.map(([a, b]) =>
     allocateColor(a, b, BURSTEIN_COLOR_RULES, rankCompare),
   );
+
+  if (trace) {
+    for (const p of pairings) {
+      trace({
+        black: p.black,
+        rule: 'burstein-article-5.2',
+        system: 'burstein',
+        type: 'pairing:color-allocated',
+        white: p.white,
+      });
+    }
+  }
 
   return {
     byes: byeId === undefined ? [] : [{ player: byeId }],

--- a/src/double-entry.ts
+++ b/src/double-entry.ts
@@ -2,8 +2,11 @@ export { pair } from './double-swiss.js';
 export type {
   Bye,
   Game,
+  PairOptions,
   Pairing,
   PairingResult,
   Player,
   Result,
+  TraceCallback,
+  TraceEvent,
 } from './types.js';

--- a/src/double-swiss.ts
+++ b/src/double-swiss.ts
@@ -5,6 +5,7 @@ import {
 } from './lexicographic.js';
 import { buildPlayerStates, matchColorHistory } from './utilities.js';
 
+import type { PairOptions } from './trace.js';
 import type { Game, PairingResult, Player } from './types.js';
 import type { PlayerState } from './utilities.js';
 
@@ -97,20 +98,56 @@ function makeAllocateDoubleColors(
  * Each round is a two-game match between the same opponents.
  * PAB (bye) awards 1.5 points.
  */
-function pair(players: Player[], games: Game[][]): PairingResult {
+function pair(
+  players: Player[],
+  games: Game[][],
+  options?: PairOptions,
+): PairingResult {
   if (players.length < 2) {
     throw new RangeError('at least 2 players are required');
   }
+
+  const trace = options?.trace;
 
   const states = buildPlayerStates(players, games);
   const ranked = rankByScoreThenTPN(states);
   const byeState = assignLexicographicBye(ranked);
 
-  const toBePaired = ranked.filter((s) => s.id !== byeState?.id);
+  const byeId = byeState?.id;
+
+  if (trace && byeId !== undefined) {
+    trace({
+      playerId: byeId,
+      reason: 'lowest-score-no-prior-bye',
+      system: 'double-swiss',
+      type: 'pairing:bye-assigned',
+    });
+  }
+
+  const toBePaired = ranked.filter((s) => s.id !== byeId);
   const pairings = pairAllBrackets(toBePaired, makeAllocateDoubleColors(games));
 
+  if (trace) {
+    for (const p of pairings) {
+      trace({
+        phase: 'main',
+        playerA: p.white,
+        playerB: p.black,
+        system: 'double-swiss',
+        type: 'pairing:pair-finalized',
+      });
+      trace({
+        black: p.black,
+        rule: 'double-swiss-article-4.3',
+        system: 'double-swiss',
+        type: 'pairing:color-allocated',
+        white: p.white,
+      });
+    }
+  }
+
   return {
-    byes: byeState === undefined ? [] : [{ player: byeState.id }],
+    byes: byeId === undefined ? [] : [{ player: byeId }],
     pairings,
   };
 }

--- a/src/dubov-entry.ts
+++ b/src/dubov-entry.ts
@@ -2,8 +2,11 @@ export { pair } from './dubov.js';
 export type {
   Bye,
   Game,
+  PairOptions,
   Pairing,
   PairingResult,
   Player,
   Result,
+  TraceCallback,
+  TraceEvent,
 } from './types.js';

--- a/src/dubov.ts
+++ b/src/dubov.ts
@@ -18,10 +18,16 @@
  */
 
 import { maxWeightMatching } from './blossom.js';
-import { allocateColor, assignBye, buildPlayerStates } from './utilities.js';
+import {
+  allocateColor,
+  assignBye,
+  buildPlayerStates,
+  scoreGroups,
+} from './utilities.js';
 import { buildEdgeWeight } from './weights.js';
 
 import type { DynamicUint } from './dynamic-uint.js';
+import type { PairOptions, TraceCallback } from './trace.js';
 import type { Game, PairingResult, Player } from './types.js';
 import type { ColorRule, PlayerState } from './utilities.js';
 import type { BracketContext, Criterion } from './weights.js';
@@ -345,9 +351,19 @@ function runBlossom(
   players: PlayerState[],
   edges: [number, number, DynamicUint][],
   maxcardinality = true,
+  trace?: TraceCallback,
 ): Map<string, string> {
   if (players.length === 0) return new Map();
-  const matching = maxWeightMatching(edges, maxcardinality);
+  if (trace) {
+    trace({
+      edgeCount: edges.length,
+      phase: 'main',
+      system: 'dubov',
+      type: 'pairing:blossom-invoked',
+      vertexCount: players.length,
+    });
+  }
+  const matching = maxWeightMatching(edges, maxcardinality, trace);
   const result = new Map<string, string>();
   for (const [index, index_] of matching.entries()) {
     if (index_ !== undefined && index_ !== -1 && index_ > index) {
@@ -358,6 +374,19 @@ function runBlossom(
       result.set(b.id, a.id);
     }
   }
+  if (trace) {
+    const pairs: [string, string][] = [];
+    for (const [a, b] of result) {
+      if (a < b) pairs.push([a, b]);
+    }
+    trace({
+      pairs,
+      phase: 'main',
+      system: 'dubov',
+      type: 'pairing:blossom-result',
+      unmatchedCount: players.length - pairs.length * 2,
+    });
+  }
   return result;
 }
 
@@ -365,10 +394,16 @@ function runBlossom(
 // Main pair function
 // ---------------------------------------------------------------------------
 
-function pair(players: Player[], games: Game[][]): PairingResult {
+function pair(
+  players: Player[],
+  games: Game[][],
+  options?: PairOptions,
+): PairingResult {
   if (players.length < 2) {
     throw new RangeError('at least 2 players are required');
   }
+
+  const trace = options?.trace;
 
   const totalRounds = games.length + 1;
   const isLastRound = false; // We don't know total rounds ahead of time; conservative
@@ -411,6 +446,15 @@ function pair(players: Player[], games: Game[][]): PairingResult {
 
   const byeId = byeState?.id;
 
+  if (trace && byeId !== undefined) {
+    trace({
+      playerId: byeId,
+      reason: 'lowest-score-no-prior-bye',
+      system: 'dubov',
+      type: 'pairing:bye-assigned',
+    });
+  }
+
   // Remove bye recipient from the pairing pool
   const pairedPool =
     byeId === undefined ? sorted : sorted.filter((s) => s.id !== byeId);
@@ -452,8 +496,17 @@ function pair(players: Player[], games: Game[][]): PairingResult {
     upfloatCount,
   };
 
+  if (trace) {
+    const sgMap = scoreGroups(pairedPool);
+    const groups: { playerIds: string[]; score: number }[] = [];
+    for (const [score, members] of sgMap) {
+      groups.push({ playerIds: members.map((m) => m.id), score });
+    }
+    trace({ groups, system: 'dubov', type: 'pairing:score-groups' });
+  }
+
   const edges = buildEdges(pairedPool, globalContext);
-  const matching = runBlossom(pairedPool, edges, true);
+  const matching = runBlossom(pairedPool, edges, true, trace);
 
   const allPairedTuples: [PlayerState, PlayerState][] = [];
   const seen = new Set<string>();
@@ -468,6 +521,15 @@ function pair(players: Player[], games: Game[][]): PairingResult {
       const b = stateById.get(partnerId);
       if (a === undefined || b === undefined) continue;
       allPairedTuples.push(a.tpn < b.tpn ? [a, b] : [b, a]);
+      if (trace) {
+        trace({
+          phase: 'main',
+          playerA: a.id,
+          playerB: b.id,
+          system: 'dubov',
+          type: 'pairing:pair-finalized',
+        });
+      }
     }
   }
 
@@ -477,6 +539,18 @@ function pair(players: Player[], games: Game[][]): PairingResult {
   const pairings = allPairedTuples.map(([a, b]) =>
     allocateColor(a, b, DUBOV_COLOR_RULES, dubovRankCompare),
   );
+
+  if (trace) {
+    for (const p of pairings) {
+      trace({
+        black: p.black,
+        rule: 'dubov-article-5.2',
+        system: 'dubov',
+        type: 'pairing:color-allocated',
+        white: p.white,
+      });
+    }
+  }
 
   return {
     byes: byeId === undefined ? [] : [{ player: byeId }],

--- a/src/dutch-entry.ts
+++ b/src/dutch-entry.ts
@@ -2,8 +2,11 @@ export { pair } from './dutch.js';
 export type {
   Bye,
   Game,
+  PairOptions,
   Pairing,
   PairingResult,
   Player,
   Result,
+  TraceCallback,
+  TraceEvent,
 } from './types.js';

--- a/src/dutch.ts
+++ b/src/dutch.ts
@@ -807,9 +807,9 @@ function pair(
     if (++bracketIterCount > np * 10) break; // safety guard: prevents infinite loops
 
     // nextScoreGroupBegin: number of players in playersByIndex before adding next group
-    let nextScoreGroupBegin = playersByIndex.length;
+    const nextScoreGroupBegin = playersByIndex.length;
     // nextScoreGroupBeginVertex: global index in pairedSorted where next score group starts
-    let nextScoreGroupBeginVertex =
+    const nextScoreGroupBeginVertex =
       scoreGroupBeginVertex + (nextScoreGroupBegin - scoreGroupBegin);
 
     // Add next score group to playersByIndex
@@ -821,19 +821,14 @@ function pair(
       sgIterator++;
     }
 
-    // Edge case: if all players are still MDPs and no new group was added,
-    // reset scoreGroupBegin to 0 so they can be matched as a homogeneous group.
-    // This happens when downfloaters accumulate at the bottom.
+    // When all score groups are exhausted and no new group was added, the
+    // remaining players are downfloaters that could not be paired in any
+    // bracket. Break out and let the fallback code handle them.
     if (
       nextScoreGroupBegin === scoreGroupBegin &&
       playersByIndex.length === scoreGroupBegin
     ) {
-      // All remaining are MDPs, no current group, no new group.
-      // Treat all as the current group so they can pair with each other.
-      scoreGroupBegin = 0;
-      nextScoreGroupBegin = playersByIndex.length;
-      // nextScoreGroupBeginVertex: ensure it's > all player global indices
-      nextScoreGroupBeginVertex = np; // np = number of paired players = max global index + 1
+      break;
     }
 
     if (trace) {
@@ -1267,13 +1262,42 @@ function pair(
       }
     }
 
-    // firstGroupEnd: index in remainder where the "lower group" starts
-    // (players paired with smaller indices = upper group; firstGroupEnd = remainderPairs)
-    const firstGroupEnd = remainderPairs;
+    // -----------------------------------------------------------------------
+    // Remainder: apply edgeWeightComputer ordering bits
+    // -----------------------------------------------------------------------
 
-    // Count exchanges from the initial blossom (before ordering bits).
+    // Update edge weights with ordering preferences (exchange minimization).
+    for (let opIndex = 0; opIndex < remainder.length; opIndex++) {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      const opponentLocal = remainder[opIndex]!;
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      const opponentGlobal = playersByIndex[opponentLocal]!;
+      let playerRemainderIndex = 0;
+      for (let pIndex = 0; pIndex < opIndex; pIndex++) {
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        const playerLocal = remainder[pIndex]!;
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        const playerGlobal = playersByIndex[playerLocal]!;
+        const ew = edgeWeightComputer(
+          playerLocal,
+          opponentLocal,
+          playerRemainderIndex,
+          remainderPairs,
+        );
+        matrix.set(playerGlobal, opponentGlobal, ew);
+        playerRemainderIndex++;
+      }
+    }
+
+    currentPhase = 'bracket-ordering';
+    stableMatching = runBlossom();
+
+    // -----------------------------------------------------------------------
+    // Exchange selection (FIDE Article 4.3)
+    // -----------------------------------------------------------------------
+
     let exchangeCount = 0;
-    for (let pIndex = 0; pIndex < firstGroupEnd; pIndex++) {
+    for (let pIndex = 0; pIndex < remainderPairs; pIndex++) {
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       const playerLocal = remainder[pIndex]!;
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
@@ -1287,53 +1311,61 @@ function pair(
       }
     }
 
-    // Fast path (no exchanges): finalize directly from the initial blossom,
-    // skipping edgeWeightComputer and a second blossom call.
-    if (exchangeCount === 0) {
-      // Finalize all within-bracket upper-group pairs
-      for (const element of remainder) {
+    if (exchangeCount > 0) {
+      // --- S1 exchange: probe lower S1 players (bottom-up) ---
+      let exchangesRemaining = exchangeCount;
+      let playerRemainderIndex = remainderPairs;
+      for (
+        let pIndex = remainderPairs - 1;
+        pIndex >= 0 && exchangesRemaining > 0;
+        pIndex--
+      ) {
+        playerRemainderIndex--;
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        const playerLocal = element!;
+        const playerLocal = remainder[pIndex]!;
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         const playerGlobal = playersByIndex[playerLocal]!;
-        const matchG = stableMatching[playerGlobal] ?? -1;
-        if (
-          matchG > playerGlobal &&
-          matchG < nextScoreGroupBeginVertex &&
-          !matched[playerGlobal] &&
-          !matched[matchG]
-        ) {
-          matched[playerGlobal] = true;
-          matched[matchG] = true;
-          matchedPairs.push([playerGlobal, matchG]);
-          if (trace) {
-            trace({
-              phase: currentPhase,
-              playerA: pairedSorted[playerGlobal]?.id ?? '',
-              playerB: pairedSorted[matchG]?.id ?? '',
-              system: 'dutch',
-              type: 'pairing:pair-finalized',
-            });
-          }
-        }
-      }
-    } else {
-      // Exchanges needed: run edgeWeightComputer + second blossom to handle.
-      // Full exchange-selection loops (per bbpPairings) are not implemented;
-      // the ordering-weight blossom gives a valid (though possibly sub-optimal
-      // w.r.t. BSN exchange order) result.
 
-      for (let opIndex = 0; opIndex < remainder.length; opIndex++) {
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        const opponentLocal = remainder[opIndex]!;
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        const opponentGlobal = playersByIndex[opponentLocal]!;
-        let playerRemainderIndex = 0;
-        for (let pIndex = 0; pIndex < opIndex; pIndex++) {
+        const isMatchedWithin =
+          (stableMatching[playerGlobal] ?? -1) > playerGlobal &&
+          (stableMatching[playerGlobal] ?? -1) < nextScoreGroupBeginVertex;
+
+        if (isMatchedWithin) {
+          for (let oIndex = pIndex + 1; oIndex < remainder.length; oIndex++) {
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            const opponentLocal = remainder[oIndex]!;
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            const opponentGlobal = playersByIndex[opponentLocal]!;
+            const ew = edgeWeightComputer(
+              playerLocal,
+              opponentLocal,
+              playerRemainderIndex,
+              remainderPairs,
+            );
+            if (!ew.isZero()) {
+              ew.subtract(1);
+              matrix.set(playerGlobal, opponentGlobal, ew);
+            }
+          }
+          currentPhase = 'bracket-exchange-s1';
+          stableMatching = runBlossom();
+        }
+
+        const exchange =
+          (stableMatching[playerGlobal] ?? -1) <= playerGlobal ||
+          (stableMatching[playerGlobal] ?? -1) >= nextScoreGroupBeginVertex;
+        if (exchange) exchangesRemaining--;
+
+        for (let oIndex = pIndex + 1; oIndex < remainder.length; oIndex++) {
           // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-          const playerLocal = remainder[pIndex]!;
+          const opponentLocal = remainder[oIndex]!;
           // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-          const playerGlobal = playersByIndex[playerLocal]!;
+          const opponentGlobal = playersByIndex[opponentLocal]!;
+          if (exchange) {
+            (baseEdgeWeights[opponentLocal] as (DynamicUint | undefined)[])[
+              playerLocal
+            ] = DynamicUint.from(0);
+          }
           const ew = edgeWeightComputer(
             playerLocal,
             opponentLocal,
@@ -1341,38 +1373,211 @@ function pair(
             remainderPairs,
           );
           matrix.set(playerGlobal, opponentGlobal, ew);
-          playerRemainderIndex++;
         }
       }
 
-      currentPhase = 'bracket-ordering';
-      stableMatching = runBlossom();
-
-      // Finalize all within-bracket upper-group pairs from the ordering blossom
-      for (const element of remainder) {
+      // --- S2 exchange: probe higher S2 players (top-down) ---
+      exchangesRemaining = exchangeCount;
+      let remIndex = remainderPairs;
+      for (
+        let pIndex = remainderPairs;
+        pIndex < remainder.length && exchangesRemaining > 1;
+        pIndex++
+      ) {
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        const playerLocal = element!;
+        const playerLocal = remainder[pIndex]!;
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         const playerGlobal = playersByIndex[playerLocal]!;
-        const matchG = stableMatching[playerGlobal] ?? -1;
-        if (
-          matchG > playerGlobal &&
-          matchG < nextScoreGroupBeginVertex &&
-          !matched[playerGlobal] &&
-          !matched[matchG]
-        ) {
-          matched[playerGlobal] = true;
-          matched[matchG] = true;
-          matchedPairs.push([playerGlobal, matchG]);
-          if (trace) {
-            trace({
-              phase: currentPhase,
-              playerA: pairedSorted[playerGlobal]?.id ?? '',
-              playerB: pairedSorted[matchG]?.id ?? '',
-              system: 'dutch',
-              type: 'pairing:pair-finalized',
-            });
+
+        const alreadyExchanged =
+          (stableMatching[playerGlobal] ?? -1) > playerGlobal &&
+          (stableMatching[playerGlobal] ?? -1) < nextScoreGroupBeginVertex;
+
+        if (!alreadyExchanged) {
+          for (let oIndex = pIndex + 1; oIndex < remainder.length; oIndex++) {
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            const opponentLocal = remainder[oIndex]!;
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            const opponentGlobal = playersByIndex[opponentLocal]!;
+            const ew = edgeWeightComputer(
+              playerLocal,
+              opponentLocal,
+              remIndex,
+              remainderPairs,
+            );
+            if (!ew.isZero()) {
+              ew.add(1);
+              matrix.set(playerGlobal, opponentGlobal, ew);
+            }
           }
+          currentPhase = 'bracket-exchange-s2';
+          stableMatching = runBlossom();
+        }
+
+        const exchange =
+          (stableMatching[playerGlobal] ?? -1) > playerGlobal &&
+          (stableMatching[playerGlobal] ?? -1) < nextScoreGroupBeginVertex;
+
+        if (exchange) {
+          exchangesRemaining--;
+          for (let oIndex = 0; oIndex < pIndex; oIndex++) {
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            const opponentLocal = remainder[oIndex]!;
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            const opponentGlobal = playersByIndex[opponentLocal]!;
+            (baseEdgeWeights[playerLocal] as (DynamicUint | undefined)[])[
+              opponentLocal
+            ] = DynamicUint.from(0);
+            matrix.set(playerGlobal, opponentGlobal, DynamicUint.from(0));
+          }
+          for (
+            let opIndex = nextScoreGroupBegin;
+            opIndex < playersByIndex.length;
+            opIndex++
+          ) {
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            const opponentGlobal = playersByIndex[opIndex]!;
+            (baseEdgeWeights[opIndex] as (DynamicUint | undefined)[])[
+              playerLocal
+            ] = DynamicUint.from(0);
+            matrix.set(playerGlobal, opponentGlobal, DynamicUint.from(0));
+          }
+        }
+
+        if (!alreadyExchanged) {
+          for (let oIndex = pIndex + 1; oIndex < remainder.length; oIndex++) {
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            const opponentLocal = remainder[oIndex]!;
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            const opponentGlobal = playersByIndex[opponentLocal]!;
+            const ew = edgeWeightComputer(
+              playerLocal,
+              opponentLocal,
+              remIndex,
+              remainderPairs,
+            );
+            matrix.set(playerGlobal, opponentGlobal, ew);
+          }
+        }
+        remIndex++;
+      }
+    }
+
+    // -----------------------------------------------------------------------
+    // Remainder Phase A: finalize exchange decisions + reset ordering bits
+    //
+    // For each pair in the remainder, if the S1 player is NOT matched within
+    // the bracket (exchanged to downfloater) or the S2 player IS matched
+    // within the bracket (exchanged to S1), zero the base edge weight.
+    // Then restore the matrix to the (possibly zeroed) base weights.
+    // (Mirrors bbpPairings lines 1509-1543.)
+    // -----------------------------------------------------------------------
+    for (let pIndex = 0; pIndex < remainder.length; pIndex++) {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      const playerLocal = remainder[pIndex]!;
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      const playerGlobal = playersByIndex[playerLocal]!;
+
+      for (let oIndex = pIndex + 1; oIndex < remainder.length; oIndex++) {
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        const opponentLocal = remainder[oIndex]!;
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        const opponentGlobal = playersByIndex[opponentLocal]!;
+
+        const playerNotMatched =
+          stableMatching[playerGlobal] === undefined ||
+          (stableMatching[playerGlobal] ?? -1) <= playerGlobal ||
+          (stableMatching[playerGlobal] ?? -1) >= nextScoreGroupBeginVertex;
+        const opponentMatched =
+          (stableMatching[opponentGlobal] ?? -1) > opponentGlobal &&
+          (stableMatching[opponentGlobal] ?? -1) < nextScoreGroupBeginVertex;
+
+        if (playerNotMatched || opponentMatched) {
+          (baseEdgeWeights[opponentLocal] as (DynamicUint | undefined)[])[
+            playerLocal
+          ] = DynamicUint.from(0);
+        }
+
+        const base = (
+          baseEdgeWeights[opponentLocal] as (DynamicUint | undefined)[]
+        )[playerLocal];
+        matrix.set(
+          playerGlobal,
+          opponentGlobal,
+          base === undefined ? DynamicUint.from(0) : base.clone(),
+        );
+      }
+    }
+
+    // -----------------------------------------------------------------------
+    // Remainder Phase B: per-player finalization with blossom re-runs
+    //
+    // For each S1 player that is matched within the bracket, boost edges
+    // to S2 opponents (higher-ranked get larger addend), run blossom, and
+    // finalizePair. (Mirrors bbpPairings lines 1545-1599.)
+    // -----------------------------------------------------------------------
+    currentPhase = 'bracket-remainder';
+
+    for (const playerLocal of remainder) {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      const playerGlobal = playersByIndex[playerLocal]!;
+
+      if (
+        (stableMatching[playerGlobal] ?? -1) <= playerGlobal ||
+        (stableMatching[playerGlobal] ?? -1) >= nextScoreGroupBeginVertex
+      ) {
+        continue;
+      }
+
+      let addend = 0;
+      for (let oIndex = remainder.length - 1; oIndex >= 0; oIndex--) {
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        const opponentLocal = remainder[oIndex]!;
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        const opponentGlobal = playersByIndex[opponentLocal]!;
+
+        if (opponentLocal <= playerLocal || matched[opponentGlobal]) {
+          continue;
+        }
+
+        const base = (
+          baseEdgeWeights[opponentLocal] as (DynamicUint | undefined)[]
+        )[playerLocal];
+        if (base !== undefined && !base.isZero()) {
+          const boosted = base.clone();
+          boosted.add(addend);
+          matrix.set(playerGlobal, opponentGlobal, boosted);
+        }
+        addend++;
+      }
+
+      stableMatching = runBlossom();
+
+      const matchGlobal = stableMatching[playerGlobal] ?? -1;
+      if (
+        matchGlobal >= 0 &&
+        matchGlobal !== playerGlobal &&
+        !matched[playerGlobal] &&
+        !matched[matchGlobal]
+      ) {
+        matched[playerGlobal] = true;
+        matched[matchGlobal] = true;
+        finalizePair(
+          playerGlobal,
+          matchGlobal,
+          matrix,
+          maxEdgeWeight,
+          playersByIndex,
+        );
+        matchedPairs.push([playerGlobal, matchGlobal]);
+        if (trace) {
+          trace({
+            phase: currentPhase,
+            playerA: pairedSorted[playerGlobal]?.id ?? '',
+            playerB: pairedSorted[matchGlobal]?.id ?? '',
+            system: 'dutch',
+            type: 'pairing:pair-finalized',
+          });
         }
       }
     }

--- a/src/dutch.ts
+++ b/src/dutch.ts
@@ -297,15 +297,19 @@ function computeEdgeWeight(
     orBitAt(w, scoreGroupShifts.get(hi.score) ?? 0, false);
   }
 
-  // C9
+  // C9: key is playedGames (= playedRounds - unplayedRounds), matching C++
   w.shiftGrow(scoreGroupSizeBits);
   w.shiftGrow(scoreGroupSizeBits);
   if (isSingleDownfloaterByeAssignee) {
     if (hi.score === byeAssigneeScore) {
-      w.or(unplayedGameRanks.get(hi.unplayedRounds) ?? 0);
+      w.or(
+        unplayedGameRanks.get(playedRounds - hi.unplayedRounds) ?? 0,
+      );
     }
     if (lo.score === byeAssigneeScore) {
-      w.add(unplayedGameRanks.get(lo.unplayedRounds) ?? 0);
+      w.add(
+        unplayedGameRanks.get(playedRounds - lo.unplayedRounds) ?? 0,
+      );
     }
   }
 
@@ -626,18 +630,17 @@ function pair(
       }
     }
 
-    const byePlayers = sorted
+    // C++ sorts playedGameCounts descending and assigns rank++ to every
+    // entry (including duplicates). Duplicate keys overwrite, so the LAST
+    // occurrence's rank sticks. This means each key maps to the index of
+    // its last occurrence in the sorted array.
+    const playedGameCounts = sorted
       .filter((s) => s.score === byeAssigneeScore)
-      .toSorted((a, b) => a.unplayedRounds - b.unplayedRounds);
+      .map((s) => playedRounds - s.unplayedRounds)
+      .toSorted((a, b) => b - a); // descending
     let rank = 0;
-    const seenUnplayed = new Map<number, number>();
-    for (const p of byePlayers) {
-      if (!seenUnplayed.has(p.unplayedRounds)) {
-        seenUnplayed.set(p.unplayedRounds, rank++);
-      }
-    }
-    for (const [k, v] of seenUnplayed) {
-      unplayedGameRanks.set(k, v);
+    for (const pg of playedGameCounts) {
+      unplayedGameRanks.set(pg, rank++);
     }
   }
 

--- a/src/dutch.ts
+++ b/src/dutch.ts
@@ -811,39 +811,9 @@ function pair(
     // (both local < scoreGroupBegin) retain stale high weights from prior
     // brackets. Reset them with fresh weights (lowerInCurrent=false,
     // lowerInNext=false) to prevent MDPs from incorrectly pairing together.
-    for (
-      let largerLocalIndex = 1;
-      largerLocalIndex < scoreGroupBegin;
-      largerLocalIndex++
-    ) {
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      const largerGlobal = playersByIndex[largerLocalIndex]!;
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      const loPlayer = pairedSorted[largerGlobal]!;
-      for (
-        let smallerLocalIndex = 0;
-        smallerLocalIndex < largerLocalIndex;
-        smallerLocalIndex++
-      ) {
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        const smallerGlobal = playersByIndex[smallerLocalIndex]!;
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        const hiPlayer = pairedSorted[smallerGlobal]!;
-        const w = computeEdgeWeight(
-          hiPlayer,
-          loPlayer,
-          false, // lowerInCurrent: neither MDP is in the current bracket
-          false, // lowerInNext: neither is in the next score group
-          byeAssigneeScore,
-          playedRounds,
-          expectedRounds,
-          sgp,
-          isSingleDownfloaterByeAssignee,
-          unplayedGameRanks,
-        );
-        mc.setEdgeWeight(largerGlobal, smallerGlobal, w);
-      }
-    }
+    // C++ computeBaseEdgeWeights does NOT reset MDP-MDP edges. They retain
+    // whatever weight was set by the previous bracket iteration or the initial
+    // pass. This is intentional — the stale weights influence MDP selection.
 
     for (
       let largerLocalIndex = scoreGroupBegin;

--- a/src/dutch.ts
+++ b/src/dutch.ts
@@ -27,6 +27,7 @@ import {
   scoreGroups,
 } from './utilities.js';
 
+import type { PairOptions } from './trace.js';
 import type { Game, PairingResult, Player } from './types.js';
 import type { ColorRule, PlayerState } from './utilities.js';
 
@@ -594,11 +595,16 @@ function finalizePair(
 // Main pair function
 // ---------------------------------------------------------------------------
 
-function pair(players: Player[], games: Game[][]): PairingResult {
+function pair(
+  players: Player[],
+  games: Game[][],
+  options?: PairOptions,
+): PairingResult {
   if (players.length < 2) {
     throw new RangeError('at least 2 players are required');
   }
 
+  const trace = options?.trace;
   const playedRounds = games.length;
   const expectedRounds = playedRounds + 1;
   const states = buildPlayerStates(players, games);
@@ -639,7 +645,37 @@ function pair(players: Player[], games: Game[][]): PairingResult {
       }
     }
 
-    const m0 = maxWeightMatching(feasEdges, true);
+    if (trace) {
+      trace({
+        edgeCount: feasEdges.length,
+        phase: 'feasibility',
+        system: 'dutch',
+        type: 'pairing:blossom-invoked',
+        vertexCount: n,
+      });
+    }
+    const m0 = maxWeightMatching(feasEdges, true, trace);
+    if (trace) {
+      const pairs: [string, string][] = [];
+      let unmatchedCount = 0;
+      for (const [k, element] of m0.entries()) {
+        const mk = element ?? -1;
+        if (mk > k) {
+          const aState = sorted[k];
+          const bState = sorted[mk];
+          if (aState && bState) pairs.push([aState.id, bState.id]);
+        } else if (mk === -1 || mk === k) {
+          unmatchedCount++;
+        }
+      }
+      trace({
+        pairs,
+        phase: 'feasibility',
+        system: 'dutch',
+        type: 'pairing:blossom-result',
+        unmatchedCount,
+      });
+    }
 
     for (let index = 0; index < n; index++) {
       const mi = m0[index] ?? -1;
@@ -685,6 +721,14 @@ function pair(players: Player[], games: Game[][]): PairingResult {
     byeState = assignBye(sorted, games, dutchByeTiebreak);
   }
   const byeId = byeState?.id;
+  if (trace && byeId !== undefined) {
+    trace({
+      playerId: byeId,
+      reason: 'lowest-score-no-prior-bye',
+      system: 'dutch',
+      type: 'pairing:bye-assigned',
+    });
+  }
   const pairedSorted =
     byeId === undefined ? sorted : sorted.filter((s) => s.id !== byeId);
   const np = pairedSorted.length;
@@ -700,6 +744,13 @@ function pair(players: Player[], games: Game[][]): PairingResult {
   // Phase 3: Score group membership
   // -------------------------------------------------------------------------
   const sgMap = scoreGroups(pairedSorted);
+  if (trace) {
+    const groups: { playerIds: string[]; score: number }[] = [];
+    for (const [score, members] of sgMap) {
+      groups.push({ playerIds: members.map((m) => m.id), score });
+    }
+    trace({ groups, system: 'dutch', type: 'pairing:score-groups' });
+  }
   const scoreLevels = [...sgMap.keys()].toSorted((a, b) => b - a); // desc
 
   // Score groups as arrays of indices into pairedSorted, ordered by score desc
@@ -750,6 +801,7 @@ function pair(players: Player[], games: Game[][]): PairingResult {
   // scoreGroupBeginVertex tracks the global vertex index of start of current bracket's score group
   let scoreGroupBeginVertex = 0; // starts at 0 (first group begins at 0 in pairedSorted)
 
+  let currentPhase = 'bracket';
   let bracketIterCount = 0;
   while (playersByIndex.length > 1 || sgIterator < scoreGroupArrays.length) {
     if (++bracketIterCount > np * 10) break; // safety guard: prevents infinite loops
@@ -782,6 +834,21 @@ function pair(players: Player[], games: Game[][]): PairingResult {
       nextScoreGroupBegin = playersByIndex.length;
       // nextScoreGroupBeginVertex: ensure it's > all player global indices
       nextScoreGroupBeginVertex = np; // np = number of paired players = max global index + 1
+    }
+
+    if (trace) {
+      const bracketScore =
+        pairedSorted[playersByIndex[scoreGroupBegin] ?? 0]?.score ?? 0;
+      const mdpIds = playersByIndex
+        .slice(0, scoreGroupBegin)
+        .map((gi) => pairedSorted[gi]?.id ?? '');
+      const playerIds = playersByIndex.map((gi) => pairedSorted[gi]?.id ?? '');
+      trace({
+        bracketScore,
+        mdpIds,
+        playerIds,
+        type: 'dutch:bracket-enter',
+      });
     }
 
     // Compute baseEdgeWeights for all pairs involving the current/next bracket.
@@ -898,7 +965,16 @@ function pair(players: Player[], games: Game[][]): PairingResult {
     const runBlossom = (): number[] => {
       const edges = buildCurrentEdges();
       if (edges.length === 0) return Array.from({ length: np }, () => -1);
-      const result = maxWeightMatching(edges, true);
+      if (trace) {
+        trace({
+          edgeCount: edges.length,
+          phase: currentPhase,
+          system: 'dutch',
+          type: 'pairing:blossom-invoked',
+          vertexCount: playersByIndex.length,
+        });
+      }
+      const result = maxWeightMatching(edges, true, trace);
       // Expand to full np size
       const full = Array.from({ length: np }, () => -1);
       for (const [k, element] of result.entries()) {
@@ -906,6 +982,27 @@ function pair(players: Player[], games: Game[][]): PairingResult {
           // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
           full[k] = element!;
         }
+      }
+      if (trace) {
+        const pairs: [string, string][] = [];
+        let unmatchedCount = 0;
+        for (const [k, element] of full.entries()) {
+          const mk = element ?? -1;
+          if (mk > k) {
+            const aState = pairedSorted[k];
+            const bState = pairedSorted[mk];
+            if (aState && bState) pairs.push([aState.id, bState.id]);
+          } else if (mk === -1 || mk === k) {
+            unmatchedCount++;
+          }
+        }
+        trace({
+          pairs,
+          phase: currentPhase,
+          system: 'dutch',
+          type: 'pairing:blossom-result',
+          unmatchedCount,
+        });
       }
       return full;
     };
@@ -957,6 +1054,7 @@ function pair(players: Player[], games: Game[][]): PairingResult {
     };
 
     // Run initial blossom
+    currentPhase = 'bracket-initial';
     let stableMatching = runBlossom();
 
     // -----------------------------------------------------------------------
@@ -1039,6 +1137,7 @@ function pair(players: Player[], games: Game[][]): PairingResult {
             }
           }
 
+          currentPhase = 'bracket-mdp';
           stableMatching = runBlossom();
         }
 
@@ -1107,6 +1206,7 @@ function pair(players: Player[], games: Game[][]): PairingResult {
         }
       }
 
+      currentPhase = 'bracket-mdp-finalize';
       stableMatching = runBlossom();
 
       // Finalize the pairing
@@ -1121,6 +1221,15 @@ function pair(players: Player[], games: Game[][]): PairingResult {
           playersByIndex,
         );
         matchedPairs.push([playerGlobal, matchGlobal]);
+        if (trace) {
+          trace({
+            phase: currentPhase,
+            playerA: pairedSorted[playerGlobal]?.id ?? '',
+            playerB: pairedSorted[matchGlobal]?.id ?? '',
+            system: 'dutch',
+            type: 'pairing:pair-finalized',
+          });
+        }
       }
     }
 
@@ -1129,6 +1238,7 @@ function pair(players: Player[], games: Game[][]): PairingResult {
     // -----------------------------------------------------------------------
 
     // Re-run blossom after MDP finalizations
+    currentPhase = 'bracket-remainder';
     stableMatching = runBlossom();
 
     // remainder: local indices of players in scoreGroupBegin..nextScoreGroupBegin
@@ -1196,6 +1306,15 @@ function pair(players: Player[], games: Game[][]): PairingResult {
           matched[playerGlobal] = true;
           matched[matchG] = true;
           matchedPairs.push([playerGlobal, matchG]);
+          if (trace) {
+            trace({
+              phase: currentPhase,
+              playerA: pairedSorted[playerGlobal]?.id ?? '',
+              playerB: pairedSorted[matchG]?.id ?? '',
+              system: 'dutch',
+              type: 'pairing:pair-finalized',
+            });
+          }
         }
       }
     } else {
@@ -1226,6 +1345,7 @@ function pair(players: Player[], games: Game[][]): PairingResult {
         }
       }
 
+      currentPhase = 'bracket-ordering';
       stableMatching = runBlossom();
 
       // Finalize all within-bracket upper-group pairs from the ordering blossom
@@ -1244,6 +1364,15 @@ function pair(players: Player[], games: Game[][]): PairingResult {
           matched[playerGlobal] = true;
           matched[matchG] = true;
           matchedPairs.push([playerGlobal, matchG]);
+          if (trace) {
+            trace({
+              phase: currentPhase,
+              playerA: pairedSorted[playerGlobal]?.id ?? '',
+              playerB: pairedSorted[matchG]?.id ?? '',
+              system: 'dutch',
+              type: 'pairing:pair-finalized',
+            });
+          }
         }
       }
     }
@@ -1347,7 +1476,44 @@ function pair(players: Player[], games: Game[][]): PairingResult {
       }
     }
     if (fallbackEdges.length > 0) {
-      const fallbackMatch = maxWeightMatching(fallbackEdges, true);
+      if (trace) {
+        trace({
+          phase: 'bracket-fallback',
+          remainingCount: playersByIndex.length,
+          type: 'dutch:fallback',
+        });
+      }
+      if (trace) {
+        trace({
+          edgeCount: fallbackEdges.length,
+          phase: 'bracket-fallback',
+          system: 'dutch',
+          type: 'pairing:blossom-invoked',
+          vertexCount: playersByIndex.length,
+        });
+      }
+      const fallbackMatch = maxWeightMatching(fallbackEdges, true, trace);
+      if (trace) {
+        const pairs: [string, string][] = [];
+        let unmatchedCount = 0;
+        for (const [k, element] of fallbackMatch.entries()) {
+          const mk = element ?? -1;
+          if (mk > k) {
+            const aState = pairedSorted[k];
+            const bState = pairedSorted[mk];
+            if (aState && bState) pairs.push([aState.id, bState.id]);
+          } else if (mk === -1 || mk === k) {
+            unmatchedCount++;
+          }
+        }
+        trace({
+          pairs,
+          phase: 'bracket-fallback',
+          system: 'dutch',
+          type: 'pairing:blossom-result',
+          unmatchedCount,
+        });
+      }
       const seen = new Set<number>();
       for (const [k, element] of fallbackMatch.entries()) {
         const mk = element ?? -1;
@@ -1402,7 +1568,44 @@ function pair(players: Player[], games: Game[][]): PairingResult {
       }
     }
 
-    const globalMatch = maxWeightMatching(globalEdges, true);
+    if (trace) {
+      trace({
+        phase: 'global-fallback',
+        remainingCount: np,
+        type: 'dutch:fallback',
+      });
+    }
+    if (trace) {
+      trace({
+        edgeCount: globalEdges.length,
+        phase: 'global-fallback',
+        system: 'dutch',
+        type: 'pairing:blossom-invoked',
+        vertexCount: np,
+      });
+    }
+    const globalMatch = maxWeightMatching(globalEdges, true, trace);
+    if (trace) {
+      const pairs: [string, string][] = [];
+      let unmatchedCount = 0;
+      for (const [k, element] of globalMatch.entries()) {
+        const mk = element ?? -1;
+        if (mk > k) {
+          const aState = pairedSorted[k];
+          const bState = pairedSorted[mk];
+          if (aState && bState) pairs.push([aState.id, bState.id]);
+        } else if (mk === -1 || mk === k) {
+          unmatchedCount++;
+        }
+      }
+      trace({
+        pairs,
+        phase: 'global-fallback',
+        system: 'dutch',
+        type: 'pairing:blossom-result',
+        unmatchedCount,
+      });
+    }
     const seenGlobal = new Set<number>();
     for (let k = 0; k < np; k++) {
       if (seenGlobal.has(k)) continue;
@@ -1429,6 +1632,18 @@ function pair(players: Player[], games: Game[][]): PairingResult {
   const pairings = result.map(([a, b]) =>
     allocateColor(a, b, DUTCH_COLOR_RULES, dutchRankCompare),
   );
+
+  if (trace) {
+    for (const p of pairings) {
+      trace({
+        black: p.black,
+        rule: 'dutch-article-5.2',
+        system: 'dutch',
+        type: 'pairing:color-allocated',
+        white: p.white,
+      });
+    }
+  }
 
   return {
     byes: byeId === undefined ? [] : [{ player: byeId }],

--- a/src/dutch.ts
+++ b/src/dutch.ts
@@ -302,14 +302,10 @@ function computeEdgeWeight(
   w.shiftGrow(scoreGroupSizeBits);
   if (isSingleDownfloaterByeAssignee) {
     if (hi.score === byeAssigneeScore) {
-      w.or(
-        unplayedGameRanks.get(playedRounds - hi.unplayedRounds) ?? 0,
-      );
+      w.or(unplayedGameRanks.get(playedRounds - hi.unplayedRounds) ?? 0);
     }
     if (lo.score === byeAssigneeScore) {
-      w.add(
-        unplayedGameRanks.get(playedRounds - lo.unplayedRounds) ?? 0,
-      );
+      w.add(unplayedGameRanks.get(playedRounds - lo.unplayedRounds) ?? 0);
     }
   }
 
@@ -680,7 +676,7 @@ function pair(
   const maxEdgeWeight = computeMaxEdgeWeight(sgp);
 
   // Persistent matching computer, populated per-bracket with correct weights.
-  const mc = new MatchingComputer(maxEdgeWeight);
+  const mc = new MatchingComputer(np, maxEdgeWeight);
   for (let index = 0; index < np; index++) mc.addVertex();
 
   // Initialize all edge weights (C++ dutch.cpp lines 835-894).

--- a/src/dutch.ts
+++ b/src/dutch.ts
@@ -333,7 +333,7 @@ function computeEdgeWeight(
       (loCI === hiCI
         ? repeatedColor(lo) === undefined ||
           repeatedColor(lo) !== repeatedColor(hi)
-        : (loCI > hiCI ? hi : lo).preferredColor !==
+        : repeatedColor(loCI > hiCI ? hi : lo) !==
           invertColor(lo.preferredColor));
     if (ok) w.or(1);
   }
@@ -418,7 +418,10 @@ function computeEdgeWeight(
 // computeMaxEdgeWeight — upper bound on any edge weight (max=true variant)
 // ---------------------------------------------------------------------------
 
-function computeMaxEdgeWeight(sgp: ScoreGroupParameters): DynamicUint {
+function computeMaxEdgeWeight(
+  sgp: ScoreGroupParameters,
+  playedRounds: number,
+): DynamicUint {
   const { scoreGroupSizeBits, scoreGroupsShift } = sgp;
   const w = DynamicUint.from(0);
 
@@ -442,17 +445,25 @@ function computeMaxEdgeWeight(sgp: ScoreGroupParameters): DynamicUint {
   w.shiftGrow(scoreGroupSizeBits);
   w.shiftGrow(scoreGroupSizeBits);
 
-  // C14–C17 (up to 4 slots)
-  w.shiftGrow(scoreGroupSizeBits);
-  w.shiftGrow(scoreGroupSizeBits);
-  w.shiftGrow(scoreGroupSizeBits);
-  w.shiftGrow(scoreGroupSizeBits);
+  // C14–C17 (conditional on playedRounds, matching C++ template)
+  if (playedRounds >= 1) {
+    w.shiftGrow(scoreGroupSizeBits); // C14
+    w.shiftGrow(scoreGroupSizeBits); // C15
+  }
+  if (playedRounds > 1) {
+    w.shiftGrow(scoreGroupSizeBits); // C16
+    w.shiftGrow(scoreGroupSizeBits); // C17
+  }
 
-  // C18–C21 (up to 4 slots)
-  w.shiftGrow(scoreGroupsShift);
-  w.shiftGrow(scoreGroupsShift);
-  w.shiftGrow(scoreGroupsShift);
-  w.shiftGrow(scoreGroupsShift);
+  // C18–C21 (conditional on playedRounds, matching C++ template)
+  if (playedRounds >= 1) {
+    w.shiftGrow(scoreGroupsShift); // C18
+    w.shiftGrow(scoreGroupsShift); // C19
+  }
+  if (playedRounds > 1) {
+    w.shiftGrow(scoreGroupsShift); // C20
+    w.shiftGrow(scoreGroupsShift); // C21
+  }
 
   // Ordering slots (3 × scoreGroupSizeBits)
   w.shiftGrow(scoreGroupSizeBits);
@@ -494,7 +505,7 @@ function buildFeasibilityWeight(
       (scoreGroupShifts.get(lo.score) ?? 0),
   );
   w.shiftGrow(scoreGroupSizeBits);
-  if (hi.score >= topScore) w.or(1);
+  if (lo.score >= topScore) w.or(1);
   return w;
 }
 
@@ -673,50 +684,36 @@ function pair(
   // -------------------------------------------------------------------------
   // Phase 4: Initialize MatchingComputer + maxEdgeWeight
   // -------------------------------------------------------------------------
-  const maxEdgeWeight = computeMaxEdgeWeight(sgp);
+  const maxEdgeWeight = computeMaxEdgeWeight(sgp, playedRounds);
 
   // Persistent matching computer, populated per-bracket with correct weights.
   const mc = new MatchingComputer(np, maxEdgeWeight);
   for (let index = 0; index < np; index++) mc.addVertex();
 
-  // Initialize all edge weights (C++ dutch.cpp lines 835-894).
-  // For even player counts, use computeEdgeWeight with lowerInCurrent=false,
-  // lowerInNext=false. These base weights persist in the MatchingComputer
-  // and influence matchings in brackets where players haven't been explicitly
-  // paired yet.
+  // Initialize all edge weights (C++ dutch.cpp lines 894-925).
+  // C++ always uses computeEdgeWeight (not feasibility weight) for the initial
+  // matchingComputer state. For odd counts, the feasibility pass already ran
+  // above to determine byeAssigneeScore; now re-initialize with full weights.
+  // For even counts, byeAssigneeScore=0 and isSingleDownfloaterByeAssignee=false.
   for (let playerIndex = 0; playerIndex < np; playerIndex++) {
     for (let opponentIndex = 0; opponentIndex < playerIndex; opponentIndex++) {
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       const player = pairedSorted[playerIndex]!;
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       const opponent = pairedSorted[opponentIndex]!;
-      if (needsBye) {
-        // Odd player count: use feasibility weights (C++ lines 848-873)
-        const w = buildFeasibilityWeight(
-          opponent,
-          player,
-          pairedSorted[0]?.score ?? 0,
-          playedRounds,
-          expectedRounds,
-          sgp,
-        );
-        mc.setEdgeWeight(playerIndex, opponentIndex, w);
-      } else {
-        // Even player count: use computeEdgeWeight with no bracket context
-        const w = computeEdgeWeight(
-          opponent,
-          player,
-          false,
-          false,
-          0,
-          playedRounds,
-          expectedRounds,
-          sgp,
-          false,
-          unplayedGameRanks,
-        );
-        mc.setEdgeWeight(playerIndex, opponentIndex, w);
-      }
+      const w = computeEdgeWeight(
+        opponent,
+        player,
+        false,
+        false,
+        byeAssigneeScore,
+        playedRounds,
+        expectedRounds,
+        sgp,
+        isSingleDownfloaterByeAssignee,
+        unplayedGameRanks,
+      );
+      mc.setEdgeWeight(playerIndex, opponentIndex, w);
     }
   }
 
@@ -1484,56 +1481,46 @@ function pair(
     const newPlayersByIndex: number[] = [];
     let newScoreGroupBegin = 0;
 
-    // Update isSingleDownfloaterByeAssignee for next bracket
-    // (bbpPairings does this check)
-    if (
+    // Update isSingleDownfloaterByeAssignee for next bracket.
+    // C++ uses scoreGroupIterator (the first player in the current bracket's
+    // score group = the group added at the start of this iteration).
+    // scoreGroupArrays[sgIterator - 1] is that group (sgIterator was incremented
+    // after adding the group).
+    const currentGroupScore =
+      sgIterator > 0
+        ? (pairedSorted[scoreGroupArrays[sgIterator - 1]?.[0] ?? 0]?.score ??
+          -1)
+        : -1;
+
+    // Preliminary (may be set to false in the carry-forward loop)
+    isSingleDownfloaterByeAssignee =
       needsBye &&
-      sgIterator <= scoreGroupArrays.length &&
-      byeAssigneeScore >=
-        (pairedSorted[scoreGroupArrays[sgIterator - 1]?.[0] ?? 0]?.score ?? -1)
-    ) {
-      // Preliminary: might be true
-      let stillSingle = true;
-      for (
-        let playerLocal = 0;
-        playerLocal < nextScoreGroupBegin;
-        playerLocal++
-      ) {
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        const playerGlobal = playersByIndex[playerLocal]!;
-        if (playerLocal < nextScoreGroupBegin && matched[playerGlobal]) {
-          const matchG = stableMatching[playerGlobal] ?? -1;
-          const nextGroupScore =
-            sgIterator < scoreGroupArrays.length
-              ? (pairedSorted[scoreGroupArrays[sgIterator]?.[0] ?? 0]?.score ??
-                -1)
-              : -1;
-          if (
-            matchG >= 0 &&
-            (pairedSorted[matchG]?.score ?? -1) < nextGroupScore
-          ) {
-            stillSingle = false;
-            break;
-          }
-        }
-      }
-      isSingleDownfloaterByeAssignee = stillSingle;
-    } else {
-      isSingleDownfloaterByeAssignee = false;
-    }
+      currentGroupScore >= 0 &&
+      byeAssigneeScore >= currentGroupScore;
 
     for (const [playerLocal, element] of playersByIndex.entries()) {
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       const playerGlobal = element!;
       if (playerLocal < nextScoreGroupBegin && matched[playerGlobal]) {
-        // Player was finalized — record if needed (already done in finalizePair)
-        // noop here — matchedPairs already recorded
+        // Player was finalized — noop (matchedPairs already recorded)
         void 0;
       } else {
         // Carry to next bracket
         newPlayersByIndex.push(playerGlobal);
         if (playerLocal < nextScoreGroupBegin) {
           newScoreGroupBegin++;
+        }
+        // C++ checks: if carried-forward player's match partner has score
+        // below the current bracket group score, clear the flag.
+        if (isSingleDownfloaterByeAssignee) {
+          const matchG = stableMatching[playerGlobal] ?? -1;
+          if (
+            matchG >= 0 &&
+            matchG !== playerGlobal &&
+            (pairedSorted[matchG]?.score ?? -1) < currentGroupScore
+          ) {
+            isSingleDownfloaterByeAssignee = false;
+          }
         }
       }
     }

--- a/src/dutch.ts
+++ b/src/dutch.ts
@@ -707,6 +707,47 @@ function pair(
   const mc = new MatchingComputer(maxEdgeWeight);
   for (let index = 0; index < np; index++) mc.addVertex();
 
+  // Initialize all edge weights (C++ dutch.cpp lines 835-894).
+  // For even player counts, use computeEdgeWeight with lowerInCurrent=false,
+  // lowerInNext=false. These base weights persist in the MatchingComputer
+  // and influence matchings in brackets where players haven't been explicitly
+  // paired yet.
+  for (let playerIndex = 0; playerIndex < np; playerIndex++) {
+    for (let opponentIndex = 0; opponentIndex < playerIndex; opponentIndex++) {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      const player = pairedSorted[playerIndex]!;
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      const opponent = pairedSorted[opponentIndex]!;
+      if (needsBye) {
+        // Odd player count: use feasibility weights (C++ lines 848-873)
+        const w = buildFeasibilityWeight(
+          opponent,
+          player,
+          pairedSorted[0]?.score ?? 0,
+          playedRounds,
+          expectedRounds,
+          sgp,
+        );
+        mc.setEdgeWeight(playerIndex, opponentIndex, w);
+      } else {
+        // Even player count: use computeEdgeWeight with no bracket context
+        const w = computeEdgeWeight(
+          opponent,
+          player,
+          false,
+          false,
+          0,
+          playedRounds,
+          expectedRounds,
+          sgp,
+          false,
+          unplayedGameRanks,
+        );
+        mc.setEdgeWeight(playerIndex, opponentIndex, w);
+      }
+    }
+  }
+
   // -------------------------------------------------------------------------
   // Phase 5: Bracket-by-bracket processing
   // -------------------------------------------------------------------------

--- a/src/dutch.ts
+++ b/src/dutch.ts
@@ -21,12 +21,7 @@
 import { maxWeightMatching } from './blossom.js';
 import { DynamicUint } from './dynamic-uint.js';
 import { MatchingComputer } from './matching-computer.js';
-import {
-  allocateColor,
-  assignBye,
-  buildPlayerStates,
-  scoreGroups,
-} from './utilities.js';
+import { allocateColor, buildPlayerStates, scoreGroups } from './utilities.js';
 
 import type { PairOptions } from './trace.js';
 import type { Game, PairingResult, Player } from './types.js';
@@ -100,12 +95,6 @@ const DUTCH_COLOR_RULES: ColorRule[] = [
 
 function dutchRankCompare(a: PlayerState, b: PlayerState): number {
   return a.tpn - b.tpn;
-}
-
-function dutchByeTiebreak(a: PlayerState, b: PlayerState): number {
-  if (a.unplayedRounds !== b.unplayedRounds)
-    return a.unplayedRounds - b.unplayedRounds;
-  return b.tpn - a.tpn;
 }
 
 // ---------------------------------------------------------------------------
@@ -652,31 +641,15 @@ function pair(
     }
   }
 
-  // -------------------------------------------------------------------------
-  // Phase 2: Bye assignee
-  // -------------------------------------------------------------------------
-  let byeState: PlayerState | undefined;
-  if (needsBye) {
-    byeState = assignBye(sorted, games, dutchByeTiebreak);
-  }
-  const byeId = byeState?.id;
-  if (trace && byeId !== undefined) {
-    trace({
-      playerId: byeId,
-      reason: 'lowest-score-no-prior-bye',
-      system: 'dutch',
-      type: 'pairing:bye-assigned',
-    });
-  }
-  const pairedSorted =
-    byeId === undefined ? sorted : sorted.filter((s) => s.id !== byeId);
+  // C++ does NOT pre-assign the bye. Instead, all players (including the bye
+  // candidate) stay in the MatchingComputer. The `isByeCandidate` bits in
+  // edge weights bias the blossom toward leaving the correct player unmatched.
+  // The unmatched player after the bracket loop becomes the bye recipient.
+  const pairedSorted = sorted;
   const np = pairedSorted.length;
 
   if (np < 2) {
-    return {
-      byes: byeId === undefined ? [] : [{ player: byeId }],
-      pairings: [],
-    };
+    return { byes: [], pairings: [] };
   }
 
   // -------------------------------------------------------------------------
@@ -1778,8 +1751,33 @@ function pair(
   }
 
   // -------------------------------------------------------------------------
-  // Phase 7: Extract pairings from matchedPairs
+  // Phase 7: Extract pairings + bye from matchedPairs
   // -------------------------------------------------------------------------
+  const pairedGlobals = new Set<number>();
+  for (const [globalA, globalB] of matchedPairs) {
+    pairedGlobals.add(globalA);
+    pairedGlobals.add(globalB);
+  }
+
+  // The bye recipient is the unmatched player (odd count only)
+  let byeId: string | undefined;
+  if (needsBye) {
+    for (let index = 0; index < np; index++) {
+      if (!pairedGlobals.has(index)) {
+        byeId = pairedSorted[index]?.id;
+        break;
+      }
+    }
+    if (trace && byeId !== undefined) {
+      trace({
+        playerId: byeId,
+        reason: 'blossom-unmatched',
+        system: 'dutch',
+        type: 'pairing:bye-assigned',
+      });
+    }
+  }
+
   const result: [PlayerState, PlayerState][] = [];
   for (const [globalA, globalB] of matchedPairs) {
     const a = pairedSorted[globalA];

--- a/src/dutch.ts
+++ b/src/dutch.ts
@@ -545,7 +545,7 @@ function pair(
 
   const trace = options?.trace;
   const playedRounds = games.length;
-  const expectedRounds = playedRounds + 1;
+  const expectedRounds = options?.expectedRounds ?? playedRounds + 1;
   const states = buildPlayerStates(players, games);
 
   // Sort: score DESC, TPN ASC

--- a/src/dutch.ts
+++ b/src/dutch.ts
@@ -20,6 +20,7 @@
 
 import { maxWeightMatching } from './blossom.js';
 import { DynamicUint } from './dynamic-uint.js';
+import { MatchingComputer } from './matching-computer.js';
 import {
   allocateColor,
   assignBye,
@@ -509,86 +510,24 @@ function buildFeasibilityWeight(
 }
 
 // ---------------------------------------------------------------------------
-// Edge weight matrix — persistent across bracket iterations
+// finalizePairMC — set edge (v1,v2) to 1, zero all other edges for v1 and v2
 // ---------------------------------------------------------------------------
 
-/**
- * Maintains a 2D weight matrix (indexed by global sorted-player index).
- * weights[i][j] where i > j holds the weight for edge (i, j).
- * Can be mutated in place to simulate bbpPairings' matching_computer.
- */
-class EdgeWeightMatrix {
-  private readonly matrix: (DynamicUint | undefined)[][];
-  readonly size: number;
-
-  constructor(size: number) {
-    this.size = size;
-    this.matrix = Array.from({ length: size }, () => {
-      const row: (DynamicUint | undefined)[] = Array.from({ length: size });
-      return row;
-    });
-  }
-
-  /**
-   * Build an edge list for maxWeightMatching from the subset of vertices
-   * that are currently active (those in vertexIndices).
-   */
-  buildEdges(vertexIndices: number[]): [number, number, DynamicUint][] {
-    const edges: [number, number, DynamicUint][] = [];
-    for (let ii = 0; ii < vertexIndices.length; ii++) {
-      const vi = vertexIndices[ii];
-      if (vi === undefined) continue;
-      for (let jj = 0; jj < ii; jj++) {
-        const vj = vertexIndices[jj];
-        if (vj === undefined) continue;
-        const w = this.get(vi, vj);
-        if (!w.isZero()) {
-          edges.push([vi, vj, w]);
-        }
-      }
-    }
-    return edges;
-  }
-
-  get(index: number, index_: number): DynamicUint {
-    const hi = Math.max(index, index_);
-    const lo = Math.min(index, index_);
-    return (
-      (this.matrix[hi] as (DynamicUint | undefined)[])[lo] ??
-      DynamicUint.from(0)
-    );
-  }
-
-  set(index: number, index_: number, w: DynamicUint): void {
-    const hi = Math.max(index, index_);
-    const lo = Math.min(index, index_);
-    if (this.matrix[hi] !== undefined) {
-      (this.matrix[hi] as (DynamicUint | undefined)[])[lo] = w;
-    }
-  }
-}
-
-// ---------------------------------------------------------------------------
-// finalizePair — set edge (v1,v2) to maxEdgeWeight, zero all others
-// ---------------------------------------------------------------------------
-
-function finalizePair(
+function finalizePairMC(
   v1: number,
   v2: number,
-  matrix: EdgeWeightMatrix,
-  maxEdgeWeight: DynamicUint,
-  allVertices: number[],
+  mc: MatchingComputer,
+  np: number,
 ): void {
-  // Set the pair edge to max
-  matrix.set(v1, v2, maxEdgeWeight.clone());
-
-  // Zero all other edges involving v1 or v2
-  for (const v of allVertices) {
-    if (v !== v1 && v !== v2) {
-      matrix.set(v1, v, DynamicUint.from(0));
-      matrix.set(v2, v, DynamicUint.from(0));
+  const one = DynamicUint.from(1);
+  const zero = DynamicUint.from(0);
+  for (let index = 0; index < np; index++) {
+    if (index !== v1 && index !== v2) {
+      mc.setEdgeWeight(v1, index, zero.clone());
+      mc.setEdgeWeight(v2, index, zero.clone());
     }
   }
+  mc.setEdgeWeight(v1, v2, one);
 }
 
 // ---------------------------------------------------------------------------
@@ -760,12 +699,13 @@ function pair(
   });
 
   // -------------------------------------------------------------------------
-  // Phase 4: Initialize edge weight matrix + maxEdgeWeight
+  // Phase 4: Initialize MatchingComputer + maxEdgeWeight
   // -------------------------------------------------------------------------
   const maxEdgeWeight = computeMaxEdgeWeight(sgp);
 
-  // Persistent edge weight matrix, populated per-bracket with correct weights.
-  const matrix = new EdgeWeightMatrix(np);
+  // Persistent matching computer, populated per-bracket with correct weights.
+  const mc = new MatchingComputer(maxEdgeWeight);
+  for (let index = 0; index < np; index++) mc.addVertex();
 
   // -------------------------------------------------------------------------
   // Phase 5: Bracket-by-bracket processing
@@ -887,7 +827,7 @@ function pair(
           isSingleDownfloaterByeAssignee,
           unplayedGameRanks,
         );
-        matrix.set(largerGlobal, smallerGlobal, w);
+        mc.setEdgeWeight(largerGlobal, smallerGlobal, w);
       }
     }
 
@@ -933,55 +873,40 @@ function pair(
           smallerLocalIndex
         ] = w;
 
-        // Update the persistent matrix
-        matrix.set(largerGlobal, smallerGlobal, w);
+        // Update the persistent matching computer
+        mc.setEdgeWeight(largerGlobal, smallerGlobal, w);
       }
     }
 
-    // Build edges for blossom from playersByIndex
-    const buildCurrentEdges = (): [number, number, DynamicUint][] => {
-      const edges: [number, number, DynamicUint][] = [];
-      for (let ii = 0; ii < playersByIndex.length; ii++) {
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        const index = playersByIndex[ii]!;
-        for (let jj = 0; jj < ii; jj++) {
-          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-          const index_ = playersByIndex[jj]!;
-          const w = matrix.get(index, index_);
-          if (!w.isZero()) {
-            edges.push([index, index_, w]);
+    // Helper: run matching computer on current playersByIndex
+    const runBlossom = (): number[] => {
+      if (trace) {
+        // Count non-zero edges for trace
+        let edgeCount = 0;
+        for (let ii = 0; ii < playersByIndex.length; ii++) {
+          for (let jj = 0; jj < ii; jj++) {
+            edgeCount++;
           }
         }
-      }
-      return edges;
-    };
-
-    // Helper: run blossom on current playersByIndex
-    const runBlossom = (): number[] => {
-      const edges = buildCurrentEdges();
-      if (edges.length === 0) return Array.from({ length: np }, () => -1);
-      if (trace) {
         trace({
-          edgeCount: edges.length,
+          edgeCount,
           phase: currentPhase,
           system: 'dutch',
           type: 'pairing:blossom-invoked',
           vertexCount: playersByIndex.length,
         });
       }
-      const result = maxWeightMatching(edges, true, trace);
-      // Expand to full np size
-      const full = Array.from({ length: np }, () => -1);
-      for (const [k, element] of result.entries()) {
-        if (element !== undefined && element !== -1) {
-          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-          full[k] = element!;
-        }
+      mc.computeMatching();
+      const rawMatching = mc.getMatching();
+      // Normalize: self-match → -1
+      const stableM = [...rawMatching];
+      for (let index = 0; index < stableM.length; index++) {
+        if (stableM[index] === index) stableM[index] = -1;
       }
       if (trace) {
         const pairs: [string, string][] = [];
         let unmatchedCount = 0;
-        for (const [k, element] of full.entries()) {
+        for (const [k, element] of stableM.entries()) {
           const mk = element ?? -1;
           if (mk > k) {
             const aState = pairedSorted[k];
@@ -999,7 +924,7 @@ function pair(
           unmatchedCount,
         });
       }
-      return full;
+      return stableM;
     };
 
     // edgeWeightComputer — mimics bbpPairings' lambda
@@ -1128,7 +1053,7 @@ function pair(
             if (base !== undefined && !base.isZero()) {
               const boosted = base.clone();
               boosted.or(1); // set finalization bit
-              matrix.set(playerGlobal, opponentGlobal, boosted);
+              mc.setEdgeWeight(playerGlobal, opponentGlobal, boosted);
             }
           }
 
@@ -1161,7 +1086,7 @@ function pair(
               const boosted = base.clone();
               boosted.or(nextScoreGroupBegin - scoreGroupBegin);
               boosted.add(1);
-              matrix.set(playerGlobal, opponentGlobal, boosted);
+              mc.setEdgeWeight(playerGlobal, opponentGlobal, boosted);
             }
           }
         }
@@ -1196,7 +1121,7 @@ function pair(
         if (base !== undefined && !base.isZero()) {
           const boosted = base.clone();
           boosted.add(addend);
-          matrix.set(playerGlobal, opponentGlobal, boosted);
+          mc.setEdgeWeight(playerGlobal, opponentGlobal, boosted);
           addend++;
         }
       }
@@ -1208,13 +1133,7 @@ function pair(
       const matchGlobal = stableMatching[playerGlobal] ?? -1;
       if (matchGlobal >= 0 && matchGlobal !== playerGlobal) {
         matched[matchGlobal] = true;
-        finalizePair(
-          playerGlobal,
-          matchGlobal,
-          matrix,
-          maxEdgeWeight,
-          playersByIndex,
-        );
+        finalizePairMC(playerGlobal, matchGlobal, mc, np);
         matchedPairs.push([playerGlobal, matchGlobal]);
         if (trace) {
           trace({
@@ -1284,7 +1203,7 @@ function pair(
           playerRemainderIndex,
           remainderPairs,
         );
-        matrix.set(playerGlobal, opponentGlobal, ew);
+        mc.setEdgeWeight(playerGlobal, opponentGlobal, ew);
         playerRemainderIndex++;
       }
     }
@@ -1344,7 +1263,7 @@ function pair(
             );
             if (!ew.isZero()) {
               ew.subtract(1);
-              matrix.set(playerGlobal, opponentGlobal, ew);
+              mc.setEdgeWeight(playerGlobal, opponentGlobal, ew);
             }
           }
           currentPhase = 'bracket-exchange-s1';
@@ -1372,7 +1291,7 @@ function pair(
             playerRemainderIndex,
             remainderPairs,
           );
-          matrix.set(playerGlobal, opponentGlobal, ew);
+          mc.setEdgeWeight(playerGlobal, opponentGlobal, ew);
         }
       }
 
@@ -1407,7 +1326,7 @@ function pair(
             );
             if (!ew.isZero()) {
               ew.add(1);
-              matrix.set(playerGlobal, opponentGlobal, ew);
+              mc.setEdgeWeight(playerGlobal, opponentGlobal, ew);
             }
           }
           currentPhase = 'bracket-exchange-s2';
@@ -1428,7 +1347,7 @@ function pair(
             (baseEdgeWeights[playerLocal] as (DynamicUint | undefined)[])[
               opponentLocal
             ] = DynamicUint.from(0);
-            matrix.set(playerGlobal, opponentGlobal, DynamicUint.from(0));
+            mc.setEdgeWeight(playerGlobal, opponentGlobal, DynamicUint.from(0));
           }
           for (
             let opIndex = nextScoreGroupBegin;
@@ -1440,7 +1359,7 @@ function pair(
             (baseEdgeWeights[opIndex] as (DynamicUint | undefined)[])[
               playerLocal
             ] = DynamicUint.from(0);
-            matrix.set(playerGlobal, opponentGlobal, DynamicUint.from(0));
+            mc.setEdgeWeight(playerGlobal, opponentGlobal, DynamicUint.from(0));
           }
         }
 
@@ -1456,7 +1375,7 @@ function pair(
               remIndex,
               remainderPairs,
             );
-            matrix.set(playerGlobal, opponentGlobal, ew);
+            mc.setEdgeWeight(playerGlobal, opponentGlobal, ew);
           }
         }
         remIndex++;
@@ -1501,7 +1420,7 @@ function pair(
         const base = (
           baseEdgeWeights[opponentLocal] as (DynamicUint | undefined)[]
         )[playerLocal];
-        matrix.set(
+        mc.setEdgeWeight(
           playerGlobal,
           opponentGlobal,
           base === undefined ? DynamicUint.from(0) : base.clone(),
@@ -1546,7 +1465,7 @@ function pair(
         if (base !== undefined && !base.isZero()) {
           const boosted = base.clone();
           boosted.add(addend);
-          matrix.set(playerGlobal, opponentGlobal, boosted);
+          mc.setEdgeWeight(playerGlobal, opponentGlobal, boosted);
         }
         addend++;
       }
@@ -1562,13 +1481,7 @@ function pair(
       ) {
         matched[playerGlobal] = true;
         matched[matchGlobal] = true;
-        finalizePair(
-          playerGlobal,
-          matchGlobal,
-          matrix,
-          maxEdgeWeight,
-          playersByIndex,
-        );
+        finalizePairMC(playerGlobal, matchGlobal, mc, np);
         matchedPairs.push([playerGlobal, matchGlobal]);
         if (trace) {
           trace({

--- a/src/dynamic-uint.ts
+++ b/src/dynamic-uint.ts
@@ -73,6 +73,17 @@ class DynamicUint {
     return 0;
   }
 
+  copyFrom(other: DynamicUint): this {
+    if (other.#data.length > this.#data.length) {
+      this.#data = new Uint32Array(other.#data.length);
+    }
+    for (let index = 0; index < this.#data.length; index++) {
+      this.#data[index] =
+        index < other.#data.length ? (other.#data[index] ?? 0) : 0;
+    }
+    return this;
+  }
+
   static from(value: number): DynamicUint {
     const lo = value >>> 0;
     const hi = Math.floor(value / 0x1_00_00_00_00) >>> 0;
@@ -88,11 +99,19 @@ class DynamicUint {
     return new DynamicUint(data);
   }
 
+  gt(other: DynamicUint): boolean {
+    return this.compareTo(other) > 0;
+  }
+
   isZero(): boolean {
     for (const word of this.#data) {
       if (word !== 0) return false;
     }
     return true;
+  }
+
+  lt(other: DynamicUint): boolean {
+    return this.compareTo(other) < 0;
   }
 
   or(value: number | DynamicUint): this {
@@ -218,6 +237,14 @@ class DynamicUint {
       }
     }
     return this;
+  }
+
+  toBigInt(): bigint {
+    let result = 0n;
+    for (let index = this.#data.length - 1; index >= 0; index--) {
+      result = (result << 32n) | BigInt(this.#data[index] ?? 0);
+    }
+    return result;
   }
 
   static zero(words: number): DynamicUint {

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,8 +3,11 @@ export type {
   Bye,
   Game,
   GameKind,
+  PairOptions,
   Pairing,
   PairingResult,
   Player,
   Result,
+  TraceCallback,
+  TraceEvent,
 } from './types.js';

--- a/src/lim-entry.ts
+++ b/src/lim-entry.ts
@@ -2,8 +2,11 @@ export { pair } from './lim.js';
 export type {
   Bye,
   Game,
+  PairOptions,
   Pairing,
   PairingResult,
   Player,
   Result,
+  TraceCallback,
+  TraceEvent,
 } from './types.js';

--- a/src/lim.ts
+++ b/src/lim.ts
@@ -33,6 +33,7 @@ import {
 import { buildEdgeWeight } from './weights.js';
 
 import type { DynamicUint } from './dynamic-uint.js';
+import type { PairOptions, TraceCallback } from './trace.js';
 import type { Game, PairingResult, Player } from './types.js';
 import type { ColorRule, PlayerState } from './utilities.js';
 import type { BracketContext, Criterion } from './weights.js';
@@ -367,9 +368,19 @@ function runBlossom(
   players: PlayerState[],
   edges: [number, number, DynamicUint][],
   maxcardinality = true,
+  trace?: TraceCallback,
 ): Map<string, string> {
   if (players.length === 0) return new Map();
-  const matching = maxWeightMatching(edges, maxcardinality);
+  if (trace) {
+    trace({
+      edgeCount: edges.length,
+      phase: 'main',
+      system: 'lim',
+      type: 'pairing:blossom-invoked',
+      vertexCount: players.length,
+    });
+  }
+  const matching = maxWeightMatching(edges, maxcardinality, trace);
   const result = new Map<string, string>();
   for (const [index, index_] of matching.entries()) {
     if (index_ !== undefined && index_ !== -1 && index_ > index) {
@@ -379,6 +390,19 @@ function runBlossom(
       result.set(a.id, b.id);
       result.set(b.id, a.id);
     }
+  }
+  if (trace) {
+    const pairs: [string, string][] = [];
+    for (const [a, b] of result) {
+      if (a < b) pairs.push([a, b]);
+    }
+    trace({
+      pairs,
+      phase: 'main',
+      system: 'lim',
+      type: 'pairing:blossom-result',
+      unmatchedCount: players.length - pairs.length * 2,
+    });
   }
   return result;
 }
@@ -403,10 +427,16 @@ function normaliseGames(games: Game[][]): Game[][] {
 // Main pair function
 // ---------------------------------------------------------------------------
 
-function pair(players: Player[], games: Game[][]): PairingResult {
+function pair(
+  players: Player[],
+  games: Game[][],
+  options?: PairOptions,
+): PairingResult {
   if (players.length < 2) {
     throw new RangeError('at least 2 players are required');
   }
+
+  const trace = options?.trace;
 
   const normalisedGames = normaliseGames(games);
   const totalRounds = normalisedGames.length + 1;
@@ -433,6 +463,15 @@ function pair(players: Player[], games: Game[][]): PairingResult {
 
   const byeId = byeState?.id;
 
+  if (trace && byeId !== undefined) {
+    trace({
+      playerId: byeId,
+      reason: 'lowest-score-no-prior-bye',
+      system: 'lim',
+      type: 'pairing:bye-assigned',
+    });
+  }
+
   // Remove bye recipient from the pairing pool
   const pairedPool =
     byeId === undefined ? sorted : sorted.filter((s) => s.id !== byeId);
@@ -441,6 +480,15 @@ function pair(players: Player[], games: Game[][]): PairingResult {
   const sgParameters = computeScoreGroupParameters(pairedPool);
   const groupPositions = buildGroupPositions(pairedPool);
   const groupSizes = buildGroupSizes(pairedPool);
+
+  if (trace) {
+    const sgMap = scoreGroups(pairedPool);
+    const groups: { playerIds: string[]; score: number }[] = [];
+    for (const [score, members] of sgMap) {
+      groups.push({ playerIds: members.map((m) => m.id), score });
+    }
+    trace({ groups, system: 'lim', type: 'pairing:score-groups' });
+  }
 
   // -------------------------------------------------------------------------
   // Single global blossom pass
@@ -463,7 +511,7 @@ function pair(players: Player[], games: Game[][]): PairingResult {
   };
 
   const edges = buildEdges(pairedPool, globalContext);
-  const matching = runBlossom(pairedPool, edges, true);
+  const matching = runBlossom(pairedPool, edges, true, trace);
 
   const allPairedTuples: [PlayerState, PlayerState][] = [];
   const seen = new Set<string>();
@@ -478,6 +526,15 @@ function pair(players: Player[], games: Game[][]): PairingResult {
       const b = stateById.get(partnerId);
       if (a === undefined || b === undefined) continue;
       allPairedTuples.push(a.tpn < b.tpn ? [a, b] : [b, a]);
+      if (trace) {
+        trace({
+          phase: 'main',
+          playerA: a.id,
+          playerB: b.id,
+          system: 'lim',
+          type: 'pairing:pair-finalized',
+        });
+      }
     }
   }
 
@@ -487,6 +544,18 @@ function pair(players: Player[], games: Game[][]): PairingResult {
   const pairings = allPairedTuples.map(([a, b]) =>
     allocateColor(a, b, LIM_COLOR_RULES, limRankCompare),
   );
+
+  if (trace) {
+    for (const p of pairings) {
+      trace({
+        black: p.black,
+        rule: 'lim-article-5.2',
+        system: 'lim',
+        type: 'pairing:color-allocated',
+        white: p.white,
+      });
+    }
+  }
 
   return {
     byes: byeId === undefined ? [] : [{ player: byeId }],

--- a/src/matching-computer.ts
+++ b/src/matching-computer.ts
@@ -84,15 +84,10 @@ class MatchingComputer {
 
     const v = this.graph.vertices[vertex]!;
     // Dissolve stale blossoms around this vertex and reset its dual variable.
+    // C++ computer.cpp only prepares modifiedVertex (not neighbor).
     v.rootBlossom!.prepareVertexForWeightAdjustments(v, this.graph);
 
     const n = this.graph.vertices[neighbor]!;
-    // Also prepare the neighbor. The C++ only prepares modifiedVertex, but our
-    // blossom port still has a residual state issue that requires this second
-    // prepare. Removing it causes wrong matchings due to different tiebreaking
-    // in the augmentation algorithm. Root cause under investigation.
-    n.rootBlossom!.prepareVertexForWeightAdjustments(n, this.graph);
-
     v.edgeWeights[neighbor] = doubled.clone();
     n.edgeWeights[vertex] = doubled.clone();
   }

--- a/src/matching-computer.ts
+++ b/src/matching-computer.ts
@@ -86,8 +86,15 @@ class MatchingComputer {
     // Dissolve stale blossoms around this vertex and reset its dual variable.
     v.rootBlossom!.prepareVertexForWeightAdjustments(v, this.graph);
 
+    const n = this.graph.vertices[neighbor]!;
+    // Dissolve stale blossoms around the neighbor and reset its dual variable.
+    // This clears any stale baseVertexMatch on the neighbor's root blossom,
+    // preventing it from being incorrectly labeled FREE in the next
+    // computeMatching when its prior match partner has been freed.
+    n.rootBlossom!.prepareVertexForWeightAdjustments(n, this.graph);
+
     v.edgeWeights[neighbor] = doubled.clone();
-    this.graph.vertices[neighbor]!.edgeWeights[vertex] = doubled.clone();
+    n.edgeWeights[vertex] = doubled.clone();
   }
 }
 

--- a/src/matching-computer.ts
+++ b/src/matching-computer.ts
@@ -89,8 +89,8 @@ class MatchingComputer {
     const n = this.graph.vertices[neighbor]!;
     // Also prepare the neighbor. The C++ only prepares modifiedVertex, but our
     // blossom port still has a residual state issue that requires this second
-    // prepare. Removing it causes wrong matchings in rounds 3-6 for 115-player
-    // tournaments. The root cause is still under investigation.
+    // prepare. Removing it causes wrong matchings due to different tiebreaking
+    // in the augmentation algorithm. Root cause under investigation.
     n.rootBlossom!.prepareVertexForWeightAdjustments(n, this.graph);
 
     v.edgeWeights[neighbor] = doubled.clone();

--- a/src/matching-computer.ts
+++ b/src/matching-computer.ts
@@ -1,0 +1,94 @@
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
+/**
+ * MatchingComputer — thin facade over Graph for persistent maximum-weight
+ * matching.
+ *
+ * Mirrors the public API of bbpPairings `Computer` (computer.cpp, 168 lines).
+ * The Graph class implements the core Galil-Micali-Gabow algorithm; this class
+ * handles:
+ *
+ * - Edge-weight doubling (user provides weight W; stored internally as 2W).
+ * - `prepareVertexForWeightAdjustments` on edge-weight updates (dissolves
+ *   stale blossoms, resets dual variables).
+ * - Calling `putVerticesInMatchingOrder` after `computeMatching` so that
+ *   `getMatching` can read matched pairs consecutively.
+ * - Extracting the matching result from RootBlossom vertex lists.
+ *
+ * @internal Not part of the public API.
+ */
+
+import { Graph } from './matching/graph.js';
+
+import type { DynamicUint } from './dynamic-uint.js';
+
+class MatchingComputer {
+  private readonly graph: Graph;
+
+  constructor(maxEdgeWeight: DynamicUint) {
+    this.graph = new Graph(maxEdgeWeight);
+  }
+
+  get size(): number {
+    return this.graph.vertices.length;
+  }
+
+  addVertex(): void {
+    this.graph.addVertex();
+  }
+
+  computeMatching(): void {
+    this.graph.computeMatching();
+    for (const rb of this.graph.rootBlossoms) {
+      rb.putVerticesInMatchingOrder();
+    }
+  }
+
+  /**
+   * Returns the matching as an array of length `size` where `result[i] = j`
+   * means vertex `i` is matched to vertex `j`.
+   *
+   * Unmatched (exposed) vertices report `result[i] = i` (matched to self).
+   *
+   * Must be called after `computeMatching`.
+   */
+  getMatching(): number[] {
+    const result = Array.from<number>({ length: this.size }).fill(-1);
+
+    for (const rb of this.graph.rootBlossoms) {
+      const baseIndex = rb.baseVertex.vertexIndex;
+
+      result[baseIndex] = rb.baseVertexMatch
+        ? rb.baseVertexMatch.vertexIndex
+        : baseIndex; // Exposed vertex — report as matched to self.
+
+      // Walk the vertex linked list (already in matching order after
+      // putVerticesInMatchingOrder). Vertices after the base are in
+      // consecutive matched pairs.
+      let v = rb.rootChild.vertexListHead.nextVertex;
+      while (v !== undefined) {
+        const partner = v.nextVertex;
+        if (partner === undefined) break;
+        result[v.vertexIndex] = partner.vertexIndex;
+        result[partner.vertexIndex] = v.vertexIndex;
+        v = partner.nextVertex;
+      }
+    }
+
+    return result;
+  }
+
+  setEdgeWeight(vertex: number, neighbor: number, weight: DynamicUint): void {
+    // Internally weights are stored doubled (2W) to keep dual arithmetic
+    // integral. Left-shift by 1 is equivalent to multiply by 2.
+    const doubled = weight.clone().shiftLeft(1);
+
+    const v = this.graph.vertices[vertex]!;
+    // Dissolve stale blossoms around this vertex and reset its dual variable.
+    v.rootBlossom!.prepareVertexForWeightAdjustments(v, this.graph);
+
+    v.edgeWeights[neighbor] = doubled.clone();
+    this.graph.vertices[neighbor]!.edgeWeights[vertex] = doubled.clone();
+  }
+}
+
+export { MatchingComputer };

--- a/src/matching-computer.ts
+++ b/src/matching-computer.ts
@@ -24,8 +24,8 @@ import type { DynamicUint } from './dynamic-uint.js';
 class MatchingComputer {
   private readonly graph: Graph;
 
-  constructor(maxEdgeWeight: DynamicUint) {
-    this.graph = new Graph(maxEdgeWeight);
+  constructor(capacity: number, maxEdgeWeight: DynamicUint) {
+    this.graph = new Graph(capacity, maxEdgeWeight);
   }
 
   get size(): number {
@@ -38,7 +38,7 @@ class MatchingComputer {
 
   computeMatching(): void {
     this.graph.computeMatching();
-    for (const rb of this.graph.rootBlossoms) {
+    for (const rb of this.graph.rootBlossomPool) {
       rb.putVerticesInMatchingOrder();
     }
   }
@@ -54,7 +54,7 @@ class MatchingComputer {
   getMatching(): number[] {
     const result = Array.from<number>({ length: this.size }).fill(-1);
 
-    for (const rb of this.graph.rootBlossoms) {
+    for (const rb of this.graph.rootBlossomPool) {
       const baseIndex = rb.baseVertex.vertexIndex;
 
       result[baseIndex] = rb.baseVertexMatch

--- a/src/matching-computer.ts
+++ b/src/matching-computer.ts
@@ -80,7 +80,7 @@ class MatchingComputer {
   setEdgeWeight(vertex: number, neighbor: number, weight: DynamicUint): void {
     // Internally weights are stored doubled (2W) to keep dual arithmetic
     // integral. Left-shift by 1 is equivalent to multiply by 2.
-    const doubled = weight.clone().shiftLeft(1);
+    const doubled = weight.clone().shiftGrow(1);
 
     const v = this.graph.vertices[vertex]!;
     // C++ computer.cpp:89-91 — only prepare the modified vertex, not the

--- a/src/matching-computer.ts
+++ b/src/matching-computer.ts
@@ -83,16 +83,11 @@ class MatchingComputer {
     const doubled = weight.clone().shiftLeft(1);
 
     const v = this.graph.vertices[vertex]!;
-    // Dissolve stale blossoms around this vertex and reset its dual variable.
+    // C++ computer.cpp:89-91 — only prepare the modified vertex, not the
+    // neighbor. Dissolves stale blossoms and resets dual variable.
     v.rootBlossom!.prepareVertexForWeightAdjustments(v, this.graph);
 
     const n = this.graph.vertices[neighbor]!;
-    // Also prepare the neighbor. The C++ only prepares modifiedVertex, but our
-    // blossom port still has a residual state issue that requires this second
-    // prepare. Removing it causes wrong matchings due to different tiebreaking
-    // in the augmentation algorithm. Root cause under investigation.
-    n.rootBlossom!.prepareVertexForWeightAdjustments(n, this.graph);
-
     v.edgeWeights[neighbor] = doubled.clone();
     n.edgeWeights[vertex] = doubled.clone();
   }

--- a/src/matching-computer.ts
+++ b/src/matching-computer.ts
@@ -87,10 +87,10 @@ class MatchingComputer {
     v.rootBlossom!.prepareVertexForWeightAdjustments(v, this.graph);
 
     const n = this.graph.vertices[neighbor]!;
-    // Dissolve stale blossoms around the neighbor and reset its dual variable.
-    // This clears any stale baseVertexMatch on the neighbor's root blossom,
-    // preventing it from being incorrectly labeled FREE in the next
-    // computeMatching when its prior match partner has been freed.
+    // Also prepare the neighbor. The C++ only prepares modifiedVertex, but our
+    // blossom port still has a residual state issue that requires this second
+    // prepare. Removing it causes wrong matchings in rounds 3-6 for 115-player
+    // tournaments. The root cause is still under investigation.
     n.rootBlossom!.prepareVertexForWeightAdjustments(n, this.graph);
 
     v.edgeWeights[neighbor] = doubled.clone();

--- a/src/matching-computer.ts
+++ b/src/matching-computer.ts
@@ -84,10 +84,15 @@ class MatchingComputer {
 
     const v = this.graph.vertices[vertex]!;
     // Dissolve stale blossoms around this vertex and reset its dual variable.
-    // C++ computer.cpp only prepares modifiedVertex (not neighbor).
     v.rootBlossom!.prepareVertexForWeightAdjustments(v, this.graph);
 
     const n = this.graph.vertices[neighbor]!;
+    // Also prepare the neighbor. The C++ only prepares modifiedVertex, but our
+    // blossom port still has a residual state issue that requires this second
+    // prepare. Removing it causes wrong matchings due to different tiebreaking
+    // in the augmentation algorithm. Root cause under investigation.
+    n.rootBlossom!.prepareVertexForWeightAdjustments(n, this.graph);
+
     v.edgeWeights[neighbor] = doubled.clone();
     n.edgeWeights[vertex] = doubled.clone();
   }

--- a/src/matching/blossom.ts
+++ b/src/matching/blossom.ts
@@ -89,6 +89,36 @@ class ParentBlossom {
     this.vertexToNextSiblingBlossom = undefined;
     this.vertexToPreviousSiblingBlossom = undefined;
   }
+
+  // ---------------------------------------------------------------------------
+  // connectChildren (parentblossom.cpp:17-40)
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Initialize sibling links, parent links, and child links from a path.
+   *
+   * The path alternates vertex pairs: path[0], path[1], path[2], path[3], …
+   * At each even index i, path[i] is the vertex inside the current child that
+   * links to the next sibling; path[i+1] is the vertex inside the next child
+   * that links back to the current sibling.
+   *
+   * After the call `this.subblossom` points to the last child in the chain.
+   *
+   * Ported from bbpPairings `parentblossom.cpp:17-40`.
+   */
+  connectChildren(path: Vertex[]): void {
+    let previousChild: Blossom = getAncestorOfVertex(path[0]!);
+    for (let index = 0; index < path.length; index += 2) {
+      previousChild.vertexToNextSiblingBlossom = path[index]!;
+      const nextVertex = path[index + 1]!;
+      this.subblossom = getAncestorOfVertex(nextVertex);
+      previousChild.nextBlossom = this.subblossom;
+      this.subblossom.vertexToPreviousSiblingBlossom = nextVertex;
+      this.subblossom.parentBlossom = this;
+      this.subblossom.previousBlossom = previousChild;
+      previousChild = this.subblossom;
+    }
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -290,6 +320,31 @@ class RootBlossom {
   }
 
   // ---------------------------------------------------------------------------
+  // updateRootBlossomInDescendants (rootblossomimpl.h:176-195)
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Update the rootBlossom pointer on all descendant vertices and
+   * ParentBlossoms to point to this RootBlossom.
+   *
+   * Ported from bbpPairings `rootblossomimpl.h:176-195`.
+   */
+  updateRootBlossomInDescendants(): void {
+    for (
+      let v: Vertex | undefined = this.rootChild.vertexListHead;
+      v;
+      v = v.nextVertex
+    ) {
+      v.rootBlossom = this;
+      let pb: ParentBlossom | undefined = v.parentBlossom;
+      while (pb && pb.vertexListTail === v) {
+        pb.rootBlossom = this;
+        pb = pb.parentBlossom;
+      }
+    }
+  }
+
+  // ---------------------------------------------------------------------------
   // freeAncestorOfBase (rootblossom.cpp:184-274)
   // ---------------------------------------------------------------------------
 
@@ -324,6 +379,7 @@ class RootBlossom {
       graph,
     );
     graph.rootBlossoms.push(ancestorRoot);
+    ancestorRoot.updateRootBlossomInDescendants();
 
     for (
       let iterator: Vertex | undefined = ancestor.vertexListHead;
@@ -361,6 +417,7 @@ class RootBlossom {
           graph,
         );
         graph.rootBlossoms.push(siblingRoot);
+        siblingRoot.updateRootBlossomInDescendants();
 
         for (
           let iterator: Vertex | undefined = currentBlossom!.vertexListHead;

--- a/src/matching/blossom.ts
+++ b/src/matching/blossom.ts
@@ -231,6 +231,10 @@ class RootBlossom {
     this.minOuterEdgeResistance = graph.aboveMaxEdgeWeight.clone();
     this.minOuterEdges = [];
     this.rootChild = rootChild;
+
+    // C++ rootblossomimpl.h:127-129
+    rootChild.parentBlossom = undefined;
+    rootChild.vertexListTail.nextVertex = undefined;
   }
 
   // ---------------------------------------------------------------------------

--- a/src/matching/blossom.ts
+++ b/src/matching/blossom.ts
@@ -226,8 +226,7 @@ class RootBlossom {
 
     this.freeAncestorOfBase(vertex, graph);
 
-    vertex.dualVariable = graph.aboveMaxEdgeWeight.clone();
-    vertex.dualVariable.shiftRight(1);
+    vertex.dualVariable.copyFrom(graph.aboveMaxEdgeWeight).shiftRight(1);
   }
 
   // ---------------------------------------------------------------------------

--- a/src/matching/blossom.ts
+++ b/src/matching/blossom.ts
@@ -229,7 +229,13 @@ class RootBlossom {
     this.labeledVertex = undefined;
     this.labelingVertex = undefined;
     this.minOuterEdgeResistance = graph.aboveMaxEdgeWeight.clone();
-    this.minOuterEdges = [];
+    // C++ rootblossomimpl.h:109 — minOuterEdges sized from old root blossom.
+    // rootChild.rootBlossom still points to the OLD root at this point, so
+    // use its minOuterEdges length to initialise ours to the same capacity.
+    const oldSize = rootChild.rootBlossom?.minOuterEdges.length ?? 0;
+    this.minOuterEdges = Array.from<Vertex | undefined>({
+      length: oldSize,
+    }).fill();
     this.rootChild = rootChild;
 
     // C++ rootblossomimpl.h:127-129

--- a/src/matching/blossom.ts
+++ b/src/matching/blossom.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 import type { DynamicUint } from '../dynamic-uint.js';
+import type { IterablePool } from './iterable-pool.js';
 import type { Label } from './types.js';
 import type { Vertex } from './vertex.js';
 
@@ -12,8 +13,8 @@ import type { Vertex } from './vertex.js';
 interface GraphLike {
   readonly aboveMaxEdgeWeight: DynamicUint;
   parentBlossoms: ParentBlossom[];
+  rootBlossomPool: IterablePool<RootBlossom>;
   readonly vertexDualVariables: DynamicUint[];
-  rootBlossoms: RootBlossom[];
 }
 
 // ---------------------------------------------------------------------------
@@ -214,6 +215,9 @@ class RootBlossom {
    */
   minOuterEdges: (Vertex | undefined)[];
 
+  /** Slot index in the Graph's rootBlossom pool. Set after construction. */
+  poolIndex = -1;
+
   /** The direct child of this RootBlossom in the blossom tree. */
   rootChild: Blossom;
 
@@ -393,7 +397,7 @@ class RootBlossom {
       this.baseVertexMatch,
       graph,
     );
-    graph.rootBlossoms.push(ancestorRoot);
+    ancestorRoot.poolIndex = graph.rootBlossomPool.construct(ancestorRoot);
     ancestorRoot.updateRootBlossomInDescendants();
 
     for (
@@ -431,7 +435,7 @@ class RootBlossom {
           siblingBaseVertexMatch,
           graph,
         );
-        graph.rootBlossoms.push(siblingRoot);
+        siblingRoot.poolIndex = graph.rootBlossomPool.construct(siblingRoot);
         siblingRoot.updateRootBlossomInDescendants();
 
         for (
@@ -470,8 +474,7 @@ class RootBlossom {
     if (rootChildIndex !== -1) graph.parentBlossoms.splice(rootChildIndex, 1);
 
     // Destroy this RootBlossom.
-    const selfIndex = graph.rootBlossoms.indexOf(this);
-    if (selfIndex !== -1) graph.rootBlossoms.splice(selfIndex, 1);
+    graph.rootBlossomPool.destroy(this.poolIndex);
   }
 }
 

--- a/src/matching/blossom.ts
+++ b/src/matching/blossom.ts
@@ -1,0 +1,413 @@
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
+import type { DynamicUint } from '../dynamic-uint.js';
+import type { Label } from './types.js';
+import type { Vertex } from './vertex.js';
+
+/**
+ * Minimal graph interface required by RootBlossom methods.
+ * The full Graph class is implemented in Task 3.
+ *
+ * @internal
+ */
+interface GraphLike {
+  readonly aboveMaxEdgeWeight: DynamicUint;
+  parentBlossoms: ParentBlossom[];
+  readonly vertexDualVariables: DynamicUint[];
+  rootBlossoms: RootBlossom[];
+}
+
+// ---------------------------------------------------------------------------
+// ParentBlossom
+// ---------------------------------------------------------------------------
+
+/**
+ * A compound blossom — an odd cycle contracted into a pseudo-vertex.
+ *
+ * Ported from bbpPairings `parentblossomsig.h` + `parentblossomimpl.h`.
+ *
+ * @internal Not part of the public API.
+ */
+class ParentBlossom {
+  /** Discriminator — always `false` for ParentBlossom. */
+  readonly isVertex = false as const;
+
+  /** Dual variable of this compound blossom. */
+  dualVariable: DynamicUint;
+
+  /** Whether iteration (for putVerticesInMatchingOrder) starts with subblossom. */
+  iterationStartsWithSubblossom: boolean;
+
+  /** Next blossom child link within the parent blossom's cycle. */
+  nextBlossom: Blossom | undefined;
+
+  /** The immediate parent compound blossom, or `undefined` if directly under a RootBlossom. */
+  parentBlossom: ParentBlossom | undefined;
+
+  /** Previous blossom child link within the parent blossom's cycle. */
+  previousBlossom: Blossom | undefined;
+
+  /**
+   * The RootBlossom at the top of the blossom tree containing this blossom.
+   * Set when the blossom is placed under a RootBlossom.
+   */
+  rootBlossom: RootBlossom;
+
+  /**
+   * One child blossom — used as the iteration start by putVerticesInMatchingOrder.
+   * Points to the child blossom through which the base vertex path enters.
+   */
+  subblossom: Blossom;
+
+  /** Head of the vertex linked list for all vertices in this blossom. */
+  vertexListHead: Vertex;
+
+  /** Tail of the vertex linked list for all vertices in this blossom. */
+  vertexListTail: Vertex;
+
+  /** Link to the vertex that connects to the next sibling blossom in parent. */
+  vertexToNextSiblingBlossom: Vertex | undefined;
+
+  /** Link to the vertex that connects to the previous sibling blossom in parent. */
+  vertexToPreviousSiblingBlossom: Vertex | undefined;
+
+  constructor(
+    dualVariable: DynamicUint,
+    rootBlossom: RootBlossom,
+    subblossom: Blossom,
+    vertexListHead: Vertex,
+    vertexListTail: Vertex,
+  ) {
+    this.dualVariable = dualVariable;
+    this.iterationStartsWithSubblossom = false;
+    this.nextBlossom = undefined;
+    this.parentBlossom = undefined;
+    this.previousBlossom = undefined;
+    this.rootBlossom = rootBlossom;
+    this.subblossom = subblossom;
+    this.vertexListHead = vertexListHead;
+    this.vertexListTail = vertexListTail;
+    this.vertexToNextSiblingBlossom = undefined;
+    this.vertexToPreviousSiblingBlossom = undefined;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Blossom union type
+// ---------------------------------------------------------------------------
+
+/**
+ * Discriminated union of the two blossom node types.
+ *
+ * - `Vertex` (`isVertex === true`): a leaf node in the blossom tree.
+ * - `ParentBlossom` (`isVertex === false`): an odd cycle contracted into a
+ *   pseudo-vertex.
+ *
+ * @internal Not part of the public API.
+ */
+type Blossom = ParentBlossom | Vertex;
+
+// ---------------------------------------------------------------------------
+// Helper functions (blossomimpl.h)
+// ---------------------------------------------------------------------------
+
+/**
+ * Walk upward from `vertex` until the parent of the current blossom equals
+ * `ancestor`, returning that child-of-`ancestor` blossom.
+ */
+function getAncestorOfVertex(
+  vertex: Vertex,
+  ancestor?: ParentBlossom,
+): Blossom {
+  let blossom: Blossom = vertex;
+  while (blossom.parentBlossom !== ancestor) {
+    blossom = blossom.parentBlossom!;
+  }
+  return blossom;
+}
+
+/**
+ * Walk upward from `vertex` to `ancestor`, setting `subblossom` and
+ * `iterationStartsWithSubblossom` on each intermediate ParentBlossom.
+ */
+function setPointersFromAncestor(
+  vertex: Vertex,
+  ancestor: Blossom,
+  startWithSubblossom: boolean,
+): void {
+  let blossom: Blossom = vertex;
+  while (blossom !== ancestor) {
+    blossom.parentBlossom!.subblossom = blossom;
+    blossom.parentBlossom!.iterationStartsWithSubblossom = startWithSubblossom;
+    blossom = blossom.parentBlossom!;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// RootBlossom
+// ---------------------------------------------------------------------------
+
+/**
+ * Top-level wrapper for a blossom tree.
+ *
+ * One RootBlossom exists per connected component of the matching. It is NOT
+ * in the Blossom hierarchy (not a Vertex or ParentBlossom) — it wraps the
+ * root child blossom and carries augmentation metadata.
+ *
+ * Ported from bbpPairings `rootblossomsig.h` + `rootblossom.cpp`.
+ *
+ * @internal Not part of the public API.
+ */
+class RootBlossom {
+  /** Representative vertex for this blossom (the "base"). */
+  baseVertex: Vertex;
+
+  /** The matched partner's base vertex. `undefined` = exposed (unmatched). */
+  baseVertexMatch: Vertex | undefined;
+
+  /** Label assigned during augmentation. */
+  label: Label;
+
+  /** Vertex that received a label during augmentation. */
+  labeledVertex: Vertex | undefined;
+
+  /** Vertex that carried the label to `labeledVertex` during augmentation. */
+  labelingVertex: Vertex | undefined;
+
+  /**
+   * Minimum resistance outer edge indexed by the other RootBlossom's base
+   * vertex index.
+   */
+  minOuterEdgeResistance: DynamicUint;
+
+  /**
+   * Minimum resistance outer edge per other RootBlossom's base vertex index.
+   */
+  minOuterEdges: (Vertex | undefined)[];
+
+  /** The direct child of this RootBlossom in the blossom tree. */
+  rootChild: Blossom;
+
+  constructor(
+    rootChild: Blossom,
+    baseVertex: Vertex,
+    baseVertexMatch: Vertex | undefined,
+    graph: GraphLike,
+  ) {
+    this.baseVertex = baseVertex;
+    this.baseVertexMatch = baseVertexMatch;
+    this.label = 3 as Label; // Label.FREE
+    this.labeledVertex = undefined;
+    this.labelingVertex = undefined;
+    this.minOuterEdgeResistance = graph.aboveMaxEdgeWeight.clone();
+    this.minOuterEdges = [];
+    this.rootChild = rootChild;
+  }
+
+  // ---------------------------------------------------------------------------
+  // prepareVertexForWeightAdjustments (rootblossomimpl.h:137-153)
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Prepares `vertex` for weight adjustments by:
+   * 1. Disconnecting the current match.
+   * 2. Setting `baseVertex` to `vertex`.
+   * 3. Dissolving all enclosing ParentBlossoms above `vertex` into independent
+   *    RootBlossoms (freeAncestorOfBase).
+   * 4. Resetting `vertex.dualVariable` to `aboveMaxEdgeWeight >> 1`.
+   *
+   * Ported from bbpPairings `rootblossomimpl.h:137-153`.
+   */
+  prepareVertexForWeightAdjustments(vertex: Vertex, graph: GraphLike): void {
+    if (this.baseVertexMatch) {
+      this.baseVertexMatch.rootBlossom!.baseVertexMatch = undefined;
+      this.baseVertexMatch = undefined;
+    }
+    this.baseVertex = vertex;
+
+    this.freeAncestorOfBase(vertex, graph);
+
+    vertex.dualVariable = graph.aboveMaxEdgeWeight.clone();
+    vertex.dualVariable.shiftRight(1);
+  }
+
+  // ---------------------------------------------------------------------------
+  // putVerticesInMatchingOrder (rootblossom.cpp:22-80)
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Reorders the vertex linked list within this RootBlossom so that
+   * `getMatching` can read matched pairs consecutively.
+   *
+   * Ported from bbpPairings `rootblossom.cpp:22-80`.
+   */
+  putVerticesInMatchingOrder(): void {
+    let currentBlossom: Blossom = this.rootChild;
+    let currentVertex: Vertex = this.baseVertex;
+    let startsWithBase = true;
+
+    do {
+      setPointersFromAncestor(currentVertex, currentBlossom, startsWithBase);
+      currentBlossom = currentVertex;
+
+      while (currentBlossom !== this.rootChild) {
+        const nextBlossom: Blossom = currentBlossom.nextBlossom!;
+        startsWithBase =
+          !startsWithBase &&
+          currentBlossom.parentBlossom!.subblossom !== currentBlossom;
+
+        currentBlossom.previousBlossom!.vertexListTail.nextVertex =
+          currentBlossom.vertexListHead;
+
+        currentBlossom = nextBlossom;
+
+        if (currentBlossom === currentBlossom.parentBlossom!.subblossom) {
+          const parentBlossom: ParentBlossom = currentBlossom.parentBlossom!;
+          startsWithBase = parentBlossom.iterationStartsWithSubblossom;
+
+          currentBlossom.previousBlossom!.vertexListTail.nextVertex =
+            currentBlossom.vertexListHead;
+
+          parentBlossom.vertexListHead = (
+            startsWithBase ? currentBlossom : currentBlossom.nextBlossom!
+          ).vertexListHead;
+
+          parentBlossom.vertexListTail = (
+            startsWithBase ? currentBlossom.previousBlossom! : currentBlossom
+          ).vertexListTail;
+
+          currentBlossom = parentBlossom;
+          // Repeat inner loop, iterating up to the parent blossom.
+        } else {
+          currentVertex = startsWithBase
+            ? currentBlossom.vertexToPreviousSiblingBlossom!
+            : currentBlossom.vertexToNextSiblingBlossom!;
+          break;
+          // Repeat outer loop with a new Vertex.
+        }
+      }
+    } while (currentBlossom !== this.rootChild);
+
+    this.rootChild.vertexListTail.nextVertex = undefined;
+  }
+
+  // ---------------------------------------------------------------------------
+  // freeAncestorOfBase (rootblossom.cpp:184-274)
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Dissolves all compound blossoms enclosing `ancestor` up to the root,
+   * creating independent RootBlossoms for each sibling and propagating dual
+   * variables down.
+   *
+   * Ported from bbpPairings `rootblossom.cpp:184-274`.
+   */
+  private freeAncestorOfBase(ancestor: Blossom, graph: GraphLike): void {
+    if (ancestor === this.rootChild) {
+      return;
+    }
+
+    // Calculate the total dualVariable adjustment from all enclosing blossoms.
+    const dualVariableAdjustment = graph.aboveMaxEdgeWeight.clone().and(0);
+    let blossom: ParentBlossom | undefined = ancestor.parentBlossom;
+    while (blossom) {
+      dualVariableAdjustment.add(blossom.dualVariable.clone().shiftRight(1));
+      blossom = blossom.parentBlossom;
+    }
+
+    blossom = ancestor.parentBlossom;
+    let nextBlossom: Blossom | undefined = ancestor.nextBlossom;
+
+    // Create a RootBlossom for ancestor.
+    const ancestorRoot = new RootBlossom(
+      ancestor,
+      this.baseVertex,
+      this.baseVertexMatch,
+      graph,
+    );
+    graph.rootBlossoms.push(ancestorRoot);
+
+    for (
+      let iterator: Vertex | undefined = ancestor.vertexListHead;
+      iterator;
+      iterator = iterator.nextVertex
+    ) {
+      iterator.dualVariable.add(dualVariableAdjustment);
+    }
+
+    // Create all the other RootBlossoms for siblings of ancestor.
+    let childToFree: Blossom = ancestor;
+    while (blossom) {
+      let linksForward = true;
+      let previousBlossom: Blossom | undefined;
+
+      for (
+        let currentBlossom: Blossom | undefined = nextBlossom;
+        currentBlossom !== childToFree;
+        currentBlossom = nextBlossom
+      ) {
+        nextBlossom = currentBlossom!.nextBlossom;
+
+        const siblingBaseVertex = linksForward
+          ? currentBlossom!.vertexToNextSiblingBlossom!
+          : currentBlossom!.vertexToPreviousSiblingBlossom!;
+
+        const siblingBaseVertexMatch = linksForward
+          ? nextBlossom?.vertexToPreviousSiblingBlossom
+          : previousBlossom?.vertexToNextSiblingBlossom;
+
+        const siblingRoot = new RootBlossom(
+          currentBlossom!,
+          siblingBaseVertex,
+          siblingBaseVertexMatch,
+          graph,
+        );
+        graph.rootBlossoms.push(siblingRoot);
+
+        for (
+          let iterator: Vertex | undefined = currentBlossom!.vertexListHead;
+          iterator;
+          iterator = iterator.nextVertex
+        ) {
+          iterator.dualVariable.add(dualVariableAdjustment);
+        }
+
+        linksForward = !linksForward;
+        previousBlossom = currentBlossom;
+      }
+
+      dualVariableAdjustment.subtract(
+        blossom.dualVariable.clone().shiftRight(1),
+      );
+
+      if (childToFree !== ancestor) {
+        // Destroy unused ParentBlossom.
+        const index = graph.parentBlossoms.indexOf(
+          childToFree as ParentBlossom,
+        );
+        if (index !== -1) graph.parentBlossoms.splice(index, 1);
+      }
+
+      childToFree = blossom;
+      nextBlossom = blossom.nextBlossom;
+      blossom = blossom.parentBlossom;
+    }
+
+    // Destroy the old RootBlossom's rootChild (the outermost ParentBlossom).
+    const rootChildIndex = graph.parentBlossoms.indexOf(
+      this.rootChild as ParentBlossom,
+    );
+    if (rootChildIndex !== -1) graph.parentBlossoms.splice(rootChildIndex, 1);
+
+    // Destroy this RootBlossom.
+    const selfIndex = graph.rootBlossoms.indexOf(this);
+    if (selfIndex !== -1) graph.rootBlossoms.splice(selfIndex, 1);
+  }
+}
+
+export type { Blossom, GraphLike };
+export {
+  getAncestorOfVertex,
+  ParentBlossom,
+  RootBlossom,
+  setPointersFromAncestor,
+};

--- a/src/matching/blossom.ts
+++ b/src/matching/blossom.ts
@@ -12,7 +12,7 @@ import type { Vertex } from './vertex.js';
  */
 interface GraphLike {
   readonly aboveMaxEdgeWeight: DynamicUint;
-  parentBlossoms: ParentBlossom[];
+  parentBlossomPool: IterablePool<ParentBlossom>;
   rootBlossomPool: IterablePool<RootBlossom>;
   readonly vertexDualVariables: DynamicUint[];
 }
@@ -43,6 +43,9 @@ class ParentBlossom {
 
   /** The immediate parent compound blossom, or `undefined` if directly under a RootBlossom. */
   parentBlossom: ParentBlossom | undefined;
+
+  /** Slot index in the Graph's parentBlossom pool. Set after construction. */
+  poolIndex = -1;
 
   /** Previous blossom child link within the parent blossom's cycle. */
   previousBlossom: Blossom | undefined;
@@ -456,10 +459,9 @@ class RootBlossom {
 
       if (childToFree !== ancestor) {
         // Destroy unused ParentBlossom.
-        const index = graph.parentBlossoms.indexOf(
-          childToFree as ParentBlossom,
+        graph.parentBlossomPool.destroy(
+          (childToFree as ParentBlossom).poolIndex,
         );
-        if (index !== -1) graph.parentBlossoms.splice(index, 1);
       }
 
       childToFree = blossom;
@@ -468,10 +470,9 @@ class RootBlossom {
     }
 
     // Destroy the old RootBlossom's rootChild (the outermost ParentBlossom).
-    const rootChildIndex = graph.parentBlossoms.indexOf(
-      this.rootChild as ParentBlossom,
+    graph.parentBlossomPool.destroy(
+      (this.rootChild as ParentBlossom).poolIndex,
     );
-    if (rootChildIndex !== -1) graph.parentBlossoms.splice(rootChildIndex, 1);
 
     // Destroy this RootBlossom.
     graph.rootBlossomPool.destroy(this.poolIndex);

--- a/src/matching/blossom.ts
+++ b/src/matching/blossom.ts
@@ -225,7 +225,8 @@ class RootBlossom {
   ) {
     this.baseVertex = baseVertex;
     this.baseVertexMatch = baseVertexMatch;
-    this.label = 3 as Label; // Label.FREE
+    // C++ rootblossomimpl.h:113 — delegates to full ctor with LABEL_ZERO.
+    this.label = 1 as Label; // LABEL_ZERO
     this.labeledVertex = undefined;
     this.labelingVertex = undefined;
     this.minOuterEdgeResistance = graph.aboveMaxEdgeWeight.clone();

--- a/src/matching/blossom.ts
+++ b/src/matching/blossom.ts
@@ -241,9 +241,7 @@ class RootBlossom {
     // rootChild.rootBlossom still points to the OLD root at this point, so
     // use its minOuterEdges length to initialise ours to the same capacity.
     const oldSize = rootChild.rootBlossom?.minOuterEdges.length ?? 0;
-    this.minOuterEdges = Array.from<Vertex | undefined>({
-      length: oldSize,
-    }).fill();
+    this.minOuterEdges = Array.from<Vertex | undefined>({ length: oldSize });
     this.rootChild = rootChild;
 
     // C++ rootblossomimpl.h:127-129

--- a/src/matching/blossom.ts
+++ b/src/matching/blossom.ts
@@ -325,20 +325,24 @@ class RootBlossom {
 
   /**
    * Update the rootBlossom pointer on all descendant vertices and
-   * ParentBlossoms to point to this RootBlossom.
+   * ParentBlossoms to point to `target` (or `this` if omitted).
    *
-   * Ported from bbpPairings `rootblossomimpl.h:176-195`.
+   * The C++ version always takes a target parameter. Existing callers that
+   * pass no argument get the old behavior (defaults to `this`).
+   *
+   * Ported from bbpPairings `rootblossomimpl.h:174-193`.
    */
-  updateRootBlossomInDescendants(): void {
+  updateRootBlossomInDescendants(target?: RootBlossom): void {
+    const rb = target ?? this;
     for (
       let v: Vertex | undefined = this.rootChild.vertexListHead;
       v;
       v = v.nextVertex
     ) {
-      v.rootBlossom = this;
+      v.rootBlossom = rb;
       let pb: ParentBlossom | undefined = v.parentBlossom;
       while (pb && pb.vertexListTail === v) {
-        pb.rootBlossom = this;
+        pb.rootBlossom = rb;
         pb = pb.parentBlossom;
       }
     }

--- a/src/matching/graph.ts
+++ b/src/matching/graph.ts
@@ -225,23 +225,13 @@ class Graph implements GraphLike {
     let minOuterDualVariableVertex: Vertex | undefined;
 
     for (const rb of this.rootBlossoms) {
-      // Reset labeling state.
+      // Reset labeling state (C++ graph.cpp:188-203).
+      // Do NOT reset minOuterEdgeResistance or minOuterEdges[] here — the C++
+      // preserves these across augmentation calls. They are recomputed per
+      // OUTER blossom in initializeOuterOuterEdges().
+      // Per-vertex minOuterEdge is reset in initializeInnerOuterEdges().
       rb.labeledVertex = undefined;
       rb.labelingVertex = undefined;
-      rb.minOuterEdgeResistance.copyFrom(this.aboveMaxEdgeWeight);
-      for (let index = 0; index < rb.minOuterEdges.length; index++) {
-        rb.minOuterEdges[index] = undefined;
-      }
-
-      // Reset vertex minOuterEdge tracking.
-      for (
-        let v: Vertex | undefined = rb.rootChild.vertexListHead;
-        v;
-        v = v.nextVertex
-      ) {
-        v.minOuterEdge = undefined;
-        v.minOuterEdgeResistance.copyFrom(this.aboveMaxEdgeWeight);
-      }
 
       if (rb.baseVertexMatch) {
         rb.label = Label.FREE;
@@ -894,6 +884,11 @@ class Graph implements GraphLike {
   private initializeOuterOuterEdges(): void {
     for (const rb of this.rootBlossoms) {
       if (rb.label !== Label.OUTER) continue;
+      // Reset per-blossom outer-outer tracking (C++ graph.cpp:275).
+      rb.minOuterEdgeResistance.copyFrom(this.aboveMaxEdgeWeight);
+      for (let index = 0; index < rb.minOuterEdges.length; index++) {
+        rb.minOuterEdges[index] = undefined;
+      }
       for (const otherRb of this.rootBlossoms) {
         if (otherRb === rb) continue;
         if (otherRb.label !== Label.OUTER) continue;

--- a/src/matching/graph.ts
+++ b/src/matching/graph.ts
@@ -222,35 +222,32 @@ class Graph implements GraphLike {
     // INITIALIZATION (initializeLabeling)
     // -------------------------------------------------------------------------
 
-    // minOuterDualVariable tracks the minimum dual among OUTER vertices,
-    // plus the vertex that achieves it.
-    const minOuterDualVariable = this.aboveMaxEdgeWeight.clone();
-    let minOuterDualVariableVertex: Vertex | undefined;
-
+    // C++ graph.cpp:188-203 — initializeLabeling: set labels on all root
+    // blossoms FIRST, before scanning for minOuterDualVariable.
     for (const rb of this.rootBlossomPool) {
-      // Reset labeling state (C++ graph.cpp:188-203).
-      // Do NOT reset minOuterEdgeResistance or minOuterEdges[] here — the C++
-      // preserves these across augmentation calls. They are recomputed per
-      // OUTER blossom in initializeOuterOuterEdges().
-      // Per-vertex minOuterEdge is reset in initializeInnerOuterEdges().
       rb.labeledVertex = undefined;
       rb.labelingVertex = undefined;
 
       if (rb.baseVertexMatch) {
         rb.label = Label.FREE;
       } else {
-        // Exposed vertex.
-        if (rb.baseVertex.dualVariable.isZero()) {
-          rb.label = Label.ZERO;
-        } else {
-          rb.label = Label.OUTER;
-          // Track min outer dual variable vertex.
-          if (rb.baseVertex.dualVariable.lt(minOuterDualVariable)) {
-            minOuterDualVariable.copyFrom(rb.baseVertex.dualVariable);
-            minOuterDualVariableVertex = rb.baseVertex;
-          }
-        }
+        rb.label = rb.baseVertex.dualVariable.isZero()
+          ? Label.ZERO
+          : Label.OUTER;
       }
+    }
+
+    // C++ graph.cpp:399-412 — scan ALL vertices (not just base vertices)
+    // for minimum dual variable among OUTER root blossoms. This matters
+    // when compound OUTER blossoms exist: the min-dual vertex may not be
+    // the base vertex.
+    const minOuterDualVariable = this.aboveMaxEdgeWeight.clone();
+    let minOuterDualVariableVertex: Vertex | undefined;
+    for (const vertex of this.vertices) {
+      if (vertex.rootBlossom!.label === Label.OUTER && vertex.dualVariable.lt(minOuterDualVariable)) {
+          minOuterDualVariable.copyFrom(vertex.dualVariable);
+          minOuterDualVariableVertex = vertex;
+        }
     }
 
     // If no OUTER vertices, no augmentation possible.

--- a/src/matching/graph.ts
+++ b/src/matching/graph.ts
@@ -484,68 +484,56 @@ class Graph implements GraphLike {
           return false;
         }
 
-        const rbA = vertex0.rootBlossom!;
-        const rbB = vertex1.rootBlossom!;
+        // Build path using the C++ deque pattern (graph.cpp:573-589).
+        // Each push_front/push_back uses the CURRENT front/back vertex,
+        // which changes after every push.
+        //
+        // We use two arrays: pathFront grows leftward (unshift), pathBack
+        // grows rightward (push). The final path is [...pathFront, ...pathBack].
+        const pathFront: Vertex[] = [vertex0];
+        const pathBack: Vertex[] = [vertex1];
 
-        if (rbA === rbB) {
+        // Expand front toward its exposed root.
+        while (pathFront[0]!.rootBlossom!.baseVertexMatch) {
+          const front = pathFront[0]!;
+          pathFront.unshift(front.rootBlossom!.baseVertex);
+          pathFront.unshift(pathFront[0]!.rootBlossom!.baseVertexMatch!);
+          pathFront.unshift(pathFront[0]!.rootBlossom!.labeledVertex!);
+          pathFront.unshift(pathFront[0]!.rootBlossom!.labelingVertex!);
+        }
+
+        // Expand back toward its exposed root.
+        while (pathBack.at(-1)!.rootBlossom!.baseVertexMatch) {
+          const b0 = pathBack.at(-1)!.rootBlossom!.baseVertex;
+          const b1 = b0.rootBlossom!.baseVertexMatch!;
+          const b2 = b1.rootBlossom!.labeledVertex!;
+          const b3 = b2.rootBlossom!.labelingVertex!;
+          pathBack.push(b0, b1, b2, b3);
+        }
+
+        // Same-root check: compare the exposed roots at the path endpoints.
+        // (C++ line 591: path.front()->rootBlossom == path.back()->rootBlossom)
+        if (pathFront[0]!.rootBlossom === pathBack.at(-1)!.rootBlossom) {
           // SAME ROOT → form new blossom.
-          // Build path from vertex0 and vertex1 back to the exposed root,
-          // following the alternating tree structure.
-          // C++ path format: [vertex0, ..., vertex1] with alternating
-          // labelingVertex→labeledVertex→baseVertex→baseVertexMatch links.
 
-          // Build path from vertex0 toward root.
-          const pathFront: Vertex[] = [vertex0];
-          {
-            let current: Vertex = vertex0;
-            while (current.rootBlossom!.baseVertexMatch) {
-              const rb = current.rootBlossom!;
-              pathFront.push(
-                rb.baseVertex,
-                rb.baseVertexMatch!,
-                rb.baseVertexMatch!.rootBlossom!.labeledVertex!,
-                rb.baseVertexMatch!.rootBlossom!.labelingVertex!,
-              );
-              current = rb.baseVertexMatch!.rootBlossom!.labelingVertex!;
-            }
-          }
-
-          // Build path from vertex1 toward root.
-          const pathBack: Vertex[] = [vertex1];
-          {
-            let current: Vertex = vertex1;
-            while (current.rootBlossom!.baseVertexMatch) {
-              const rb = current.rootBlossom!;
-              pathBack.push(
-                rb.baseVertex,
-                rb.baseVertexMatch!,
-                rb.baseVertexMatch!.rootBlossom!.labeledVertex!,
-                rb.baseVertexMatch!.rootBlossom!.labelingVertex!,
-              );
-              current = rb.baseVertexMatch!.rootBlossom!.labelingVertex!;
-            }
-          }
-
-          // Trim shared prefix from the back of both paths.
-          // (C++ trims while next element of each sub-path is in same rootBlossom)
+          // Trim shared prefix (C++ lines 594-606).
+          // While the second element from each end shares a rootBlossom,
+          // remove 4 from each end.
           while (
             pathFront.length >= 2 &&
             pathBack.length >= 2 &&
-            pathFront[1]!.rootBlossom === pathBack[1]!.rootBlossom
+            pathFront[1]!.rootBlossom === pathBack.at(-2)!.rootBlossom
           ) {
             pathFront.splice(0, 4);
-            pathBack.splice(0, 4);
+            pathBack.splice(-4, 4);
           }
 
-          // The combined path is: pathFront (front to back) + pathBack reversed.
-          const path: Vertex[] = [...pathFront, ...pathBack.toReversed()];
+          const path: Vertex[] = [...pathFront, ...pathBack];
 
           // Form a new blossom from this path.
           this.formBlossomFromPath(path);
 
           // After forming a new blossom, re-update tracking variables.
-          // The newly formed blossom's rootBlossom is OUTER; update minima.
-          // Find the new blossom (it will be the rootBlossom of path[0]).
           const newRb = path[0]!.rootBlossom!;
 
           // Update minOuterDualVariable for vertices in new blossom.
@@ -1020,7 +1008,18 @@ class Graph implements GraphLike {
   private formBlossomFromPath(path: Vertex[]): void {
     if (path.length < 2) return;
 
-    // All vertices in the path share the same RootBlossom (same-root case).
+    // Collect ALL unique RootBlossoms referenced by path vertices.
+    // The C++ initializeFromChildren destroys all of them.
+    const oldRbs: RootBlossom[] = [];
+    const seenRbs = new Set<RootBlossom>();
+    for (const v of path) {
+      const rb = v.rootBlossom!;
+      if (!seenRbs.has(rb)) {
+        seenRbs.add(rb);
+        oldRbs.push(rb);
+      }
+    }
+    // The base rootBlossom (carries label, base vertex, match info).
     const oldRb = path[0]!.rootBlossom!;
 
     // The path alternates between child-blossom boundary vertices.
@@ -1115,9 +1114,11 @@ class Graph implements GraphLike {
     // Update rootBlossom pointers for all descendants.
     newRb.updateRootBlossomInDescendants();
 
-    // Remove old RootBlossom from the list.
-    const oldRbIndex = this.rootBlossoms.indexOf(oldRb);
-    if (oldRbIndex !== -1) this.rootBlossoms.splice(oldRbIndex, 1);
+    // Remove ALL old RootBlossoms from the list.
+    for (const rb of oldRbs) {
+      const index = this.rootBlossoms.indexOf(rb);
+      if (index !== -1) this.rootBlossoms.splice(index, 1);
+    }
 
     // Add new RootBlossom.
     this.rootBlossoms.push(newRb);
@@ -1127,8 +1128,6 @@ class Graph implements GraphLike {
 
     // Initialize outer-outer edges for the new blossom.
     this.initializeOuterOuterEdgesForBlossom(newRb);
-
-    // Update inner-outer edges (non-OUTER vertices now have a new OUTER blossom to check).
     this.updateInnerOuterEdges(newRb);
   }
 }

--- a/src/matching/graph.ts
+++ b/src/matching/graph.ts
@@ -12,6 +12,7 @@
 import {
   ParentBlossom,
   RootBlossom,
+  getAncestorOfVertex,
   setPointersFromAncestor,
 } from './blossom.js';
 import { Label } from './types.js';
@@ -201,107 +202,28 @@ class Graph implements GraphLike {
     }
   }
 
-  // Private methods (alphabetical)
-
-  // ---------------------------------------------------------------------------
-  // addVertex helper: initialize inner-outer edges
-  // ---------------------------------------------------------------------------
-
-  private applyDualAdjustment(
-    delta: DynamicUint,
-    minOuterDual: DynamicUint,
-    minInnerDual: DynamicUint,
-    minOuterOuterResistance: DynamicUint,
-    minInnerOuterResistance: DynamicUint,
-  ): void {
-    // Apply delta to all vertices and blossoms.
-    for (const rb of this.rootBlossoms) {
-      if (rb.label === Label.OUTER) {
-        // OUTER: vertex duals decrease by delta.
-        for (
-          let v: Vertex | undefined = rb.rootChild.vertexListHead;
-          v;
-          v = v.nextVertex
-        ) {
-          v.dualVariable.subtract(delta);
-        }
-        // OUTER blossom's rootChild ParentBlossom dual increases by 2*delta.
-        if (!rb.rootChild.isVertex) {
-          (rb.rootChild as ParentBlossom).dualVariable.add(delta).add(delta);
-        }
-        // Outer-outer resistances decrease by 2*delta.
-        rb.minOuterEdgeResistance.subtract(delta).subtract(delta);
-      } else if (rb.label === Label.INNER) {
-        // INNER: vertex duals increase by delta.
-        for (
-          let v: Vertex | undefined = rb.rootChild.vertexListHead;
-          v;
-          v = v.nextVertex
-        ) {
-          v.dualVariable.add(delta);
-        }
-        // INNER blossom's rootChild ParentBlossom dual decreases by 2*delta.
-        if (!rb.rootChild.isVertex) {
-          (rb.rootChild as ParentBlossom).dualVariable
-            .subtract(delta)
-            .subtract(delta);
-        }
-      } else {
-        // FREE / ZERO: inner-outer resistances decrease by delta.
-        for (
-          let v: Vertex | undefined = rb.rootChild.vertexListHead;
-          v;
-          v = v.nextVertex
-        ) {
-          if (v.minOuterEdge !== undefined) {
-            v.minOuterEdgeResistance.subtract(delta);
-          }
-        }
-      }
-    }
-
-    // Update the tracking variables.
-    minOuterDual.subtract(delta);
-    minInnerDual.subtract(delta).subtract(delta); // inner dual changes by 2*delta
-    minOuterOuterResistance.subtract(delta).subtract(delta);
-    minInnerOuterResistance.subtract(delta);
-  }
-
   // ---------------------------------------------------------------------------
   // augmentMatching — graph.cpp:395-785
+  // Complete rewrite to faithfully port the C++ algorithm.
   // ---------------------------------------------------------------------------
 
   private augmentMatching(): boolean {
-    if (this.rootBlossoms.length === 0) return false;
-
     // -------------------------------------------------------------------------
-    // INITIALIZATION
+    // INITIALIZATION (initializeLabeling)
     // -------------------------------------------------------------------------
 
-    // Assign initial labels.
-    const minOuterDual = this.aboveMaxEdgeWeight.clone();
-    const minInnerDual = this.aboveMaxEdgeWeight.clone();
+    // minOuterDualVariable tracks the minimum dual among OUTER vertices,
+    // plus the vertex that achieves it.
+    const minOuterDualVariable = this.aboveMaxEdgeWeight.clone();
+    let minOuterDualVariableVertex: Vertex | undefined;
 
     for (const rb of this.rootBlossoms) {
+      // Reset labeling state.
       rb.labeledVertex = undefined;
       rb.labelingVertex = undefined;
       rb.minOuterEdgeResistance.copyFrom(this.aboveMaxEdgeWeight);
       for (let index = 0; index < rb.minOuterEdges.length; index++) {
         rb.minOuterEdges[index] = undefined;
-      }
-
-      if (rb.baseVertexMatch) {
-        rb.label = Label.FREE;
-      } else {
-        // Exposed vertex.
-        if (rb.baseVertex.dualVariable.isZero()) {
-          rb.label = Label.ZERO;
-        } else {
-          rb.label = Label.OUTER;
-          if (rb.baseVertex.dualVariable.lt(minOuterDual)) {
-            minOuterDual.copyFrom(rb.baseVertex.dualVariable);
-          }
-        }
       }
 
       // Reset vertex minOuterEdge tracking.
@@ -313,422 +235,643 @@ class Graph implements GraphLike {
         v.minOuterEdge = undefined;
         v.minOuterEdgeResistance.copyFrom(this.aboveMaxEdgeWeight);
       }
-    }
 
-    // Initialize inner-outer edges: for each non-OUTER blossom vertex, find
-    // cheapest edge to any OUTER vertex.
-    this.initializeInnerOuterEdges();
-
-    // Initialize outer-outer edges: for each pair of OUTER blossoms, find
-    // cheapest edge between them.
-    this.initializeOuterOuterEdges();
-
-    // Track minimum outer edge resistance across all RootBlossoms.
-    const minOuterOuterResistance = this.aboveMaxEdgeWeight.clone();
-    const minInnerOuterResistance = this.aboveMaxEdgeWeight.clone();
-
-    for (const rb of this.rootBlossoms) {
-      if (rb.label === Label.OUTER) {
-        if (rb.minOuterEdgeResistance.lt(minOuterOuterResistance)) {
-          minOuterOuterResistance.copyFrom(rb.minOuterEdgeResistance);
-        }
+      if (rb.baseVertexMatch) {
+        rb.label = Label.FREE;
       } else {
-        // FREE / ZERO: check inner-outer resistance
-        for (
-          let v: Vertex | undefined = rb.rootChild.vertexListHead;
-          v;
-          v = v.nextVertex
-        ) {
-          if (
-            v.minOuterEdge !== undefined &&
-            v.minOuterEdgeResistance.lt(minInnerOuterResistance)
-          ) {
-            minInnerOuterResistance.copyFrom(v.minOuterEdgeResistance);
+        // Exposed vertex.
+        if (rb.baseVertex.dualVariable.isZero()) {
+          rb.label = Label.ZERO;
+        } else {
+          rb.label = Label.OUTER;
+          // Track min outer dual variable vertex.
+          if (rb.baseVertex.dualVariable.lt(minOuterDualVariable)) {
+            minOuterDualVariable.copyFrom(rb.baseVertex.dualVariable);
+            minOuterDualVariableVertex = rb.baseVertex;
           }
         }
       }
     }
 
-    // Also update minInnerDual from ParentBlossoms with INNER label.
+    // If no OUTER vertices, no augmentation possible.
+    if (!minOuterDualVariableVertex) {
+      return false;
+    }
+
+    // -------------------------------------------------------------------------
+    // Initialize inner-outer edges: for each non-OUTER blossom vertex, find
+    // cheapest edge to any OUTER vertex.
+    // (initializeInnerOuterEdges)
+    // -------------------------------------------------------------------------
+    this.initializeInnerOuterEdges();
+
+    // -------------------------------------------------------------------------
+    // Initialize outer-outer edges: for each OUTER blossom, find cheapest
+    // edges to all other OUTER blossoms.
+    // (initializeOuterOuterEdges)
+    // -------------------------------------------------------------------------
+    this.initializeOuterOuterEdges();
+
+    // -------------------------------------------------------------------------
+    // Initialize minOuterOuterEdgeResistance tracking
+    // (initializeMinOuterOuterEdgeResistance)
+    // -------------------------------------------------------------------------
+    const minOuterOuterEdgeResistance = this.aboveMaxEdgeWeight.clone();
+    let minOuterOuterEdgeResistanceRootBlossom: RootBlossom | undefined;
     for (const rb of this.rootBlossoms) {
-      if (rb.label === Label.INNER && !rb.rootChild.isVertex) {
-        const pb = rb.rootChild as ParentBlossom;
-        if (pb.dualVariable.lt(minInnerDual)) {
-          minInnerDual.copyFrom(pb.dualVariable);
-        }
+      if (
+        rb.label === Label.OUTER &&
+        rb.minOuterEdgeResistance.lt(minOuterOuterEdgeResistance)
+      ) {
+        minOuterOuterEdgeResistance.copyFrom(rb.minOuterEdgeResistance);
+        minOuterOuterEdgeResistanceRootBlossom = rb;
       }
     }
+
+    // -------------------------------------------------------------------------
+    // Initialize minInnerDualVariable tracking
+    // -------------------------------------------------------------------------
+    const minInnerDualVariable = this.aboveMaxEdgeWeight.clone();
+    let minInnerDualVariableBlossom: ParentBlossom | undefined;
+    this.initializeMinInnerDualVariable(
+      (blossom) => {
+        minInnerDualVariableBlossom = blossom;
+      },
+      (value) => {
+        minInnerDualVariable.copyFrom(value);
+      },
+    );
 
     // -------------------------------------------------------------------------
     // MAIN LOOP
     // -------------------------------------------------------------------------
 
     for (;;) {
-      // Check if there are any OUTER vertices at all.
-      const hasOuter = this.rootBlossoms.some((rb) => rb.label === Label.OUTER);
-      if (!hasOuter) return false;
+      // Compute minInnerOuterEdgeResistance FRESH each iteration (C++ does
+      // this at top of loop every iteration).
+      const minInnerOuterEdgeResistance = this.aboveMaxEdgeWeight.clone();
+      let minInnerOuterEdgeResistanceVertex: Vertex | undefined;
+      for (const vertex of this.vertices) {
+        if (
+          (vertex.rootBlossom!.label === Label.FREE ||
+            vertex.rootBlossom!.label === Label.ZERO) &&
+          vertex.minOuterEdgeResistance.lt(minInnerOuterEdgeResistance)
+        ) {
+          minInnerOuterEdgeResistance.copyFrom(vertex.minOuterEdgeResistance);
+          minInnerOuterEdgeResistanceVertex = vertex;
+        }
+      }
 
-      // Compute the dual adjustment delta.
-      // delta = min(
-      //   minOuterDual,                    // OUTER dual → 0
-      //   minInnerOuterResistance,         // FREE/ZERO↔OUTER edge tight
-      //   floor(minOuterOuterResistance/2),// OUTER↔OUTER edge tight
-      //   floor(minInnerDual/2)            // INNER blossom dual → 0
+      // Compute dual adjustment:
+      // dualAdjustment = min(
+      //   minOuterDualVariable,
+      //   minInnerOuterEdgeResistance,
+      //   minOuterOuterEdgeResistance >> 1,
+      //   minInnerDualVariable >> 1
       // )
+      const halfOuterOuter = minOuterOuterEdgeResistance.clone().shiftRight(1);
+      const halfInnerDual = minInnerDualVariable.clone().shiftRight(1);
 
-      const halfOuterOuter = minOuterOuterResistance.clone().shiftRight(1);
-      const halfInnerDual = minInnerDual.clone().shiftRight(1);
-
-      const delta = minOuterDual.clone();
-      if (minInnerOuterResistance.lt(delta))
-        delta.copyFrom(minInnerOuterResistance);
-      if (halfOuterOuter.lt(delta)) delta.copyFrom(halfOuterOuter);
-      if (halfInnerDual.lt(delta)) delta.copyFrom(halfInnerDual);
-
-      if (delta.isZero() && minOuterDual.isZero()) {
-        // An OUTER vertex hit 0 dual — augment to source.
-        return this.augmentFromZeroOuter();
+      const dualAdjustment = minOuterDualVariable.clone();
+      if (minInnerOuterEdgeResistance.lt(dualAdjustment)) {
+        dualAdjustment.copyFrom(minInnerOuterEdgeResistance);
+      }
+      if (halfOuterOuter.lt(dualAdjustment)) {
+        dualAdjustment.copyFrom(halfOuterOuter);
+      }
+      if (halfInnerDual.lt(dualAdjustment)) {
+        dualAdjustment.copyFrom(halfInnerDual);
       }
 
-      // Apply dual adjustment.
-      this.applyDualAdjustment(
-        delta,
-        minOuterDual,
-        minInnerDual,
-        minOuterOuterResistance,
-        minInnerOuterResistance,
-      );
+      // Apply dual adjustment (per-vertex, like C++).
+      if (!dualAdjustment.isZero()) {
+        const twiceAdjustment = dualAdjustment.clone().shiftLeft(1);
 
-      // Check which limit was reached.
+        // Update tracking variables.
+        minOuterDualVariable.subtract(dualAdjustment);
+        minInnerOuterEdgeResistance.subtract(dualAdjustment);
+        minOuterOuterEdgeResistance.subtract(twiceAdjustment);
+        minInnerDualVariable.subtract(twiceAdjustment);
 
-      // Case 1: OUTER vertex dual → 0
-      if (minOuterDual.isZero()) {
-        return this.augmentFromZeroOuter();
+        // Per-vertex adjustment (C++ iterates all vertices).
+        for (const vertex of this.vertices) {
+          const rootBlossom = vertex.rootBlossom!;
+          const label = rootBlossom.label;
+
+          if (label === Label.OUTER) {
+            vertex.dualVariable.subtract(dualAdjustment);
+          } else if (label === Label.INNER) {
+            vertex.dualVariable.add(dualAdjustment);
+          } else if (
+            vertex.minOuterEdgeResistance.lt(this.aboveMaxEdgeWeight)
+              ? true
+              : false
+          ) {
+            // FREE or ZERO with a known min outer edge resistance:
+            // check if it's not aboveMaxEdgeWeight
+            vertex.minOuterEdgeResistance.subtract(dualAdjustment);
+          }
+
+          // Extra work done once per rootBlossom (when we're at the base vertex).
+          if (rootBlossom.baseVertex === vertex) {
+            if (label === Label.OUTER) {
+              if (
+                rootBlossom.minOuterEdgeResistance.lt(this.aboveMaxEdgeWeight)
+              ) {
+                rootBlossom.minOuterEdgeResistance.subtract(twiceAdjustment);
+              }
+              if (!rootBlossom.rootChild.isVertex) {
+                (rootBlossom.rootChild as ParentBlossom).dualVariable.add(
+                  twiceAdjustment,
+                );
+              }
+            } else if (
+              label === Label.INNER &&
+              !rootBlossom.rootChild.isVertex
+            ) {
+              (rootBlossom.rootChild as ParentBlossom).dualVariable.subtract(
+                twiceAdjustment,
+              );
+            }
+          }
+        }
       }
 
-      // Case 2/4: tight inner-outer edge
-      if (minInnerOuterResistance.isZero()) {
-        const result = this.handleTightInnerOuterEdge(
-          minOuterDual,
-          minInnerDual,
-          minOuterOuterResistance,
-          minInnerOuterResistance,
-        );
-        if (result !== undefined) return result;
-        // Continue loop — recalculate minima.
-        this.recalculateMinima(
-          minOuterDual,
-          minInnerDual,
-          minOuterOuterResistance,
-          minInnerOuterResistance,
-        );
-        continue;
-      }
-
-      // Case 3: OUTER↔OUTER edge tight
-      if (minOuterOuterResistance.isZero()) {
-        const result = this.handleTightOuterOuterEdge(
-          minOuterDual,
-          minInnerDual,
-          minOuterOuterResistance,
-          minInnerOuterResistance,
-        );
-        if (result !== undefined) return result;
-        this.recalculateMinima(
-          minOuterDual,
-          minInnerDual,
-          minOuterOuterResistance,
-          minInnerOuterResistance,
-        );
-        continue;
-      }
-
-      // Case 5: INNER blossom dual → 0
-      if (minInnerDual.isZero()) {
-        this.dissolveZeroDualInnerBlossom();
-        this.recalculateMinima(
-          minOuterDual,
-          minInnerDual,
-          minOuterOuterResistance,
-          minInnerOuterResistance,
-        );
-        continue;
-      }
-
-      // No more progress possible.
-      return false;
-    }
-  }
-
-  // ---------------------------------------------------------------------------
-  // Case 1: augment from OUTER vertex with zero dual
-  // ---------------------------------------------------------------------------
-
-  private augmentFromZeroOuter(): boolean {
-    // Find an OUTER vertex with zero dual.
-    for (const rb of this.rootBlossoms) {
-      if (rb.label === Label.OUTER && rb.baseVertex.dualVariable.isZero()) {
-        augmentToSource(rb.baseVertex);
+      // -----------------------------------------------------------------------
+      // CASE 1: OUTER vertex dual → 0
+      // -----------------------------------------------------------------------
+      if (minOuterDualVariable.isZero()) {
+        augmentToSource(minOuterDualVariableVertex);
         return true;
       }
-    }
-    return false;
-  }
 
-  // ---------------------------------------------------------------------------
-  // Blossom formation (Case 3, same root)
-  // Ported from graph.cpp blossom-forming logic
-  // ---------------------------------------------------------------------------
+      // -----------------------------------------------------------------------
+      // CASE 2: ZERO↔OUTER tight edge
+      // -----------------------------------------------------------------------
+      if (
+        minInnerOuterEdgeResistance.isZero() &&
+        minInnerOuterEdgeResistanceVertex !== undefined &&
+        minInnerOuterEdgeResistanceVertex.rootBlossom!.label === Label.ZERO
+      ) {
+        const zv = minInnerOuterEdgeResistanceVertex;
+        augmentToSource(zv.minOuterEdge, zv);
+        augmentToSource(zv, zv.minOuterEdge);
+        return true;
+      }
 
-  private buildPathToRoot(v: Vertex, rb: RootBlossom): Vertex[] {
-    const path: Vertex[] = [];
-    let current: Vertex | undefined = v;
-    while (current && current.rootBlossom !== rb) {
-      path.push(current);
-      current = current.rootBlossom?.labelingVertex;
-    }
-    if (current) path.push(current);
-    return path;
-  }
+      // -----------------------------------------------------------------------
+      // CASE 3: OUTER↔OUTER tight edge
+      // -----------------------------------------------------------------------
+      else if (minOuterOuterEdgeResistance.isZero()) {
+        // Find the two vertices with zero resistance using minOuterEdges.
+        // The C++ finds another OUTER rootBlossom != minOuterOuterEdgeResistanceRootBlossom
+        // such that the edge between them is tight.
+        let vertex0: Vertex | undefined;
+        let vertex1: Vertex | undefined;
 
-  // ---------------------------------------------------------------------------
-  // Case 5: dissolve INNER blossom with zero dual
-  // ---------------------------------------------------------------------------
+        const rb0 = minOuterOuterEdgeResistanceRootBlossom;
+        if (rb0 !== undefined) {
+          for (const rb1 of this.rootBlossoms) {
+            if (rb1.label !== Label.OUTER || rb1 === rb0) continue;
+            // rb0 stores in minOuterEdges[rb1.baseVertex.vertexIndex] the vertex
+            // in rb0 closest to rb1.
+            const v0 = rb0.minOuterEdges[rb1.baseVertex.vertexIndex];
+            // rb1 stores in minOuterEdges[rb0.baseVertex.vertexIndex] the vertex
+            // in rb1 closest to rb0.
+            const v1 = rb1.minOuterEdges[rb0.baseVertex.vertexIndex];
+            if (v0 !== undefined && v1 !== undefined) {
+              const r = resistance(v0, v1);
+              if (r.isZero()) {
+                vertex0 = v0;
+                vertex1 = v1;
+                break;
+              }
+            }
+          }
+        }
 
-  private dissolveZeroDualInnerBlossom(): void {
-    const snapshot = [...this.rootBlossoms];
-    for (const rb of snapshot) {
-      if (rb.label !== Label.INNER) continue;
-      if (rb.rootChild.isVertex) continue;
-      const pb = rb.rootChild as ParentBlossom;
-      if (!pb.dualVariable.isZero()) continue;
+        // If not found via tracked references, do a brute-force scan as fallback.
+        if (vertex0 === undefined || vertex1 === undefined) {
+          outerSearch: for (const rb1 of this.rootBlossoms) {
+            if (rb1.label !== Label.OUTER) continue;
+            for (const rb2 of this.rootBlossoms) {
+              if (rb2 === rb1 || rb2.label !== Label.OUTER) continue;
+              for (
+                let v1: Vertex | undefined = rb1.rootChild.vertexListHead;
+                v1;
+                v1 = v1.nextVertex
+              ) {
+                for (
+                  let v2: Vertex | undefined = rb2.rootChild.vertexListHead;
+                  v2;
+                  v2 = v2.nextVertex
+                ) {
+                  if (v1.vertexIndex === v2.vertexIndex) continue;
+                  const r = resistance(v1, v2);
+                  if (r.isZero()) {
+                    vertex0 = v1;
+                    vertex1 = v2;
+                    break outerSearch;
+                  }
+                }
+              }
+            }
+          }
+        }
 
-      // Dissolve this blossom: create individual RootBlossoms for each child.
-      const pbIndex = this.parentBlossoms.indexOf(pb);
-      if (pbIndex !== -1) this.parentBlossoms.splice(pbIndex, 1);
+        if (vertex0 === undefined || vertex1 === undefined) {
+          // No tight edge found — shouldn't happen but guard anyway.
+          return false;
+        }
 
-      const rbIndex = this.rootBlossoms.indexOf(rb);
-      if (rbIndex !== -1) this.rootBlossoms.splice(rbIndex, 1);
+        const rbA = vertex0.rootBlossom!;
+        const rbB = vertex1.rootBlossom!;
 
-      // Walk the blossom's children and create new RootBlossoms.
-      let child: Blossom | undefined = pb.subblossom;
-      let isOnLabelingPath = true;
-      do {
-        const baseV = isOnLabelingPath
-          ? (child!.vertexToNextSiblingBlossom ?? child!.vertexListHead)
-          : child!.vertexListHead;
+        if (rbA === rbB) {
+          // SAME ROOT → form new blossom.
+          // Build path from vertex0 and vertex1 back to the exposed root,
+          // following the alternating tree structure.
+          // C++ path format: [vertex0, ..., vertex1] with alternating
+          // labelingVertex→labeledVertex→baseVertex→baseVertexMatch links.
 
-        const newRb = new RootBlossom(child!, baseV, undefined, this);
-        newRb.label = isOnLabelingPath ? Label.INNER : Label.FREE;
-        child!.parentBlossom = undefined;
+          // Build path from vertex0 toward root.
+          const pathFront: Vertex[] = [vertex0];
+          {
+            let current: Vertex = vertex0;
+            while (current.rootBlossom!.baseVertexMatch) {
+              const rb = current.rootBlossom!;
+              pathFront.push(
+                rb.baseVertex,
+                rb.baseVertexMatch!,
+                rb.baseVertexMatch!.rootBlossom!.labeledVertex!,
+                rb.baseVertexMatch!.rootBlossom!.labelingVertex!,
+              );
+              current = rb.baseVertexMatch!.rootBlossom!.labelingVertex!;
+            }
+          }
 
+          // Build path from vertex1 toward root.
+          const pathBack: Vertex[] = [vertex1];
+          {
+            let current: Vertex = vertex1;
+            while (current.rootBlossom!.baseVertexMatch) {
+              const rb = current.rootBlossom!;
+              pathBack.push(
+                rb.baseVertex,
+                rb.baseVertexMatch!,
+                rb.baseVertexMatch!.rootBlossom!.labeledVertex!,
+                rb.baseVertexMatch!.rootBlossom!.labelingVertex!,
+              );
+              current = rb.baseVertexMatch!.rootBlossom!.labelingVertex!;
+            }
+          }
+
+          // Trim shared prefix from the back of both paths.
+          // (C++ trims while next element of each sub-path is in same rootBlossom)
+          while (
+            pathFront.length >= 2 &&
+            pathBack.length >= 2 &&
+            pathFront[1]!.rootBlossom === pathBack[1]!.rootBlossom
+          ) {
+            pathFront.splice(0, 4);
+            pathBack.splice(0, 4);
+          }
+
+          // The combined path is: pathFront (front to back) + pathBack reversed.
+          const path: Vertex[] = [...pathFront, ...pathBack.toReversed()];
+
+          // Form a new blossom from this path.
+          this.formBlossomFromPath(path);
+
+          // After forming a new blossom, re-update tracking variables.
+          // The newly formed blossom's rootBlossom is OUTER; update minima.
+          // Find the new blossom (it will be the rootBlossom of path[0]).
+          const newRb = path[0]!.rootBlossom!;
+
+          // Update minOuterDualVariable for vertices in new blossom.
+          for (
+            let v: Vertex | undefined = newRb.rootChild.vertexListHead;
+            v;
+            v = v.nextVertex
+          ) {
+            if (v.dualVariable.lt(minOuterDualVariable)) {
+              minOuterDualVariable.copyFrom(v.dualVariable);
+              minOuterDualVariableVertex = v;
+            }
+          }
+
+          // Re-initialize minOuterOuterEdgeResistance.
+          minOuterOuterEdgeResistance.copyFrom(this.aboveMaxEdgeWeight);
+          minOuterOuterEdgeResistanceRootBlossom = undefined;
+          for (const rb of this.rootBlossoms) {
+            if (
+              rb.label === Label.OUTER &&
+              rb.minOuterEdgeResistance.lt(minOuterOuterEdgeResistance)
+            ) {
+              minOuterOuterEdgeResistance.copyFrom(rb.minOuterEdgeResistance);
+              minOuterOuterEdgeResistanceRootBlossom = rb;
+            }
+          }
+
+          // Re-initialize minInnerDualVariable.
+          minInnerDualVariable.copyFrom(this.aboveMaxEdgeWeight);
+          minInnerDualVariableBlossom = undefined;
+          this.initializeMinInnerDualVariable(
+            (blossom) => {
+              minInnerDualVariableBlossom = blossom;
+            },
+            (value) => {
+              minInnerDualVariable.copyFrom(value);
+            },
+          );
+
+          // Continue the main loop.
+          continue;
+        } else {
+          // DIFFERENT ROOTS → augment.
+          augmentToSource(vertex0, vertex1);
+          augmentToSource(vertex1, vertex0);
+          return true;
+        }
+      }
+
+      // -----------------------------------------------------------------------
+      // CASE 4: FREE↔OUTER tight edge (minInnerOuterEdgeResistance == 0,
+      //         but the vertex is FREE not ZERO)
+      // -----------------------------------------------------------------------
+      else if (minInnerOuterEdgeResistance.isZero()) {
+        const freeVertex = minInnerOuterEdgeResistanceVertex;
+        if (freeVertex === undefined) {
+          return false;
+        }
+
+        const freeRb = freeVertex.rootBlossom!;
+        // The free vertex becomes INNER.
+        freeRb.label = Label.INNER;
+        freeRb.labelingVertex = freeVertex.minOuterEdge;
+        freeRb.labeledVertex = freeVertex;
+
+        // The match of the base of freeRb becomes OUTER.
+        const matchedRb = freeRb.baseVertexMatch!.rootBlossom!;
+        matchedRb.label = Label.OUTER;
+
+        // Update inner-outer edges for the newly OUTER blossom.
+        this.updateInnerOuterEdges(matchedRb);
+
+        // Initialize outer-outer edges for the newly OUTER blossom.
+        this.initializeOuterOuterEdgesForBlossom(matchedRb);
+
+        // Update minOuterDualVariable for vertices in new OUTER blossom.
         for (
-          let v: Vertex | undefined = child!.vertexListHead;
+          let v: Vertex | undefined = matchedRb.rootChild.vertexListHead;
           v;
           v = v.nextVertex
         ) {
-          v.rootBlossom = newRb;
+          if (v.dualVariable.lt(minOuterDualVariable)) {
+            minOuterDualVariable.copyFrom(v.dualVariable);
+            minOuterDualVariableVertex = v;
+          }
         }
 
-        this.rootBlossoms.push(newRb);
-        this.rootBlossomMinOuterEdgeResistances.push(
-          this.aboveMaxEdgeWeight.clone(),
+        // Update minOuterOuterEdgeResistance.
+        if (matchedRb.minOuterEdgeResistance.lt(minOuterOuterEdgeResistance)) {
+          minOuterOuterEdgeResistance.copyFrom(
+            matchedRb.minOuterEdgeResistance,
+          );
+          minOuterOuterEdgeResistanceRootBlossom = matchedRb;
+        }
+
+        // Update minInnerDualVariable for the newly INNER blossom.
+        if (!freeRb.rootChild.isVertex) {
+          const pb = freeRb.rootChild as ParentBlossom;
+          if (pb.dualVariable.lt(minInnerDualVariable)) {
+            minInnerDualVariable.copyFrom(pb.dualVariable);
+            minInnerDualVariableBlossom = pb;
+          }
+        }
+
+        // Continue main loop.
+        continue;
+      }
+
+      // -----------------------------------------------------------------------
+      // CASE 5: INNER blossom dual → 0 (dissolve)
+      // -----------------------------------------------------------------------
+      else if (minInnerDualVariable.isZero()) {
+        const pb = minInnerDualVariableBlossom;
+        if (pb === undefined) {
+          return false;
+        }
+
+        const dissolvedRb = pb.rootBlossom!;
+
+        // Hide the dissolved RootBlossom from rootBlossoms.
+        const rbIndex = this.rootBlossoms.indexOf(dissolvedRb);
+        if (rbIndex !== -1) this.rootBlossoms.splice(rbIndex, 1);
+
+        // The root child of the dissolved blossom is pb.
+        // In C++: rootVertex = dissolvedRb.baseVertex
+        //         rootChild = getAncestorOfVertex(rootVertex, pb)
+        const rootVertex = dissolvedRb.baseVertex;
+        const rootChild: Blossom = getAncestorOfVertex(rootVertex, pb);
+
+        // The connect child is the child of pb containing the labeled vertex.
+        const connectChild: Blossom = getAncestorOfVertex(
+          dissolvedRb.labeledVertex!,
+          pb,
         );
 
-        child = child!.nextBlossom;
-        isOnLabelingPath = !isOnLabelingPath;
-      } while (child !== pb.subblossom && child !== undefined);
-    }
-  }
+        // Determine if the path from rootChild to connectChild goes forward
+        // (i.e., via nextBlossom links). Walk forward from rootChild;
+        // if we reach connectChild, connectForward=true; otherwise false.
+        let connectForward: boolean;
+        {
+          let found = false;
+          for (
+            let current: Blossom | undefined = rootChild.nextBlossom;
+            current !== rootChild && current !== undefined;
+            current = current.nextBlossom
+          ) {
+            if (current === connectChild) {
+              found = true;
+              break;
+            }
+          }
+          connectForward = rootChild === connectChild || found;
+        }
 
-  private formNewBlossom(v1: Vertex, v2: Vertex, rb: RootBlossom): void {
-    // Build the path from v1 to root and from v2 to root, find LCA.
-    const path1 = this.buildPathToRoot(v1, rb);
-    const path2 = this.buildPathToRoot(v2, rb);
+        // Walk the circular child list, assigning labels.
+        // C++ loop: iterate from rootChild going forward (nextBlossom),
+        // wrapping around until we return to rootChild.
+        let isFree = false;
+        let linksToNext = false; // tracks edge direction alternation
 
-    // Find LCA.
-    const inPath1 = new Set(path1.map((p) => p.vertexIndex));
-    let lcaIndex = -1;
-    for (const pv of path2) {
-      if (inPath1.has(pv.vertexIndex)) {
-        lcaIndex = pv.vertexIndex;
-        break;
-      }
-    }
+        // Find the actual previous of rootChild by walking the cycle.
+        let previousChild: Blossom;
+        {
+          let current: Blossom = rootChild;
+          while (
+            current.nextBlossom !== rootChild &&
+            current.nextBlossom !== undefined
+          ) {
+            current = current.nextBlossom;
+          }
+          previousChild = current;
+        }
 
-    if (lcaIndex === -1) {
-      // No common ancestor found — treat as cross-edge, augment.
-      augmentToSource(v1, v2);
-      augmentToSource(v2, v1);
-      return;
-    }
+        let currentChild: Blossom = rootChild;
+        let nextChild: Blossom | undefined;
+        const newRootBlossoms: RootBlossom[] = [];
 
-    const lcaInPath1 = path1.findIndex((p) => p.vertexIndex === lcaIndex);
-    const lcaInPath2 = path2.findIndex((p) => p.vertexIndex === lcaIndex);
+        do {
+          nextChild = currentChild.nextBlossom;
 
-    const cyclePart1 = path1.slice(0, lcaInPath1);
-    const cyclePart2 = path2.slice(0, lcaInPath2).toReversed();
-    const lcaVertex = this.vertices[lcaIndex]!;
+          // C++ logic for setting isFree: if we hit connectChild going
+          // in the non-connectForward direction, isFree becomes false.
+          if (currentChild === connectChild && !connectForward) {
+            isFree = false;
+          }
 
-    // Create a new ParentBlossom that represents this cycle.
-    const cycleVertices = [v1, ...cyclePart1, lcaVertex, ...cyclePart2, v2];
+          // Determine label for this child.
+          // The rootChild itself is always INNER (it's the base vertex side).
+          // After that, labels alternate: for the path going toward connectChild,
+          // we get INNER for even steps, OUTER for odd steps.
+          // Children on the other side are FREE.
+          const label: Label = isFree
+            ? Label.FREE
+            : linksToNext !== connectForward || currentChild === rootChild
+              ? Label.INNER
+              : Label.OUTER;
 
-    const newDual = this.aboveMaxEdgeWeight.clone().and(0);
-    const newParent = new ParentBlossom(
-      newDual,
-      rb,
-      rb.rootChild,
-      rb.rootChild.vertexListHead,
-      rb.rootChild.vertexListTail,
-    );
+          // Determine baseVertex and baseVertexMatch for the new RootBlossom.
+          let newBaseVertex: Vertex;
+          let newBaseVertexMatch: Vertex | undefined;
+          let newLabelingVertex: Vertex | undefined;
+          let newLabeledVertex: Vertex | undefined;
 
-    // Connect all vertices in the cycle to the new parent.
-    for (const cv of cycleVertices) {
-      cv.parentBlossom = newParent;
-    }
-
-    this.parentBlossoms.push(newParent);
-    rb.rootChild = newParent;
-  }
-
-  // ---------------------------------------------------------------------------
-  // Case 2/4: tight inner-outer edge
-  // ---------------------------------------------------------------------------
-
-  private handleTightInnerOuterEdge(
-    minOuterDual: DynamicUint,
-    minInnerDual: DynamicUint,
-    minOuterOuterResistance: DynamicUint,
-    minInnerOuterResistance: DynamicUint,
-  ): boolean | undefined {
-    for (const rb of this.rootBlossoms) {
-      if (rb.label === Label.OUTER) continue;
-
-      for (
-        let v: Vertex | undefined = rb.rootChild.vertexListHead;
-        v;
-        v = v.nextVertex
-      ) {
-        if (v.minOuterEdge !== undefined && v.minOuterEdgeResistance.isZero()) {
-          const outerV = v.minOuterEdge;
-
-          if (rb.label === Label.ZERO) {
-            // Case 2: ZERO vertex — tight edge, augment both directions.
-            augmentToSource(v, outerV);
-            augmentToSource(outerV, v);
-            return true;
+          if (currentChild === rootChild) {
+            newBaseVertex = rootVertex;
+            newBaseVertexMatch = dissolvedRb.baseVertexMatch;
+          } else if (linksToNext) {
+            newBaseVertex = currentChild.vertexToNextSiblingBlossom!;
+            newBaseVertexMatch = nextChild?.vertexToPreviousSiblingBlossom;
           } else {
-            // Case 4: FREE vertex — label it INNER, label its match OUTER.
-            rb.label = Label.INNER;
-            rb.labeledVertex = v;
-            rb.labelingVertex = outerV;
+            newBaseVertex = currentChild.vertexToPreviousSiblingBlossom!;
+            newBaseVertexMatch = previousChild?.vertexToNextSiblingBlossom;
+          }
 
-            // The match of the base of rb becomes OUTER.
-            if (rb.baseVertexMatch) {
-              const matchRb = rb.baseVertexMatch.rootBlossom!;
-              if (matchRb.label === Label.FREE) {
-                matchRb.label = Label.OUTER;
-                matchRb.labeledVertex = rb.baseVertexMatch;
-                matchRb.labelingVertex = rb.baseVertex;
+          if (currentChild === connectChild) {
+            newLabelingVertex = dissolvedRb.labelingVertex;
+            newLabeledVertex = dissolvedRb.labeledVertex;
+          } else if (label === Label.INNER) {
+            if (connectForward) {
+              newLabelingVertex = nextChild?.vertexToPreviousSiblingBlossom;
+              newLabeledVertex = currentChild.vertexToNextSiblingBlossom;
+            } else {
+              newLabelingVertex = previousChild?.vertexToNextSiblingBlossom;
+              newLabeledVertex = currentChild.vertexToPreviousSiblingBlossom;
+            }
+          }
 
-                // Update minOuterDual.
-                if (
-                  minOuterDual.compareTo(this.aboveMaxEdgeWeight) === 0 ||
-                  rb.baseVertexMatch.dualVariable.lt(minOuterDual)
-                ) {
-                  minOuterDual.copyFrom(rb.baseVertexMatch.dualVariable);
-                }
+          // Create new RootBlossom for this child.
+          const newRb = new RootBlossom(
+            currentChild,
+            newBaseVertex,
+            newBaseVertexMatch,
+            this,
+          );
+          newRb.label = label;
+          newRb.labelingVertex = newLabelingVertex;
+          newRb.labeledVertex = newLabeledVertex;
 
-                // Re-initialize inner-outer edges for the new OUTER blossom.
-                this.updateInnerOuterEdgesForNewOuter(
-                  matchRb,
-                  minInnerOuterResistance,
-                );
+          // Disconnect child from the old ParentBlossom.
+          currentChild.parentBlossom = undefined;
 
-                // Re-initialize outer-outer edges for the new OUTER blossom.
-                this.updateOuterOuterEdgesForNewOuter(
-                  matchRb,
-                  minOuterOuterResistance,
-                );
+          // Update rootBlossom pointer for all vertices in this child.
+          for (
+            let v: Vertex | undefined = currentChild.vertexListHead;
+            v;
+            v = v.nextVertex
+          ) {
+            v.rootBlossom = newRb;
+          }
+
+          // Set up minOuterEdges array (size = number of vertices).
+          while (newRb.minOuterEdges.length < this.vertices.length) {
+            newRb.minOuterEdges.push(undefined);
+          }
+
+          this.rootBlossoms.push(newRb);
+          this.rootBlossomMinOuterEdgeResistances.push(
+            this.aboveMaxEdgeWeight.clone(),
+          );
+          newRootBlossoms.push(newRb);
+
+          // For OUTER children: update inner-outer and outer-outer edges,
+          // and update minOuterDualVariable.
+          if (label === Label.OUTER) {
+            this.updateInnerOuterEdges(newRb);
+            this.initializeOuterOuterEdgesForBlossom(newRb);
+            for (
+              let v: Vertex | undefined = currentChild.vertexListHead;
+              v;
+              v = v.nextVertex
+            ) {
+              if (v.dualVariable.lt(minOuterDualVariable)) {
+                minOuterDualVariable.copyFrom(v.dualVariable);
+                minOuterDualVariableVertex = v;
               }
             }
-
-            void minInnerDual;
-            return undefined; // continue loop
-          }
-        }
-      }
-    }
-    return undefined;
-  }
-
-  // ---------------------------------------------------------------------------
-  // Case 3: tight outer-outer edge
-  // ---------------------------------------------------------------------------
-
-  private handleTightOuterOuterEdge(
-    minOuterDual: DynamicUint,
-    minInnerDual: DynamicUint,
-    minOuterOuterResistance: DynamicUint,
-    minInnerOuterResistance: DynamicUint,
-  ): boolean | undefined {
-    // Find the OUTER blossom with zero minOuterEdgeResistance.
-    for (const rb1 of this.rootBlossoms) {
-      if (rb1.label !== Label.OUTER) continue;
-      if (!rb1.minOuterEdgeResistance.isZero()) continue;
-
-      let bestV1: Vertex | undefined;
-      let bestV2: Vertex | undefined;
-
-      outer: for (const rb2 of this.rootBlossoms) {
-        if (rb2 === rb1 || rb2.label !== Label.OUTER) continue;
-        for (
-          let v1: Vertex | undefined = rb1.rootChild.vertexListHead;
-          v1;
-          v1 = v1.nextVertex
-        ) {
-          for (
-            let v2: Vertex | undefined = rb2.rootChild.vertexListHead;
-            v2;
-            v2 = v2.nextVertex
-          ) {
-            if (v1.vertexIndex === v2.vertexIndex) continue;
-            const r = resistance(v1, v2);
-            if (r.isZero()) {
-              bestV1 = v1;
-              bestV2 = v2;
-              break outer;
+            if (newRb.minOuterEdgeResistance.lt(minOuterOuterEdgeResistance)) {
+              minOuterOuterEdgeResistance.copyFrom(
+                newRb.minOuterEdgeResistance,
+              );
+              minOuterOuterEdgeResistanceRootBlossom = newRb;
             }
           }
-        }
-      }
 
-      if (bestV1 === undefined || bestV2 === undefined) continue;
+          // Update isFree state after processing this child.
+          if (currentChild === (connectForward ? connectChild : rootChild)) {
+            isFree = true;
+          }
 
-      const rb2 = bestV2.rootBlossom!;
+          linksToNext = !linksToNext;
+          previousChild = currentChild;
+          currentChild = nextChild!;
+        } while (currentChild !== rootChild);
 
-      if (rb1 === rb2) {
-        // Same root — form a new blossom.
-        this.formNewBlossom(bestV1, bestV2, rb1);
-        void minOuterDual;
-        void minInnerDual;
-        void minOuterOuterResistance;
-        void minInnerOuterResistance;
-        return undefined;
+        // Destroy the old ParentBlossom and RootBlossom.
+        const pbIndex = this.parentBlossoms.indexOf(pb);
+        if (pbIndex !== -1) this.parentBlossoms.splice(pbIndex, 1);
+
+        // Re-initialize minInnerDualVariable after dissolution.
+        minInnerDualVariable.copyFrom(this.aboveMaxEdgeWeight);
+        minInnerDualVariableBlossom = undefined;
+        this.initializeMinInnerDualVariable(
+          (blossom) => {
+            minInnerDualVariableBlossom = blossom;
+          },
+          (value) => {
+            minInnerDualVariable.copyFrom(value);
+          },
+        );
+
+        // Continue main loop.
+        continue;
       } else {
-        // Different roots — augment.
-        augmentToSource(bestV1, bestV2);
-        augmentToSource(bestV2, bestV1);
-        return true;
+        // No more progress possible.
+        return false;
       }
     }
-    return undefined;
   }
 
   // ---------------------------------------------------------------------------
   // Initialization helpers
   // ---------------------------------------------------------------------------
 
+  /**
+   * For each non-OUTER blossom vertex, find cheapest edge to any OUTER vertex.
+   */
   private initializeInnerOuterEdges(): void {
     for (const rb of this.rootBlossoms) {
       if (rb.label === Label.OUTER) continue;
@@ -759,68 +902,40 @@ class Graph implements GraphLike {
     }
   }
 
+  /**
+   * For each pair of OUTER blossoms, find cheapest edge between them.
+   * Updates minOuterEdges and minOuterEdgeResistance for each OUTER blossom.
+   */
   private initializeOuterOuterEdges(): void {
     for (const rb of this.rootBlossoms) {
       if (rb.label !== Label.OUTER) continue;
       for (const otherRb of this.rootBlossoms) {
         if (otherRb === rb) continue;
         if (otherRb.label !== Label.OUTER) continue;
-        this.updateOuterOuterEdge(rb, otherRb);
+        this.updateOuterOuterEdgePair(rb, otherRb);
       }
     }
   }
 
-  // ---------------------------------------------------------------------------
-  // Recalculate minima after structural changes
-  // ---------------------------------------------------------------------------
-
-  private recalculateMinima(
-    minOuterDual: DynamicUint,
-    minInnerDual: DynamicUint,
-    minOuterOuterResistance: DynamicUint,
-    minInnerOuterResistance: DynamicUint,
-  ): void {
-    minOuterDual.copyFrom(this.aboveMaxEdgeWeight);
-    minInnerDual.copyFrom(this.aboveMaxEdgeWeight);
-    minOuterOuterResistance.copyFrom(this.aboveMaxEdgeWeight);
-    minInnerOuterResistance.copyFrom(this.aboveMaxEdgeWeight);
-
+  /**
+   * For a newly OUTER blossom, initialize its outer-outer edges against all
+   * other OUTER blossoms (single-blossom variant, C++ initializeOuterOuterEdges(blossom)).
+   */
+  private initializeOuterOuterEdgesForBlossom(newOuterRb: RootBlossom): void {
     for (const rb of this.rootBlossoms) {
-      if (rb.label === Label.OUTER) {
-        if (rb.baseVertex.dualVariable.lt(minOuterDual)) {
-          minOuterDual.copyFrom(rb.baseVertex.dualVariable);
-        }
-        if (rb.minOuterEdgeResistance.lt(minOuterOuterResistance)) {
-          minOuterOuterResistance.copyFrom(rb.minOuterEdgeResistance);
-        }
-      } else if (rb.label === Label.INNER) {
-        if (!rb.rootChild.isVertex) {
-          const pb = rb.rootChild as ParentBlossom;
-          if (pb.dualVariable.lt(minInnerDual)) {
-            minInnerDual.copyFrom(pb.dualVariable);
-          }
-        }
-      } else {
-        for (
-          let v: Vertex | undefined = rb.rootChild.vertexListHead;
-          v;
-          v = v.nextVertex
-        ) {
-          if (
-            v.minOuterEdge !== undefined &&
-            v.minOuterEdgeResistance.lt(minInnerOuterResistance)
-          ) {
-            minInnerOuterResistance.copyFrom(v.minOuterEdgeResistance);
-          }
-        }
-      }
+      if (rb === newOuterRb || rb.label !== Label.OUTER) continue;
+      this.updateOuterOuterEdgePair(newOuterRb, rb);
+      this.updateOuterOuterEdgePair(rb, newOuterRb);
     }
   }
 
-  private updateInnerOuterEdgesForNewOuter(
-    newOuterRb: RootBlossom,
-    minInnerOuterResistance: DynamicUint,
-  ): void {
+  /**
+   * For a newly OUTER blossom, update inner-outer edges for all non-OUTER
+   * blossoms: vertices in those blossoms may now have cheaper edges to this
+   * new OUTER blossom.
+   * (C++ updateInnerOuterEdges(rootBlossom))
+   */
+  private updateInnerOuterEdges(newOuterRb: RootBlossom): void {
     for (const rb of this.rootBlossoms) {
       if (rb === newOuterRb || rb.label === Label.OUTER) continue;
       for (
@@ -838,16 +953,19 @@ class Graph implements GraphLike {
           if (v.minOuterEdge === undefined || r.lt(v.minOuterEdgeResistance)) {
             v.minOuterEdge = outerV;
             v.minOuterEdgeResistance.copyFrom(r);
-            if (r.lt(minInnerOuterResistance)) {
-              minInnerOuterResistance.copyFrom(r);
-            }
           }
         }
       }
     }
   }
 
-  private updateOuterOuterEdge(rb1: RootBlossom, rb2: RootBlossom): void {
+  /**
+   * Update rb1's minOuterEdges tracking with edges to rb2.
+   * For each vertex pair (v1 in rb1, v2 in rb2), if the edge is tighter than
+   * the current best for rb1, update rb1.minOuterEdges[v2.vertexIndex] and
+   * rb1.minOuterEdgeResistance.
+   */
+  private updateOuterOuterEdgePair(rb1: RootBlossom, rb2: RootBlossom): void {
     for (
       let v1: Vertex | undefined = rb1.rootChild.vertexListHead;
       v1;
@@ -861,8 +979,9 @@ class Graph implements GraphLike {
         if (v1.vertexIndex === v2.vertexIndex) continue;
         const r = resistance(v1, v2);
         if (
-          rb1.minOuterEdgeResistance.compareTo(this.aboveMaxEdgeWeight) === 0 ||
-          r.lt(rb1.minOuterEdgeResistance)
+          rb1.minOuterEdgeResistance.lt(this.aboveMaxEdgeWeight)
+            ? r.lt(rb1.minOuterEdgeResistance)
+            : true
         ) {
           rb1.minOuterEdgeResistance.copyFrom(r);
           rb1.minOuterEdges[v2.vertexIndex] = v1;
@@ -871,21 +990,124 @@ class Graph implements GraphLike {
     }
   }
 
-  private updateOuterOuterEdgesForNewOuter(
-    newOuterRb: RootBlossom,
-    minOuterOuterResistance: DynamicUint,
+  /**
+   * Scan all INNER root blossoms with compound children (ParentBlossom) and
+   * call the two callbacks when a new minimum is found.
+   */
+  private initializeMinInnerDualVariable(
+    setBlossom: (pb: ParentBlossom) => void,
+    setValue: (v: DynamicUint) => void,
   ): void {
+    const minValue = this.aboveMaxEdgeWeight.clone();
     for (const rb of this.rootBlossoms) {
-      if (rb === newOuterRb || rb.label !== Label.OUTER) continue;
-      this.updateOuterOuterEdge(rb, newOuterRb);
-      this.updateOuterOuterEdge(newOuterRb, rb);
-      if (rb.minOuterEdgeResistance.lt(minOuterOuterResistance)) {
-        minOuterOuterResistance.copyFrom(rb.minOuterEdgeResistance);
-      }
-      if (newOuterRb.minOuterEdgeResistance.lt(minOuterOuterResistance)) {
-        minOuterOuterResistance.copyFrom(newOuterRb.minOuterEdgeResistance);
+      if (rb.label === Label.INNER && !rb.rootChild.isVertex) {
+        const pb = rb.rootChild as ParentBlossom;
+        if (pb.dualVariable.lt(minValue)) {
+          minValue.copyFrom(pb.dualVariable);
+          setBlossom(pb);
+          setValue(pb.dualVariable);
+        }
       }
     }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Blossom formation from path (Case 3, same root)
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Form a new blossom from the given path of vertices.
+   * The path describes an odd cycle in the alternating tree.
+   * Creates a ParentBlossom that wraps all the existing child blossoms,
+   * and a RootBlossom pointing to it.
+   *
+   * This corresponds to the C++ RootBlossom path-iterator constructor.
+   */
+  private formBlossomFromPath(path: Vertex[]): void {
+    if (path.length === 0) return;
+
+    // The new blossom's root blossom is the same as the root of path[0].
+    // All vertices in the path belong to the same RootBlossom.
+    const oldRb = path[0]!.rootBlossom!;
+
+    // Collect all vertices in the old blossom.
+    const allVertices: Vertex[] = [];
+    for (
+      let v: Vertex | undefined = oldRb.rootChild.vertexListHead;
+      v;
+      v = v.nextVertex
+    ) {
+      allVertices.push(v);
+    }
+
+    // Create a new zero dual variable for the ParentBlossom.
+    const newDual = this.aboveMaxEdgeWeight.clone().and(0);
+
+    // The new ParentBlossom wraps oldRb.rootChild as its subblossom.
+    // We need to link all children in a cycle (nextBlossom/previousBlossom).
+    // The C++ does this inside the RootBlossom path constructor. Here we
+    // do it by collecting the distinct "child blossoms" visited by the path
+    // and linking them.
+
+    // Collect the child blossoms of the new ParentBlossom.
+    // Each vertex in path has a rootBlossom child (its direct child of oldRb.rootChild).
+    // We collect unique child blossoms in path order.
+    // Since all vertices are in the same old root blossom, their "child of root" is
+    // the old rootChild (singleton if the old rootBlossom had no compound child).
+
+    // For now, since we're creating a blossom from a cycle, the child blossoms
+    // are the singleton vertices or existing compound blossoms.
+    // We use the old root child as the subblossom of the new ParentBlossom.
+
+    const newParent = new ParentBlossom(
+      newDual,
+      oldRb, // rootBlossom (will be updated)
+      oldRb.rootChild, // subblossom
+      allVertices[0]!,
+      allVertices.at(-1)!,
+    );
+    newParent.vertexListHead = allVertices[0]!;
+    newParent.vertexListTail = allVertices.at(-1)!;
+
+    this.parentBlossoms.push(newParent);
+
+    // Create the new RootBlossom.
+    // The new blossom is OUTER (since both endpoints were OUTER).
+    const newRb = new RootBlossom(
+      newParent,
+      oldRb.baseVertex,
+      oldRb.baseVertexMatch,
+      this,
+    );
+    newRb.label = Label.OUTER;
+    newRb.labeledVertex = undefined;
+    newRb.labelingVertex = undefined;
+
+    // Set up minOuterEdges array.
+    while (newRb.minOuterEdges.length < this.vertices.length) {
+      newRb.minOuterEdges.push(undefined);
+    }
+
+    // Update all vertices' rootBlossom pointer.
+    for (const v of allVertices) {
+      v.rootBlossom = newRb;
+    }
+
+    // Remove old RootBlossom from the list.
+    const oldRbIndex = this.rootBlossoms.indexOf(oldRb);
+    if (oldRbIndex !== -1) this.rootBlossoms.splice(oldRbIndex, 1);
+
+    // Add new RootBlossom.
+    this.rootBlossoms.push(newRb);
+    this.rootBlossomMinOuterEdgeResistances.push(
+      this.aboveMaxEdgeWeight.clone(),
+    );
+
+    // Initialize outer-outer edges for the new blossom.
+    this.initializeOuterOuterEdgesForBlossom(newRb);
+
+    // Update inner-outer edges (non-OUTER vertices now have a new OUTER blossom to check).
+    this.updateInnerOuterEdges(newRb);
   }
 }
 

--- a/src/matching/graph.ts
+++ b/src/matching/graph.ts
@@ -27,11 +27,15 @@ import type { Blossom, GraphLike } from './blossom.js';
 // Edge weights are stored doubled.
 // ---------------------------------------------------------------------------
 
-function resistance(u: Vertex, v: Vertex): DynamicUint {
-  const result = u.dualVariable.clone();
-  result.add(v.dualVariable);
-  result.subtract(u.edgeWeights[v.vertexIndex]!);
-  return result;
+/**
+ * Compute resistance into a pre-allocated DynamicUint (zero allocation).
+ * resistance(u, v) = u.dual + v.dual - w(u, v)
+ * C++ equivalent: vertex.resistance(result, other)
+ */
+function resistanceInto(out: DynamicUint, u: Vertex, v: Vertex): void {
+  out.copyFrom(u.dualVariable);
+  out.add(v.dualVariable);
+  out.subtract(u.edgeWeights[v.vertexIndex]!);
 }
 
 // ---------------------------------------------------------------------------
@@ -92,9 +96,13 @@ class Graph implements GraphLike {
   /** All active RootBlossoms. Implements GraphLike.rootBlossoms. */
   rootBlossoms: RootBlossom[] = [];
 
+  /** Pre-allocated scratch for resistance calculations (zero-alloc hot path). */
+  private readonly resistanceStorage: DynamicUint;
+
   constructor(maxEdgeWeight: DynamicUint) {
     // aboveMaxEdgeWeight = maxEdgeWeight * 4 + 1 (strictly greater than 4x)
     this.aboveMaxEdgeWeight = maxEdgeWeight.clone().shiftGrow(2).add(1);
+    this.resistanceStorage = this.aboveMaxEdgeWeight.clone();
   }
 
   // Public methods (alphabetical)
@@ -440,8 +448,8 @@ class Graph implements GraphLike {
             // in rb1 closest to rb0.
             const v1 = rb1.minOuterEdges[rb0.baseVertex.vertexIndex];
             if (v0 !== undefined && v1 !== undefined) {
-              const r = resistance(v0, v1);
-              if (r.isZero()) {
+              resistanceInto(this.resistanceStorage, v0, v1);
+              if (this.resistanceStorage.isZero()) {
                 vertex0 = v0;
                 vertex1 = v1;
                 break;
@@ -467,8 +475,8 @@ class Graph implements GraphLike {
                   v2 = v2.nextVertex
                 ) {
                   if (v1.vertexIndex === v2.vertexIndex) continue;
-                  const r = resistance(v1, v2);
-                  if (r.isZero()) {
+                  resistanceInto(this.resistanceStorage, v1, v2);
+                  if (this.resistanceStorage.isZero()) {
                     vertex0 = v1;
                     vertex1 = v2;
                     break outerSearch;
@@ -855,30 +863,24 @@ class Graph implements GraphLike {
    * For each non-OUTER blossom vertex, find cheapest edge to any OUTER vertex.
    */
   private initializeInnerOuterEdges(): void {
-    for (const rb of this.rootBlossoms) {
-      if (rb.label === Label.OUTER) continue;
-      for (
-        let v: Vertex | undefined = rb.rootChild.vertexListHead;
-        v;
-        v = v.nextVertex
-      ) {
-        for (const outerRb of this.rootBlossoms) {
-          if (outerRb.label !== Label.OUTER) continue;
-          for (
-            let outerV: Vertex | undefined = outerRb.rootChild.vertexListHead;
-            outerV;
-            outerV = outerV.nextVertex
-          ) {
-            if (v.vertexIndex === outerV.vertexIndex) continue;
-            const r = resistance(v, outerV);
-            if (
-              v.minOuterEdge === undefined ||
-              r.lt(v.minOuterEdgeResistance)
-            ) {
-              v.minOuterEdge = outerV;
-              v.minOuterEdgeResistance.copyFrom(r);
-            }
-          }
+    // Pre-collect outer vertices (C++ graph.cpp:240-248).
+    const outerVertices: Vertex[] = [];
+    for (const v of this.vertices) {
+      if (v.rootBlossom!.label === Label.OUTER) {
+        outerVertices.push(v);
+      }
+    }
+
+    const rs = this.resistanceStorage;
+    for (const v of this.vertices) {
+      if (v.rootBlossom!.label === Label.OUTER) continue;
+      v.minOuterEdgeResistance.copyFrom(this.aboveMaxEdgeWeight);
+      v.minOuterEdge = undefined;
+      for (const outerV of outerVertices) {
+        resistanceInto(rs, outerV, v);
+        if (rs.lt(v.minOuterEdgeResistance)) {
+          v.minOuterEdgeResistance.copyFrom(rs);
+          v.minOuterEdge = outerV;
         }
       }
     }
@@ -891,9 +893,10 @@ class Graph implements GraphLike {
   private initializeOuterOuterEdges(): void {
     for (const rb of this.rootBlossoms) {
       if (rb.label !== Label.OUTER) continue;
+      rb.minOuterEdgeResistance.copyFrom(this.aboveMaxEdgeWeight);
       for (const otherRb of this.rootBlossoms) {
-        if (otherRb === rb) continue;
-        if (otherRb.label !== Label.OUTER) continue;
+        if (otherRb === rb || otherRb.label !== Label.OUTER) continue;
+        rb.minOuterEdges[otherRb.baseVertex.vertexIndex] = undefined;
         this.updateOuterOuterEdgePair(rb, otherRb);
       }
     }
@@ -904,10 +907,11 @@ class Graph implements GraphLike {
    * other OUTER blossoms (single-blossom variant, C++ initializeOuterOuterEdges(blossom)).
    */
   private initializeOuterOuterEdgesForBlossom(newOuterRb: RootBlossom): void {
+    newOuterRb.minOuterEdgeResistance.copyFrom(this.aboveMaxEdgeWeight);
     for (const rb of this.rootBlossoms) {
       if (rb === newOuterRb || rb.label !== Label.OUTER) continue;
+      newOuterRb.minOuterEdges[rb.baseVertex.vertexIndex] = undefined;
       this.updateOuterOuterEdgePair(newOuterRb, rb);
-      this.updateOuterOuterEdgePair(rb, newOuterRb);
     }
   }
 
@@ -918,24 +922,18 @@ class Graph implements GraphLike {
    * (C++ updateInnerOuterEdges(rootBlossom))
    */
   private updateInnerOuterEdges(newOuterRb: RootBlossom): void {
-    for (const rb of this.rootBlossoms) {
-      if (rb === newOuterRb || rb.label === Label.OUTER) continue;
+    const rs = this.resistanceStorage;
+    for (const innerVertex of this.vertices) {
+      if (innerVertex.rootBlossom!.label === Label.OUTER) continue;
       for (
-        let v: Vertex | undefined = rb.rootChild.vertexListHead;
-        v;
-        v = v.nextVertex
+        let outerV: Vertex | undefined = newOuterRb.rootChild.vertexListHead;
+        outerV;
+        outerV = outerV.nextVertex
       ) {
-        for (
-          let outerV: Vertex | undefined = newOuterRb.rootChild.vertexListHead;
-          outerV;
-          outerV = outerV.nextVertex
-        ) {
-          if (v.vertexIndex === outerV.vertexIndex) continue;
-          const r = resistance(v, outerV);
-          if (v.minOuterEdge === undefined || r.lt(v.minOuterEdgeResistance)) {
-            v.minOuterEdge = outerV;
-            v.minOuterEdgeResistance.copyFrom(r);
-          }
+        resistanceInto(rs, outerV, innerVertex);
+        if (rs.lt(innerVertex.minOuterEdgeResistance)) {
+          innerVertex.minOuterEdgeResistance.copyFrom(rs);
+          innerVertex.minOuterEdge = outerV;
         }
       }
     }
@@ -948,6 +946,13 @@ class Graph implements GraphLike {
    * rb1.minOuterEdgeResistance.
    */
   private updateOuterOuterEdgePair(rb1: RootBlossom, rb2: RootBlossom): void {
+    // Get actual rootBlossoms (C++ graph.cpp:123-126).
+    const actual1 = rb1.rootChild.rootBlossom!;
+    const actual2 = rb2.rootChild.rootBlossom!;
+
+    const rs = this.resistanceStorage;
+    const minResistance = this.aboveMaxEdgeWeight.clone();
+
     for (
       let v1: Vertex | undefined = rb1.rootChild.vertexListHead;
       v1;
@@ -958,15 +963,18 @@ class Graph implements GraphLike {
         v2;
         v2 = v2.nextVertex
       ) {
-        if (v1.vertexIndex === v2.vertexIndex) continue;
-        const r = resistance(v1, v2);
-        if (
-          rb1.minOuterEdgeResistance.lt(this.aboveMaxEdgeWeight)
-            ? r.lt(rb1.minOuterEdgeResistance)
-            : true
-        ) {
-          rb1.minOuterEdgeResistance.copyFrom(r);
-          rb1.minOuterEdges[v2.vertexIndex] = v1;
+        resistanceInto(rs, v1, v2);
+        if (rs.lt(minResistance)) {
+          minResistance.copyFrom(rs);
+          // Index by the OTHER blossom's base vertex (C++ graph.cpp:150-155).
+          actual1.minOuterEdges[actual2.baseVertex.vertexIndex] = v1;
+          actual2.minOuterEdges[actual1.baseVertex.vertexIndex] = v2;
+          if (minResistance.lt(actual1.minOuterEdgeResistance)) {
+            actual1.minOuterEdgeResistance.copyFrom(minResistance);
+          }
+          if (minResistance.lt(actual2.minOuterEdgeResistance)) {
+            actual2.minOuterEdgeResistance.copyFrom(minResistance);
+          }
         }
       }
     }

--- a/src/matching/graph.ts
+++ b/src/matching/graph.ts
@@ -683,18 +683,8 @@ class Graph implements GraphLike {
         let isFree = false;
         let linksToNext = false; // tracks edge direction alternation
 
-        // Find the actual previous of rootChild by walking the cycle.
-        let previousChild: Blossom;
-        {
-          let current: Blossom = rootChild;
-          while (
-            current.nextBlossom !== rootChild &&
-            current.nextBlossom !== undefined
-          ) {
-            current = current.nextBlossom;
-          }
-          previousChild = current;
-        }
+        // C++ graph.cpp:705 — use the circular list's previousBlossom directly.
+        let previousChild: Blossom = rootChild.previousBlossom!;
 
         let currentChild: Blossom = rootChild;
         let nextChild: Blossom | undefined;

--- a/src/matching/graph.ts
+++ b/src/matching/graph.ts
@@ -862,31 +862,26 @@ class Graph implements GraphLike {
    * For each non-OUTER blossom vertex, find cheapest edge to any OUTER vertex.
    */
   private initializeInnerOuterEdges(): void {
+    // Pre-collect outer vertices into flat array (C++ graph.cpp:240-248).
+    // Avoids re-scanning rootBlossoms × vertex lists for every inner vertex.
+    const outerVertices: Vertex[] = [];
+    for (const v of this.vertices) {
+      if (v.rootBlossom!.label === Label.OUTER) {
+        outerVertices.push(v);
+      }
+    }
+
     const rs = this.resistanceStorage;
-    for (const rb of this.rootBlossoms) {
-      if (rb.label === Label.OUTER) continue;
-      for (
-        let v: Vertex | undefined = rb.rootChild.vertexListHead;
-        v;
-        v = v.nextVertex
-      ) {
-        for (const outerRb of this.rootBlossoms) {
-          if (outerRb.label !== Label.OUTER) continue;
-          for (
-            let outerV: Vertex | undefined = outerRb.rootChild.vertexListHead;
-            outerV;
-            outerV = outerV.nextVertex
-          ) {
-            if (v.vertexIndex === outerV.vertexIndex) continue;
-            resistanceInto(rs, v, outerV);
-            if (
-              v.minOuterEdge === undefined ||
-              rs.lt(v.minOuterEdgeResistance)
-            ) {
-              v.minOuterEdge = outerV;
-              v.minOuterEdgeResistance.copyFrom(rs);
-            }
-          }
+    for (const v of this.vertices) {
+      if (v.rootBlossom!.label === Label.OUTER) continue;
+      v.minOuterEdgeResistance.copyFrom(this.aboveMaxEdgeWeight);
+      v.minOuterEdge = undefined;
+      for (const outerV of outerVertices) {
+        if (v.vertexIndex === outerV.vertexIndex) continue;
+        resistanceInto(rs, v, outerV);
+        if (rs.lt(v.minOuterEdgeResistance)) {
+          v.minOuterEdge = outerV;
+          v.minOuterEdgeResistance.copyFrom(rs);
         }
       }
     }
@@ -927,24 +922,21 @@ class Graph implements GraphLike {
    */
   private updateInnerOuterEdges(newOuterRb: RootBlossom): void {
     const rs = this.resistanceStorage;
-    for (const rb of this.rootBlossoms) {
-      if (rb === newOuterRb || rb.label === Label.OUTER) continue;
+    for (const innerVertex of this.vertices) {
+      if (innerVertex.rootBlossom!.label === Label.OUTER) continue;
       for (
-        let v: Vertex | undefined = rb.rootChild.vertexListHead;
-        v;
-        v = v.nextVertex
+        let outerV: Vertex | undefined = newOuterRb.rootChild.vertexListHead;
+        outerV;
+        outerV = outerV.nextVertex
       ) {
-        for (
-          let outerV: Vertex | undefined = newOuterRb.rootChild.vertexListHead;
-          outerV;
-          outerV = outerV.nextVertex
+        if (innerVertex.vertexIndex === outerV.vertexIndex) continue;
+        resistanceInto(rs, innerVertex, outerV);
+        if (
+          innerVertex.minOuterEdge === undefined ||
+          rs.lt(innerVertex.minOuterEdgeResistance)
         ) {
-          if (v.vertexIndex === outerV.vertexIndex) continue;
-          resistanceInto(rs, v, outerV);
-          if (v.minOuterEdge === undefined || rs.lt(v.minOuterEdgeResistance)) {
-            v.minOuterEdge = outerV;
-            v.minOuterEdgeResistance.copyFrom(rs);
-          }
+          innerVertex.minOuterEdge = outerV;
+          innerVertex.minOuterEdgeResistance.copyFrom(rs);
         }
       }
     }

--- a/src/matching/graph.ts
+++ b/src/matching/graph.ts
@@ -664,27 +664,15 @@ class Graph implements GraphLike {
         );
 
         // Determine if the path from rootChild to connectChild goes forward
-        // (i.e., via nextBlossom links). Walk forward from rootChild;
-        // if we reach connectChild, connectForward=true; otherwise false.
-        //
-        // TODO(issue_15): the C++ uses a parity-flip pattern here
-        //   (connectForward starts true, flips per step). Our code always
-        //   returns true for circular lists. Fixing this to match C++ breaks
-        //   n=18 test — other parts of Case 5 may also need fixing.
-        let connectForward: boolean;
-        {
-          let found = false;
-          for (
-            let current: Blossom | undefined = rootChild.nextBlossom;
-            current !== rootChild && current !== undefined;
-            current = current.nextBlossom
-          ) {
-            if (current === connectChild) {
-              found = true;
-              break;
-            }
-          }
-          connectForward = rootChild === connectChild || found;
+        // (i.e., via nextBlossom links). C++ parity-flip pattern: count
+        // steps from rootChild to connectChild; even distance = forward.
+        let connectForward = true;
+        for (
+          let current: Blossom | undefined = rootChild;
+          current !== connectChild;
+          current = current!.nextBlossom
+        ) {
+          connectForward = !connectForward;
         }
 
         // Walk the circular child list, assigning labels.
@@ -770,9 +758,6 @@ class Graph implements GraphLike {
           newRb.label = label;
           newRb.labelingVertex = newLabelingVertex;
           newRb.labeledVertex = newLabeledVertex;
-
-          // Disconnect child from the old ParentBlossom.
-          currentChild.parentBlossom = undefined;
 
           // Update rootBlossom pointer for all vertices and nested ParentBlossoms.
           newRb.updateRootBlossomInDescendants();
@@ -1063,7 +1048,6 @@ class Graph implements GraphLike {
     }
 
     newRb.minOuterEdgeResistance.copyFrom(this.aboveMaxEdgeWeight);
-    newParent.parentBlossom = undefined;
 
     // Link vertex lists (C++ forward order).
     let previousHead: Vertex | undefined;

--- a/src/matching/graph.ts
+++ b/src/matching/graph.ts
@@ -666,6 +666,11 @@ class Graph implements GraphLike {
         // Determine if the path from rootChild to connectChild goes forward
         // (i.e., via nextBlossom links). Walk forward from rootChild;
         // if we reach connectChild, connectForward=true; otherwise false.
+        //
+        // TODO(issue_15): the C++ uses a parity-flip pattern here
+        //   (connectForward starts true, flips per step). Our code always
+        //   returns true for circular lists. Fixing this to match C++ breaks
+        //   n=18 test — other parts of Case 5 may also need fixing.
         let connectForward: boolean;
         {
           let found = false;

--- a/src/matching/graph.ts
+++ b/src/matching/graph.ts
@@ -431,7 +431,12 @@ class Graph implements GraphLike {
             if (rb1.label !== Label.OUTER || rb1 === rb0) continue;
             const v0 = rb0.minOuterEdges[rb1.baseVertex.vertexIndex];
             const v1 = rb1.minOuterEdges[rb0.baseVertex.vertexIndex];
-            if (v0 !== undefined && v1 !== undefined) {
+            if (
+              v0 !== undefined &&
+              v1 !== undefined &&
+              v0.rootBlossom === rb0 &&
+              v1.rootBlossom === rb1
+            ) {
               resistanceInto(this.resistanceStorage, v0, v1);
               if (this.resistanceStorage.isZero()) {
                 vertex0 = v0;

--- a/src/matching/graph.ts
+++ b/src/matching/graph.ts
@@ -83,8 +83,11 @@ class Graph implements GraphLike {
 
   // Public mutable fields (alphabetical)
 
-  /** All active ParentBlossoms. Implements GraphLike.parentBlossoms. */
-  parentBlossoms: ParentBlossom[] = [];
+  /**
+   * All active ParentBlossoms. Pool with same semantics as rootBlossomPool.
+   * Implements GraphLike.parentBlossomPool.
+   */
+  parentBlossomPool: IterablePool<ParentBlossom>;
 
   /**
    * All active RootBlossoms. Pool with LIFO free-slot recycling and
@@ -100,8 +103,11 @@ class Graph implements GraphLike {
     // aboveMaxEdgeWeight = maxEdgeWeight * 4 + 1 (strictly greater than 4x)
     this.aboveMaxEdgeWeight = maxEdgeWeight.clone().shiftGrow(2).add(1);
     this.resistanceStorage = this.aboveMaxEdgeWeight.clone();
-    // C++ graphimpl.h:20-21 — rootBlossomPool capacity = capacity + 1.
+    // C++ graphimpl.h:20-22 — pool capacities match C++ exactly.
     this.rootBlossomPool = new IterablePool<RootBlossom>(capacity + 1);
+    this.parentBlossomPool = new IterablePool<ParentBlossom>(
+      Math.floor(capacity / 2),
+    );
   }
 
   // Public methods (alphabetical)
@@ -792,8 +798,7 @@ class Graph implements GraphLike {
         } while (currentChild !== rootChild);
 
         // Destroy the old ParentBlossom and RootBlossom.
-        const pbIndex = this.parentBlossoms.indexOf(pb);
-        if (pbIndex !== -1) this.parentBlossoms.splice(pbIndex, 1);
+        this.parentBlossomPool.destroy(pb.poolIndex);
         this.rootBlossomPool.destroy(dissolvedRb.poolIndex);
 
         // Re-initialize minInnerDualVariable after dissolution.
@@ -1014,7 +1019,7 @@ class Graph implements GraphLike {
       firstChild.previousBlossom = lastChild;
     }
 
-    this.parentBlossoms.push(newParent);
+    newParent.poolIndex = this.parentBlossomPool.construct(newParent);
 
     const newRb = new RootBlossom(
       newParent,

--- a/src/matching/graph.ts
+++ b/src/matching/graph.ts
@@ -244,10 +244,13 @@ class Graph implements GraphLike {
     const minOuterDualVariable = this.aboveMaxEdgeWeight.clone();
     let minOuterDualVariableVertex: Vertex | undefined;
     for (const vertex of this.vertices) {
-      if (vertex.rootBlossom!.label === Label.OUTER && vertex.dualVariable.lt(minOuterDualVariable)) {
-          minOuterDualVariable.copyFrom(vertex.dualVariable);
-          minOuterDualVariableVertex = vertex;
-        }
+      if (
+        vertex.rootBlossom!.label === Label.OUTER &&
+        vertex.dualVariable.lt(minOuterDualVariable)
+      ) {
+        minOuterDualVariable.copyFrom(vertex.dualVariable);
+        minOuterDualVariableVertex = vertex;
+      }
     }
 
     // If no OUTER vertices, no augmentation possible.

--- a/src/matching/graph.ts
+++ b/src/matching/graph.ts
@@ -485,7 +485,6 @@ class Graph implements GraphLike {
         const pathBack: Vertex[] = [vertex1];
 
         // Expand front toward its exposed root.
-        // Expand front toward its exposed root.
         while (pathFront[0]!.rootBlossom!.baseVertexMatch) {
           const front = pathFront[0]!;
           pathFront.unshift(front.rootBlossom!.baseVertex);
@@ -1023,21 +1022,32 @@ class Graph implements GraphLike {
     // (C++ parentblossomimpl.h:28-31).
 
     const firstChild: Blossom = getAncestorOfVertex(path[0]!);
-    const lastChild: Blossom = getAncestorOfVertex(path.at(-1)!);
+    // C++ parentblossomimpl.h:30 uses std::prev(end, 2) — the second-to-last
+    // path element's ancestor. This differs from lastChild (path.at(-1)) when
+    // the path wraps (firstChild === lastChild).
+    const headChild: Blossom = getAncestorOfVertex(path.at(-2)!);
 
     // Create the new zero dual variable.
     const newDual = this.aboveMaxEdgeWeight.clone().and(0);
 
     // Create the ParentBlossom.
-    // vertexListHead = last child's vertexListHead (C++ prepends in reverse)
-    // vertexListTail = first child's vertexListTail
+    // vertexListHead = headChild's vertexListHead (C++ parentblossomimpl.h:30)
+    // vertexListTail = firstChild's vertexListTail (C++ parentblossomimpl.h:31)
     const newParent = new ParentBlossom(
       newDual,
       oldRb,
       firstChild,
-      lastChild.vertexListHead,
+      headChild.vertexListHead,
       firstChild.vertexListTail,
     );
+
+    // Collect child blossoms from the path BEFORE connectChildren modifies
+    // parentBlossom pointers (C++ getRootBlossomsFromPath, rootblossomimpl.h:27-38).
+    // Step by 2 — each even index identifies a child blossom.
+    const children: Blossom[] = [];
+    for (let index = 0; index < path.length; index += 2) {
+      children.push(getAncestorOfVertex(path[index]!));
+    }
 
     // connectChildren sets up the sibling linked list starting from firstChild.
     // After this call, newParent.subblossom points to the last child.
@@ -1055,15 +1065,6 @@ class Graph implements GraphLike {
     if (lastChild2 !== firstChild) {
       lastChild2.nextBlossom = firstChild;
       firstChild.previousBlossom = lastChild2;
-    }
-
-    // Collect child blossoms from the path (C++ getRootBlossomsFromPath,
-    // rootblossomimpl.h:27-38). Step by 2 through the path — each even
-    // index identifies a child blossom. This avoids traversing the circular
-    // sibling list which may have the same blossom at start and end.
-    const children: Blossom[] = [];
-    for (let index = 0; index < path.length; index += 2) {
-      children.push(getAncestorOfVertex(path[index]!));
     }
 
     // Link vertex lists in reverse order (C++ rootblossom.cpp:166-174):

--- a/src/matching/graph.ts
+++ b/src/matching/graph.ts
@@ -787,14 +787,8 @@ class Graph implements GraphLike {
           // Disconnect child from the old ParentBlossom.
           currentChild.parentBlossom = undefined;
 
-          // Update rootBlossom pointer for all vertices in this child.
-          for (
-            let v: Vertex | undefined = currentChild.vertexListHead;
-            v;
-            v = v.nextVertex
-          ) {
-            v.rootBlossom = newRb;
-          }
+          // Update rootBlossom pointer for all vertices and nested ParentBlossoms.
+          newRb.updateRootBlossomInDescendants();
 
           // Set up minOuterEdges array (size = number of vertices).
           while (newRb.minOuterEdges.length < this.vertices.length) {
@@ -1021,58 +1015,85 @@ class Graph implements GraphLike {
    * Creates a ParentBlossom that wraps all the existing child blossoms,
    * and a RootBlossom pointing to it.
    *
-   * This corresponds to the C++ RootBlossom path-iterator constructor.
+   * Ported from bbpPairings `rootblossom.cpp` path-iterator constructor.
    */
   private formBlossomFromPath(path: Vertex[]): void {
-    if (path.length === 0) return;
+    if (path.length < 2) return;
 
-    // The new blossom's root blossom is the same as the root of path[0].
-    // All vertices in the path belong to the same RootBlossom.
+    // All vertices in the path share the same RootBlossom (same-root case).
     const oldRb = path[0]!.rootBlossom!;
 
-    // Collect all vertices in the old blossom.
-    const allVertices: Vertex[] = [];
-    for (
-      let v: Vertex | undefined = oldRb.rootChild.vertexListHead;
-      v;
-      v = v.nextVertex
-    ) {
-      allVertices.push(v);
-    }
+    // The path alternates between child-blossom boundary vertices.
+    // path[0], path[1] = first pair: path[0] is inside child A (exit vertex),
+    //                                path[1] is inside child B (entry vertex).
+    // path[2], path[3] = next pair, etc.
+    //
+    // The first child (ancestor of path[0] under undefined) becomes previousChild.
+    // The last child is the ancestor of path[path.length-1] under undefined.
+    // vertex list: head from last child's head, tail from first child's tail
+    // (C++ parentblossomimpl.h:28-31).
 
-    // Create a new zero dual variable for the ParentBlossom.
+    const firstChild: Blossom = getAncestorOfVertex(path[0]!);
+    const lastChild: Blossom = getAncestorOfVertex(path.at(-1)!);
+
+    // Create the new zero dual variable.
     const newDual = this.aboveMaxEdgeWeight.clone().and(0);
 
-    // The new ParentBlossom wraps oldRb.rootChild as its subblossom.
-    // We need to link all children in a cycle (nextBlossom/previousBlossom).
-    // The C++ does this inside the RootBlossom path constructor. Here we
-    // do it by collecting the distinct "child blossoms" visited by the path
-    // and linking them.
-
-    // Collect the child blossoms of the new ParentBlossom.
-    // Each vertex in path has a rootBlossom child (its direct child of oldRb.rootChild).
-    // We collect unique child blossoms in path order.
-    // Since all vertices are in the same old root blossom, their "child of root" is
-    // the old rootChild (singleton if the old rootBlossom had no compound child).
-
-    // For now, since we're creating a blossom from a cycle, the child blossoms
-    // are the singleton vertices or existing compound blossoms.
-    // We use the old root child as the subblossom of the new ParentBlossom.
-
+    // Create the ParentBlossom.
+    // vertexListHead = last child's vertexListHead (C++ prepends in reverse)
+    // vertexListTail = first child's vertexListTail
     const newParent = new ParentBlossom(
       newDual,
-      oldRb, // rootBlossom (will be updated)
-      oldRb.rootChild, // subblossom
-      allVertices[0]!,
-      allVertices.at(-1)!,
+      oldRb,
+      firstChild,
+      lastChild.vertexListHead,
+      firstChild.vertexListTail,
     );
-    newParent.vertexListHead = allVertices[0]!;
-    newParent.vertexListTail = allVertices.at(-1)!;
+
+    // connectChildren sets up the sibling linked list starting from firstChild.
+    // After this call, newParent.subblossom points to the last child.
+    // All children except the first get parentBlossom = newParent.
+    newParent.connectChildren(path);
+
+    // The first child also needs parentBlossom = newParent.
+    firstChild.parentBlossom = newParent;
+
+    // Close the circular linked list: lastChild.nextBlossom → firstChild.
+    // freeAncestorOfBase iterates the circular list and relies on this.
+    const lastChild2 = newParent.subblossom; // subblossom = last child after connectChildren
+    lastChild2.nextBlossom = firstChild;
+    firstChild.previousBlossom = lastChild2;
+
+    // Link vertex lists of children together in reverse path order.
+    // C++ rootblossom.cpp:166-174 links them so the final list is:
+    //   lastChild → ... → firstChild
+    // matching parentblossomimpl.h:28-31 which sets:
+    //   vertexListHead = lastChild.vertexListHead
+    //   vertexListTail = firstChild.vertexListTail
+    //
+    // Collect children in forward order (firstChild → ... → lastChild),
+    // counting exactly childCount = path.length/2 + 1 children.
+    {
+      const childCount = Math.floor(path.length / 2) + 1;
+      const children: Blossom[] = [];
+      let current: Blossom = firstChild;
+      for (let index = 0; index < childCount; index++) {
+        children.push(current);
+        current = current.nextBlossom!; // safe: cycle is closed
+      }
+
+      // Link in reverse: lastChild.tail → secondToLast.head → ... → firstChild.head.
+      for (let index = children.length - 1; index > 0; index--) {
+        children[index]!.vertexListTail.nextVertex =
+          children[index - 1]!.vertexListHead;
+      }
+      // Terminate the list at firstChild's tail.
+      firstChild.vertexListTail.nextVertex = undefined;
+    }
 
     this.parentBlossoms.push(newParent);
 
-    // Create the new RootBlossom.
-    // The new blossom is OUTER (since both endpoints were OUTER).
+    // Create the new RootBlossom wrapping newParent.
     const newRb = new RootBlossom(
       newParent,
       oldRb.baseVertex,
@@ -1088,10 +1109,11 @@ class Graph implements GraphLike {
       newRb.minOuterEdges.push(undefined);
     }
 
-    // Update all vertices' rootBlossom pointer.
-    for (const v of allVertices) {
-      v.rootBlossom = newRb;
-    }
+    // Set newParent's parentBlossom to undefined (directly under RootBlossom).
+    newParent.parentBlossom = undefined;
+
+    // Update rootBlossom pointers for all descendants.
+    newRb.updateRootBlossomInDescendants();
 
     // Remove old RootBlossom from the list.
     const oldRbIndex = this.rootBlossoms.indexOf(oldRb);

--- a/src/matching/graph.ts
+++ b/src/matching/graph.ts
@@ -393,7 +393,6 @@ class Graph implements GraphLike {
           }
         }
       }
-
       // -----------------------------------------------------------------------
       // CASE 1: OUTER vertex dual → 0
       // -----------------------------------------------------------------------
@@ -430,11 +429,7 @@ class Graph implements GraphLike {
         if (rb0 !== undefined) {
           for (const rb1 of this.rootBlossoms) {
             if (rb1.label !== Label.OUTER || rb1 === rb0) continue;
-            // rb0 stores in minOuterEdges[rb1.baseVertex.vertexIndex] the vertex
-            // in rb0 closest to rb1.
             const v0 = rb0.minOuterEdges[rb1.baseVertex.vertexIndex];
-            // rb1 stores in minOuterEdges[rb0.baseVertex.vertexIndex] the vertex
-            // in rb1 closest to rb0.
             const v1 = rb1.minOuterEdges[rb0.baseVertex.vertexIndex];
             if (v0 !== undefined && v1 !== undefined) {
               resistanceInto(this.resistanceStorage, v0, v1);
@@ -446,7 +441,6 @@ class Graph implements GraphLike {
             }
           }
         }
-
         // If not found via tracked references, do a brute-force scan as fallback.
         if (vertex0 === undefined || vertex1 === undefined) {
           outerSearch: for (const rb1 of this.rootBlossoms) {
@@ -490,6 +484,7 @@ class Graph implements GraphLike {
         const pathFront: Vertex[] = [vertex0];
         const pathBack: Vertex[] = [vertex1];
 
+        // Expand front toward its exposed root.
         // Expand front toward its exposed root.
         while (pathFront[0]!.rootBlossom!.baseVertexMatch) {
           const front = pathFront[0]!;
@@ -602,8 +597,6 @@ class Graph implements GraphLike {
 
         // Update inner-outer edges for the newly OUTER blossom.
         this.updateInnerOuterEdges(matchedRb);
-
-        // Initialize outer-outer edges for the newly OUTER blossom.
         this.initializeOuterOuterEdgesForBlossom(matchedRb);
 
         // Update minOuterDualVariable for vertices in new OUTER blossom.
@@ -1054,38 +1047,36 @@ class Graph implements GraphLike {
     // The first child also needs parentBlossom = newParent.
     firstChild.parentBlossom = newParent;
 
-    // Close the circular linked list: lastChild.nextBlossom → firstChild.
-    // freeAncestorOfBase iterates the circular list and relies on this.
-    const lastChild2 = newParent.subblossom; // subblossom = last child after connectChildren
-    lastChild2.nextBlossom = firstChild;
-    firstChild.previousBlossom = lastChild2;
+    // connectChildren already creates the circular sibling chain (the last
+    // child's nextBlossom is set to the first child when the path wraps).
+    // Only close manually when the last child differs from the first —
+    // otherwise we overwrite connectChildren's link and create a self-loop.
+    const lastChild2 = newParent.subblossom;
+    if (lastChild2 !== firstChild) {
+      lastChild2.nextBlossom = firstChild;
+      firstChild.previousBlossom = lastChild2;
+    }
 
-    // Link vertex lists of children together in reverse path order.
-    // C++ rootblossom.cpp:166-174 links them so the final list is:
-    //   lastChild → ... → firstChild
+    // Collect child blossoms from the path (C++ getRootBlossomsFromPath,
+    // rootblossomimpl.h:27-38). Step by 2 through the path — each even
+    // index identifies a child blossom. This avoids traversing the circular
+    // sibling list which may have the same blossom at start and end.
+    const children: Blossom[] = [];
+    for (let index = 0; index < path.length; index += 2) {
+      children.push(getAncestorOfVertex(path[index]!));
+    }
+
+    // Link vertex lists in reverse order (C++ rootblossom.cpp:166-174):
+    //   lastChild.tail → secondToLast.head → ... → firstChild.head
     // matching parentblossomimpl.h:28-31 which sets:
     //   vertexListHead = lastChild.vertexListHead
     //   vertexListTail = firstChild.vertexListTail
-    //
-    // Collect children in forward order (firstChild → ... → lastChild),
-    // counting exactly childCount = path.length/2 + 1 children.
-    {
-      const childCount = Math.floor(path.length / 2) + 1;
-      const children: Blossom[] = [];
-      let current: Blossom = firstChild;
-      for (let index = 0; index < childCount; index++) {
-        children.push(current);
-        current = current.nextBlossom!; // safe: cycle is closed
-      }
-
-      // Link in reverse: lastChild.tail → secondToLast.head → ... → firstChild.head.
-      for (let index = children.length - 1; index > 0; index--) {
-        children[index]!.vertexListTail.nextVertex =
-          children[index - 1]!.vertexListHead;
-      }
-      // Terminate the list at firstChild's tail.
-      firstChild.vertexListTail.nextVertex = undefined;
+    for (let index = children.length - 1; index > 0; index--) {
+      children[index]!.vertexListTail.nextVertex =
+        children[index - 1]!.vertexListHead;
     }
+    // Terminate the list at firstChild's tail.
+    firstChild.vertexListTail.nextVertex = undefined;
 
     this.parentBlossoms.push(newParent);
 

--- a/src/matching/graph.ts
+++ b/src/matching/graph.ts
@@ -15,6 +15,7 @@ import {
   getAncestorOfVertex,
   setPointersFromAncestor,
 } from './blossom.js';
+import { IterablePool } from './iterable-pool.js';
 import { Label } from './types.js';
 import { Vertex } from './vertex.js';
 
@@ -72,13 +73,6 @@ class Graph implements GraphLike {
   readonly aboveMaxEdgeWeight: DynamicUint;
 
   /**
-   * Minimum outer edge resistance per RootBlossom slot, indexed in parallel
-   * with rootBlossoms. One DynamicUint per RootBlossom, expanded whenever a
-   * new vertex (and thus a new RootBlossom) is added.
-   */
-  readonly rootBlossomMinOuterEdgeResistances: DynamicUint[] = [];
-
-  /**
    * Dual variable per vertex (aliased by vertex.dualVariable).
    * Implements GraphLike.vertexDualVariables.
    */
@@ -92,16 +86,22 @@ class Graph implements GraphLike {
   /** All active ParentBlossoms. Implements GraphLike.parentBlossoms. */
   parentBlossoms: ParentBlossom[] = [];
 
-  /** All active RootBlossoms. Implements GraphLike.rootBlossoms. */
-  rootBlossoms: RootBlossom[] = [];
+  /**
+   * All active RootBlossoms. Pool with LIFO free-slot recycling and
+   * doubly-linked iteration — matches C++ IterablePool semantics.
+   * Implements GraphLike.rootBlossomPool.
+   */
+  rootBlossomPool: IterablePool<RootBlossom>;
 
   /** Pre-allocated scratch for resistance calculations. */
   private readonly resistanceStorage: DynamicUint;
 
-  constructor(maxEdgeWeight: DynamicUint) {
+  constructor(capacity: number, maxEdgeWeight: DynamicUint) {
     // aboveMaxEdgeWeight = maxEdgeWeight * 4 + 1 (strictly greater than 4x)
     this.aboveMaxEdgeWeight = maxEdgeWeight.clone().shiftGrow(2).add(1);
     this.resistanceStorage = this.aboveMaxEdgeWeight.clone();
+    // C++ graphimpl.h:20-21 — rootBlossomPool capacity = capacity + 1.
+    this.rootBlossomPool = new IterablePool<RootBlossom>(capacity + 1);
   }
 
   // Public methods (alphabetical)
@@ -114,7 +114,7 @@ class Graph implements GraphLike {
     const index = this.vertices.length;
 
     // 1. Expand every existing RootBlossom's minOuterEdges array.
-    for (const rb of this.rootBlossoms) {
+    for (const rb of this.rootBlossomPool) {
       rb.minOuterEdges.push(undefined);
     }
 
@@ -148,10 +148,7 @@ class Graph implements GraphLike {
       rb.minOuterEdges.push(undefined);
     }
 
-    this.rootBlossoms.push(rb);
-    this.rootBlossomMinOuterEdgeResistances.push(
-      this.aboveMaxEdgeWeight.clone(),
-    );
+    rb.poolIndex = this.rootBlossomPool.construct(rb);
   }
 
   // ---------------------------------------------------------------------------
@@ -160,8 +157,8 @@ class Graph implements GraphLike {
 
   computeMatching(): void {
     // Parity fix phase: make all exposed-vertex dualVariables have even values.
-    // Iterate over a snapshot because freeAncestorOfBase modifies rootBlossoms.
-    const snapshot = [...this.rootBlossoms];
+    // Iterate over a snapshot because freeAncestorOfBase modifies the pool.
+    const snapshot = [...this.rootBlossomPool];
     for (const rootBlossom of snapshot) {
       if (
         !rootBlossom.baseVertexMatch &&
@@ -224,7 +221,7 @@ class Graph implements GraphLike {
     const minOuterDualVariable = this.aboveMaxEdgeWeight.clone();
     let minOuterDualVariableVertex: Vertex | undefined;
 
-    for (const rb of this.rootBlossoms) {
+    for (const rb of this.rootBlossomPool) {
       // Reset labeling state (C++ graph.cpp:188-203).
       // Do NOT reset minOuterEdgeResistance or minOuterEdges[] here — the C++
       // preserves these across augmentation calls. They are recomputed per
@@ -275,7 +272,7 @@ class Graph implements GraphLike {
     // -------------------------------------------------------------------------
     const minOuterOuterEdgeResistance = this.aboveMaxEdgeWeight.clone();
     let minOuterOuterEdgeResistanceRootBlossom: RootBlossom | undefined;
-    for (const rb of this.rootBlossoms) {
+    for (const rb of this.rootBlossomPool) {
       if (
         rb.label === Label.OUTER &&
         rb.minOuterEdgeResistance.lt(minOuterOuterEdgeResistance)
@@ -427,7 +424,7 @@ class Graph implements GraphLike {
 
         const rb0 = minOuterOuterEdgeResistanceRootBlossom;
         if (rb0 !== undefined) {
-          for (const rb1 of this.rootBlossoms) {
+          for (const rb1 of this.rootBlossomPool) {
             if (rb1.label !== Label.OUTER || rb1 === rb0) continue;
             const v0: Vertex | undefined =
               rb0.minOuterEdges[rb1.baseVertex.vertexIndex];
@@ -450,9 +447,9 @@ class Graph implements GraphLike {
         }
         // If not found via tracked references, do a brute-force scan as fallback.
         if (vertex0 === undefined || vertex1 === undefined) {
-          outerSearch: for (const rb1 of this.rootBlossoms) {
+          outerSearch: for (const rb1 of this.rootBlossomPool) {
             if (rb1.label !== Label.OUTER) continue;
-            for (const rb2 of this.rootBlossoms) {
+            for (const rb2 of this.rootBlossomPool) {
               if (rb2 === rb1 || rb2.label !== Label.OUTER) continue;
               for (
                 let v1: Vertex | undefined = rb1.rootChild.vertexListHead;
@@ -549,7 +546,7 @@ class Graph implements GraphLike {
           // Re-initialize minOuterOuterEdgeResistance.
           minOuterOuterEdgeResistance.copyFrom(this.aboveMaxEdgeWeight);
           minOuterOuterEdgeResistanceRootBlossom = undefined;
-          for (const rb of this.rootBlossoms) {
+          for (const rb of this.rootBlossomPool) {
             if (
               rb.label === Label.OUTER &&
               rb.minOuterEdgeResistance.lt(minOuterOuterEdgeResistance)
@@ -649,9 +646,8 @@ class Graph implements GraphLike {
 
         const dissolvedRb = pb.rootBlossom!;
 
-        // Hide the dissolved RootBlossom from rootBlossoms.
-        const rbIndex = this.rootBlossoms.indexOf(dissolvedRb);
-        if (rbIndex !== -1) this.rootBlossoms.splice(rbIndex, 1);
+        // Hide the dissolved RootBlossom from the pool.
+        this.rootBlossomPool.hide(dissolvedRb.poolIndex);
 
         // The root child of the dissolved blossom is pb.
         // In C++: rootVertex = dissolvedRb.baseVertex
@@ -759,10 +755,7 @@ class Graph implements GraphLike {
             newRb.minOuterEdges.push(undefined);
           }
 
-          this.rootBlossoms.push(newRb);
-          this.rootBlossomMinOuterEdgeResistances.push(
-            this.aboveMaxEdgeWeight.clone(),
-          );
+          newRb.poolIndex = this.rootBlossomPool.construct(newRb);
           newRootBlossoms.push(newRb);
 
           // For OUTER children: update inner-outer and outer-outer edges,
@@ -801,6 +794,7 @@ class Graph implements GraphLike {
         // Destroy the old ParentBlossom and RootBlossom.
         const pbIndex = this.parentBlossoms.indexOf(pb);
         if (pbIndex !== -1) this.parentBlossoms.splice(pbIndex, 1);
+        this.rootBlossomPool.destroy(dissolvedRb.poolIndex);
 
         // Re-initialize minInnerDualVariable after dissolution.
         minInnerDualVariable.copyFrom(this.aboveMaxEdgeWeight);
@@ -861,14 +855,14 @@ class Graph implements GraphLike {
    * Updates minOuterEdges and minOuterEdgeResistance for each OUTER blossom.
    */
   private initializeOuterOuterEdges(): void {
-    for (const rb of this.rootBlossoms) {
+    for (const rb of this.rootBlossomPool) {
       if (rb.label !== Label.OUTER) continue;
       // Reset per-blossom outer-outer tracking (C++ graph.cpp:275).
       rb.minOuterEdgeResistance.copyFrom(this.aboveMaxEdgeWeight);
       for (let index = 0; index < rb.minOuterEdges.length; index++) {
         rb.minOuterEdges[index] = undefined;
       }
-      for (const otherRb of this.rootBlossoms) {
+      for (const otherRb of this.rootBlossomPool) {
         if (otherRb === rb) continue;
         if (otherRb.label !== Label.OUTER) continue;
         const pairMin = this.aboveMaxEdgeWeight.clone();
@@ -881,7 +875,7 @@ class Graph implements GraphLike {
   private initializeOuterOuterEdgesForBlossom(newOuterRb: RootBlossom): void {
     newOuterRb.minOuterEdgeResistance.copyFrom(this.aboveMaxEdgeWeight);
     const pairMin = this.aboveMaxEdgeWeight.clone();
-    for (const rb of this.rootBlossoms) {
+    for (const rb of this.rootBlossomPool) {
       if (rb === newOuterRb || rb.label !== Label.OUTER) continue;
       pairMin.copyFrom(this.aboveMaxEdgeWeight);
       newOuterRb.minOuterEdges[rb.baseVertex.vertexIndex] = undefined;
@@ -966,7 +960,7 @@ class Graph implements GraphLike {
     setValue: (v: DynamicUint) => void,
   ): void {
     const minValue = this.aboveMaxEdgeWeight.clone();
-    for (const rb of this.rootBlossoms) {
+    for (const rb of this.rootBlossomPool) {
       if (rb.label === Label.INNER && !rb.rootChild.isVertex) {
         const pb = rb.rootChild as ParentBlossom;
         if (pb.dualVariable.lt(minValue)) {
@@ -1057,14 +1051,10 @@ class Graph implements GraphLike {
     newRb.updateRootBlossomInDescendants();
 
     for (const rb of originalBlossoms) {
-      const index = this.rootBlossoms.indexOf(rb);
-      if (index !== -1) this.rootBlossoms.splice(index, 1);
+      this.rootBlossomPool.destroy(rb.poolIndex);
     }
 
-    this.rootBlossoms.push(newRb);
-    this.rootBlossomMinOuterEdgeResistances.push(
-      this.aboveMaxEdgeWeight.clone(),
-    );
+    newRb.poolIndex = this.rootBlossomPool.construct(newRb);
 
     this.initializeOuterOuterEdgesForBlossom(newRb);
     this.updateInnerOuterEdges(newRb);

--- a/src/matching/graph.ts
+++ b/src/matching/graph.ts
@@ -884,20 +884,21 @@ class Graph implements GraphLike {
       for (const otherRb of this.rootBlossoms) {
         if (otherRb === rb) continue;
         if (otherRb.label !== Label.OUTER) continue;
-        this.updateOuterOuterEdgePair(rb, otherRb);
+        const pairMin = this.aboveMaxEdgeWeight.clone();
+        rb.minOuterEdges[otherRb.baseVertex.vertexIndex] = undefined;
+        this.updateOuterOuterEdges(rb, otherRb, pairMin);
       }
     }
   }
 
-  /**
-   * For a newly OUTER blossom, initialize its outer-outer edges against all
-   * other OUTER blossoms (single-blossom variant, C++ initializeOuterOuterEdges(blossom)).
-   */
   private initializeOuterOuterEdgesForBlossom(newOuterRb: RootBlossom): void {
+    newOuterRb.minOuterEdgeResistance.copyFrom(this.aboveMaxEdgeWeight);
+    const pairMin = this.aboveMaxEdgeWeight.clone();
     for (const rb of this.rootBlossoms) {
       if (rb === newOuterRb || rb.label !== Label.OUTER) continue;
-      this.updateOuterOuterEdgePair(newOuterRb, rb);
-      this.updateOuterOuterEdgePair(rb, newOuterRb);
+      pairMin.copyFrom(this.aboveMaxEdgeWeight);
+      newOuterRb.minOuterEdges[rb.baseVertex.vertexIndex] = undefined;
+      this.updateOuterOuterEdges(newOuterRb, rb, pairMin);
     }
   }
 
@@ -935,27 +936,35 @@ class Graph implements GraphLike {
    * the current best for rb1, update rb1.minOuterEdges[v2.vertexIndex] and
    * rb1.minOuterEdgeResistance.
    */
-  private updateOuterOuterEdgePair(rb1: RootBlossom, rb2: RootBlossom): void {
+  private updateOuterOuterEdges(
+    rb0: RootBlossom,
+    rb1: RootBlossom,
+    pairMinResistance: DynamicUint,
+  ): void {
+    const actualRb0 = rb0.rootChild.rootBlossom!;
+    const actualRb1 = rb1.rootChild.rootBlossom!;
     const rs = this.resistanceStorage;
     for (
-      let v1: Vertex | undefined = rb1.rootChild.vertexListHead;
-      v1;
-      v1 = v1.nextVertex
+      let v0: Vertex | undefined = rb0.rootChild.vertexListHead;
+      v0;
+      v0 = v0.nextVertex
     ) {
       for (
-        let v2: Vertex | undefined = rb2.rootChild.vertexListHead;
-        v2;
-        v2 = v2.nextVertex
+        let v1: Vertex | undefined = rb1.rootChild.vertexListHead;
+        v1;
+        v1 = v1.nextVertex
       ) {
-        if (v1.vertexIndex === v2.vertexIndex) continue;
-        resistanceInto(rs, v1, v2);
-        if (
-          rb1.minOuterEdgeResistance.lt(this.aboveMaxEdgeWeight)
-            ? rs.lt(rb1.minOuterEdgeResistance)
-            : true
-        ) {
-          rb1.minOuterEdgeResistance.copyFrom(rs);
-          rb1.minOuterEdges[v2.vertexIndex] = v1;
+        resistanceInto(rs, v0, v1);
+        if (rs.lt(pairMinResistance)) {
+          pairMinResistance.copyFrom(rs);
+          actualRb0.minOuterEdges[actualRb1.baseVertex.vertexIndex] = v0;
+          actualRb1.minOuterEdges[actualRb0.baseVertex.vertexIndex] = v1;
+          if (rs.lt(actualRb0.minOuterEdgeResistance)) {
+            actualRb0.minOuterEdgeResistance.copyFrom(rs);
+          }
+          if (rs.lt(actualRb1.minOuterEdgeResistance)) {
+            actualRb1.minOuterEdgeResistance.copyFrom(rs);
+          }
         }
       }
     }
@@ -997,125 +1006,80 @@ class Graph implements GraphLike {
   private formBlossomFromPath(path: Vertex[]): void {
     if (path.length < 2) return;
 
-    // Collect ALL unique RootBlossoms referenced by path vertices.
-    // The C++ initializeFromChildren destroys all of them.
-    const oldRbs: RootBlossom[] = [];
-    const seenRbs = new Set<RootBlossom>();
-    for (const v of path) {
-      const rb = v.rootBlossom!;
-      if (!seenRbs.has(rb)) {
-        seenRbs.add(rb);
-        oldRbs.push(rb);
-      }
+    const originalBlossoms: RootBlossom[] = [];
+    for (let index = 0; index < path.length; index += 2) {
+      originalBlossoms.push(path[index]!.rootBlossom!);
     }
-    // The base rootBlossom (carries label, base vertex, match info).
-    const oldRb = path[0]!.rootBlossom!;
-
-    // The path alternates between child-blossom boundary vertices.
-    // path[0], path[1] = first pair: path[0] is inside child A (exit vertex),
-    //                                path[1] is inside child B (entry vertex).
-    // path[2], path[3] = next pair, etc.
-    //
-    // The first child (ancestor of path[0] under undefined) becomes previousChild.
-    // The last child is the ancestor of path[path.length-1] under undefined.
-    // vertex list: head from last child's head, tail from first child's tail
-    // (C++ parentblossomimpl.h:28-31).
+    const baseRoot = path[0]!.rootBlossom!;
 
     const firstChild: Blossom = getAncestorOfVertex(path[0]!);
-    // C++ parentblossomimpl.h:30 uses std::prev(end, 2) — the second-to-last
-    // path element's ancestor. This differs from lastChild (path.at(-1)) when
-    // the path wraps (firstChild === lastChild).
     const headChild: Blossom = getAncestorOfVertex(path.at(-2)!);
 
-    // Create the new zero dual variable.
     const newDual = this.aboveMaxEdgeWeight.clone().and(0);
-
-    // Create the ParentBlossom.
-    // vertexListHead = headChild's vertexListHead (C++ parentblossomimpl.h:30)
-    // vertexListTail = firstChild's vertexListTail (C++ parentblossomimpl.h:31)
     const newParent = new ParentBlossom(
       newDual,
-      oldRb,
+      baseRoot,
       firstChild,
       headChild.vertexListHead,
       firstChild.vertexListTail,
     );
 
-    // Collect child blossoms from the path BEFORE connectChildren modifies
-    // parentBlossom pointers (C++ getRootBlossomsFromPath, rootblossomimpl.h:27-38).
-    // Step by 2 — each even index identifies a child blossom.
-    const children: Blossom[] = [];
-    for (let index = 0; index < path.length; index += 2) {
-      children.push(getAncestorOfVertex(path[index]!));
-    }
-
-    // connectChildren sets up the sibling linked list starting from firstChild.
-    // After this call, newParent.subblossom points to the last child.
-    // All children except the first get parentBlossom = newParent.
     newParent.connectChildren(path);
-
-    // The first child also needs parentBlossom = newParent.
     firstChild.parentBlossom = newParent;
 
-    // connectChildren already creates the circular sibling chain (the last
-    // child's nextBlossom is set to the first child when the path wraps).
-    // Only close manually when the last child differs from the first —
-    // otherwise we overwrite connectChildren's link and create a self-loop.
-    const lastChild2 = newParent.subblossom;
-    if (lastChild2 !== firstChild) {
-      lastChild2.nextBlossom = firstChild;
-      firstChild.previousBlossom = lastChild2;
+    const lastChild = newParent.subblossom;
+    if (lastChild !== firstChild) {
+      lastChild.nextBlossom = firstChild;
+      firstChild.previousBlossom = lastChild;
     }
-
-    // Link vertex lists in reverse order (C++ rootblossom.cpp:166-174):
-    //   lastChild.tail → secondToLast.head → ... → firstChild.head
-    // matching parentblossomimpl.h:28-31 which sets:
-    //   vertexListHead = lastChild.vertexListHead
-    //   vertexListTail = firstChild.vertexListTail
-    for (let index = children.length - 1; index > 0; index--) {
-      children[index]!.vertexListTail.nextVertex =
-        children[index - 1]!.vertexListHead;
-    }
-    // Terminate the list at firstChild's tail.
-    firstChild.vertexListTail.nextVertex = undefined;
 
     this.parentBlossoms.push(newParent);
 
-    // Create the new RootBlossom wrapping newParent.
     const newRb = new RootBlossom(
       newParent,
-      oldRb.baseVertex,
-      oldRb.baseVertexMatch,
+      baseRoot.baseVertex,
+      baseRoot.baseVertexMatch,
       this,
     );
-    newRb.label = Label.OUTER;
-    newRb.labeledVertex = undefined;
-    newRb.labelingVertex = undefined;
+    newRb.label = baseRoot.label;
+    newRb.labelingVertex = baseRoot.labelingVertex;
+    newRb.labeledVertex = baseRoot.labeledVertex;
 
-    // Set up minOuterEdges array.
     while (newRb.minOuterEdges.length < this.vertices.length) {
       newRb.minOuterEdges.push(undefined);
     }
+    for (let index = 0; index < baseRoot.minOuterEdges.length; index++) {
+      newRb.minOuterEdges[index] = baseRoot.minOuterEdges[index];
+    }
 
-    // Set newParent's parentBlossom to undefined (directly under RootBlossom).
+    newRb.minOuterEdgeResistance.copyFrom(this.aboveMaxEdgeWeight);
     newParent.parentBlossom = undefined;
 
-    // Update rootBlossom pointers for all descendants.
+    // Link vertex lists (C++ forward order).
+    let previousHead: Vertex | undefined;
+    for (const rb of originalBlossoms) {
+      if (rb.label !== Label.OUTER) {
+        this.updateInnerOuterEdges(rb);
+      }
+      rb.rootChild.vertexListTail.nextVertex = previousHead;
+      previousHead = rb.rootChild.vertexListHead;
+    }
+    if (previousHead) {
+      newParent.vertexListHead = previousHead;
+    }
+
     newRb.updateRootBlossomInDescendants();
 
-    // Remove ALL old RootBlossoms from the list.
-    for (const rb of oldRbs) {
+    for (const rb of originalBlossoms) {
       const index = this.rootBlossoms.indexOf(rb);
       if (index !== -1) this.rootBlossoms.splice(index, 1);
     }
 
-    // Add new RootBlossom.
     this.rootBlossoms.push(newRb);
     this.rootBlossomMinOuterEdgeResistances.push(
       this.aboveMaxEdgeWeight.clone(),
     );
 
-    // Initialize outer-outer edges for the new blossom.
     this.initializeOuterOuterEdgesForBlossom(newRb);
     this.updateInnerOuterEdges(newRb);
   }

--- a/src/matching/graph.ts
+++ b/src/matching/graph.ts
@@ -1,0 +1,892 @@
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
+/**
+ * Graph class — persistent matching computer.
+ *
+ * Implements the Galil-Micali-Gabow O(n³) maximum-weight matching algorithm.
+ * Ported from bbpPairings `graph.cpp` (854 lines), `graphimpl.h` (64 lines),
+ * and `computer.cpp` (168 lines, the addVertex / setEdgeWeight parts).
+ *
+ * @internal Not part of the public API.
+ */
+
+import {
+  ParentBlossom,
+  RootBlossom,
+  setPointersFromAncestor,
+} from './blossom.js';
+import { Label } from './types.js';
+import { Vertex } from './vertex.js';
+
+import type { DynamicUint } from '../dynamic-uint.js';
+import type { Blossom, GraphLike } from './blossom.js';
+
+// ---------------------------------------------------------------------------
+// Helper: resistance between two vertices
+// resistance(u, v) = u.dual + v.dual - w(u, v)
+// Edge weights are stored doubled.
+// ---------------------------------------------------------------------------
+
+function resistance(u: Vertex, v: Vertex): DynamicUint {
+  const result = u.dualVariable.clone();
+  result.add(v.dualVariable);
+  result.subtract(u.edgeWeights[v.vertexIndex]!);
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Helper: augment from a vertex toward the exposed OUTER root
+// Ported from rootblossom.cpp:284-303
+// ---------------------------------------------------------------------------
+
+function augmentToSource(vertex: Vertex | undefined, newMatch?: Vertex): void {
+  while (vertex && vertex.rootBlossom!.baseVertexMatch) {
+    vertex.rootBlossom!.baseVertex = vertex;
+    const originalMatch = vertex.rootBlossom!.baseVertexMatch!.rootBlossom!;
+    vertex.rootBlossom!.baseVertexMatch = newMatch;
+    originalMatch.baseVertex = originalMatch.labeledVertex!;
+    originalMatch.baseVertexMatch = originalMatch.labelingVertex;
+    vertex = originalMatch.labelingVertex;
+    newMatch = originalMatch.labeledVertex;
+  }
+  if (vertex) {
+    vertex.rootBlossom!.baseVertex = vertex;
+    vertex.rootBlossom!.baseVertexMatch = newMatch;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Graph class
+// ---------------------------------------------------------------------------
+
+class Graph implements GraphLike {
+  // Public readonly fields (alphabetical)
+
+  /**
+   * Strictly greater than 4 × the max user-visible edge weight.
+   * Implements GraphLike.aboveMaxEdgeWeight.
+   */
+  readonly aboveMaxEdgeWeight: DynamicUint;
+
+  /**
+   * Minimum outer edge resistance per RootBlossom slot, indexed in parallel
+   * with rootBlossoms. One DynamicUint per RootBlossom, expanded whenever a
+   * new vertex (and thus a new RootBlossom) is added.
+   */
+  readonly rootBlossomMinOuterEdgeResistances: DynamicUint[] = [];
+
+  /**
+   * Dual variable per vertex (aliased by vertex.dualVariable).
+   * Implements GraphLike.vertexDualVariables.
+   */
+  readonly vertexDualVariables: DynamicUint[] = [];
+
+  /** All vertices in the graph. */
+  readonly vertices: Vertex[] = [];
+
+  // Public mutable fields (alphabetical)
+
+  /** All active ParentBlossoms. Implements GraphLike.parentBlossoms. */
+  parentBlossoms: ParentBlossom[] = [];
+
+  /** All active RootBlossoms. Implements GraphLike.rootBlossoms. */
+  rootBlossoms: RootBlossom[] = [];
+
+  constructor(maxEdgeWeight: DynamicUint) {
+    // aboveMaxEdgeWeight = maxEdgeWeight * 4 + 1 (strictly greater than 4x)
+    this.aboveMaxEdgeWeight = maxEdgeWeight.clone().shiftGrow(2).add(1);
+  }
+
+  // Public methods (alphabetical)
+
+  // ---------------------------------------------------------------------------
+  // addVertex — computer.cpp:45-65
+  // ---------------------------------------------------------------------------
+
+  addVertex(): void {
+    const index = this.vertices.length;
+
+    // 1. Expand every existing RootBlossom's minOuterEdges array.
+    for (const rb of this.rootBlossoms) {
+      rb.minOuterEdges.push(undefined);
+    }
+
+    // 2. Create the dual variable for the new vertex (zero, same word width).
+    const dual = this.aboveMaxEdgeWeight.clone().and(0);
+    this.vertexDualVariables.push(dual);
+
+    // 3. Create the Vertex.
+    const zero = this.aboveMaxEdgeWeight.clone().and(0);
+    const vertex = new Vertex(index, zero);
+    vertex.dualVariable = dual;
+    this.vertices.push(vertex);
+
+    // 4. Expand all existing vertices' edgeWeights (add one zero slot for the
+    //    new vertex), and build the new vertex's full edgeWeights array.
+    for (let index_ = 0; index_ < index; index_++) {
+      const existingVertex = this.vertices[index_]!;
+      existingVertex.edgeWeights.push(this.aboveMaxEdgeWeight.clone().and(0));
+      vertex.edgeWeights.push(this.aboveMaxEdgeWeight.clone().and(0));
+    }
+    // The new vertex needs a slot for itself too (self-edge, always zero).
+    vertex.edgeWeights.push(this.aboveMaxEdgeWeight.clone().and(0));
+
+    // 5. Create singleton RootBlossom for the new vertex.
+    const rb = new RootBlossom(vertex, vertex, undefined, this);
+    vertex.rootBlossom = rb;
+
+    // The new RootBlossom's minOuterEdges needs one slot per existing vertex
+    // (including self).
+    for (let index_ = 0; index_ <= index; index_++) {
+      rb.minOuterEdges.push(undefined);
+    }
+
+    this.rootBlossoms.push(rb);
+    this.rootBlossomMinOuterEdgeResistances.push(
+      this.aboveMaxEdgeWeight.clone(),
+    );
+  }
+
+  // ---------------------------------------------------------------------------
+  // computeMatching — graph.cpp:791-849
+  // ---------------------------------------------------------------------------
+
+  computeMatching(): void {
+    // Parity fix phase: make all exposed-vertex dualVariables have even values.
+    // Iterate over a snapshot because freeAncestorOfBase modifies rootBlossoms.
+    const snapshot = [...this.rootBlossoms];
+    for (const rootBlossom of snapshot) {
+      if (
+        !rootBlossom.baseVertexMatch &&
+        !rootBlossom.baseVertex.dualVariable.clone().and(1).isZero()
+      ) {
+        // dualVariable is odd — fix parity.
+        let adjustableBlossom: Blossom = rootBlossom.rootChild;
+        setPointersFromAncestor(
+          rootBlossom.baseVertex,
+          adjustableBlossom,
+          true,
+        );
+
+        // Walk down to the deepest blossom with positive dual (or a vertex).
+        while (
+          !adjustableBlossom.isVertex &&
+          (adjustableBlossom as ParentBlossom).dualVariable.isZero()
+        ) {
+          adjustableBlossom = (adjustableBlossom as ParentBlossom).subblossom;
+        }
+
+        // This modifies rootBlossoms (splits the blossom).
+        // Access private method via bracket notation (same pattern as C++ friend).
+        rootBlossom['freeAncestorOfBase'](adjustableBlossom, this);
+
+        if (!adjustableBlossom.isVertex) {
+          // ParentBlossom dual -= 2.
+          (adjustableBlossom as ParentBlossom).dualVariable.subtract(2);
+        }
+
+        // Add 1 to every vertex's dual in the adjustable blossom.
+        for (
+          let v: Vertex | undefined = adjustableBlossom.vertexListHead;
+          v;
+          v = v.nextVertex
+        ) {
+          v.dualVariable.add(1);
+        }
+      }
+    }
+
+    // Main augmentation loop.
+    while (this.augmentMatching()) {
+      // keep augmenting until no more augmentations are possible
+    }
+  }
+
+  // Private methods (alphabetical)
+
+  // ---------------------------------------------------------------------------
+  // addVertex helper: initialize inner-outer edges
+  // ---------------------------------------------------------------------------
+
+  private applyDualAdjustment(
+    delta: DynamicUint,
+    minOuterDual: DynamicUint,
+    minInnerDual: DynamicUint,
+    minOuterOuterResistance: DynamicUint,
+    minInnerOuterResistance: DynamicUint,
+  ): void {
+    // Apply delta to all vertices and blossoms.
+    for (const rb of this.rootBlossoms) {
+      if (rb.label === Label.OUTER) {
+        // OUTER: vertex duals decrease by delta.
+        for (
+          let v: Vertex | undefined = rb.rootChild.vertexListHead;
+          v;
+          v = v.nextVertex
+        ) {
+          v.dualVariable.subtract(delta);
+        }
+        // OUTER blossom's rootChild ParentBlossom dual increases by 2*delta.
+        if (!rb.rootChild.isVertex) {
+          (rb.rootChild as ParentBlossom).dualVariable.add(delta).add(delta);
+        }
+        // Outer-outer resistances decrease by 2*delta.
+        rb.minOuterEdgeResistance.subtract(delta).subtract(delta);
+      } else if (rb.label === Label.INNER) {
+        // INNER: vertex duals increase by delta.
+        for (
+          let v: Vertex | undefined = rb.rootChild.vertexListHead;
+          v;
+          v = v.nextVertex
+        ) {
+          v.dualVariable.add(delta);
+        }
+        // INNER blossom's rootChild ParentBlossom dual decreases by 2*delta.
+        if (!rb.rootChild.isVertex) {
+          (rb.rootChild as ParentBlossom).dualVariable
+            .subtract(delta)
+            .subtract(delta);
+        }
+      } else {
+        // FREE / ZERO: inner-outer resistances decrease by delta.
+        for (
+          let v: Vertex | undefined = rb.rootChild.vertexListHead;
+          v;
+          v = v.nextVertex
+        ) {
+          if (v.minOuterEdge !== undefined) {
+            v.minOuterEdgeResistance.subtract(delta);
+          }
+        }
+      }
+    }
+
+    // Update the tracking variables.
+    minOuterDual.subtract(delta);
+    minInnerDual.subtract(delta).subtract(delta); // inner dual changes by 2*delta
+    minOuterOuterResistance.subtract(delta).subtract(delta);
+    minInnerOuterResistance.subtract(delta);
+  }
+
+  // ---------------------------------------------------------------------------
+  // augmentMatching — graph.cpp:395-785
+  // ---------------------------------------------------------------------------
+
+  private augmentMatching(): boolean {
+    if (this.rootBlossoms.length === 0) return false;
+
+    // -------------------------------------------------------------------------
+    // INITIALIZATION
+    // -------------------------------------------------------------------------
+
+    // Assign initial labels.
+    const minOuterDual = this.aboveMaxEdgeWeight.clone();
+    const minInnerDual = this.aboveMaxEdgeWeight.clone();
+
+    for (const rb of this.rootBlossoms) {
+      rb.labeledVertex = undefined;
+      rb.labelingVertex = undefined;
+      rb.minOuterEdgeResistance.copyFrom(this.aboveMaxEdgeWeight);
+      for (let index = 0; index < rb.minOuterEdges.length; index++) {
+        rb.minOuterEdges[index] = undefined;
+      }
+
+      if (rb.baseVertexMatch) {
+        rb.label = Label.FREE;
+      } else {
+        // Exposed vertex.
+        if (rb.baseVertex.dualVariable.isZero()) {
+          rb.label = Label.ZERO;
+        } else {
+          rb.label = Label.OUTER;
+          if (rb.baseVertex.dualVariable.lt(minOuterDual)) {
+            minOuterDual.copyFrom(rb.baseVertex.dualVariable);
+          }
+        }
+      }
+
+      // Reset vertex minOuterEdge tracking.
+      for (
+        let v: Vertex | undefined = rb.rootChild.vertexListHead;
+        v;
+        v = v.nextVertex
+      ) {
+        v.minOuterEdge = undefined;
+        v.minOuterEdgeResistance.copyFrom(this.aboveMaxEdgeWeight);
+      }
+    }
+
+    // Initialize inner-outer edges: for each non-OUTER blossom vertex, find
+    // cheapest edge to any OUTER vertex.
+    this.initializeInnerOuterEdges();
+
+    // Initialize outer-outer edges: for each pair of OUTER blossoms, find
+    // cheapest edge between them.
+    this.initializeOuterOuterEdges();
+
+    // Track minimum outer edge resistance across all RootBlossoms.
+    const minOuterOuterResistance = this.aboveMaxEdgeWeight.clone();
+    const minInnerOuterResistance = this.aboveMaxEdgeWeight.clone();
+
+    for (const rb of this.rootBlossoms) {
+      if (rb.label === Label.OUTER) {
+        if (rb.minOuterEdgeResistance.lt(minOuterOuterResistance)) {
+          minOuterOuterResistance.copyFrom(rb.minOuterEdgeResistance);
+        }
+      } else {
+        // FREE / ZERO: check inner-outer resistance
+        for (
+          let v: Vertex | undefined = rb.rootChild.vertexListHead;
+          v;
+          v = v.nextVertex
+        ) {
+          if (
+            v.minOuterEdge !== undefined &&
+            v.minOuterEdgeResistance.lt(minInnerOuterResistance)
+          ) {
+            minInnerOuterResistance.copyFrom(v.minOuterEdgeResistance);
+          }
+        }
+      }
+    }
+
+    // Also update minInnerDual from ParentBlossoms with INNER label.
+    for (const rb of this.rootBlossoms) {
+      if (rb.label === Label.INNER && !rb.rootChild.isVertex) {
+        const pb = rb.rootChild as ParentBlossom;
+        if (pb.dualVariable.lt(minInnerDual)) {
+          minInnerDual.copyFrom(pb.dualVariable);
+        }
+      }
+    }
+
+    // -------------------------------------------------------------------------
+    // MAIN LOOP
+    // -------------------------------------------------------------------------
+
+    for (;;) {
+      // Check if there are any OUTER vertices at all.
+      const hasOuter = this.rootBlossoms.some((rb) => rb.label === Label.OUTER);
+      if (!hasOuter) return false;
+
+      // Compute the dual adjustment delta.
+      // delta = min(
+      //   minOuterDual,                    // OUTER dual → 0
+      //   minInnerOuterResistance,         // FREE/ZERO↔OUTER edge tight
+      //   floor(minOuterOuterResistance/2),// OUTER↔OUTER edge tight
+      //   floor(minInnerDual/2)            // INNER blossom dual → 0
+      // )
+
+      const halfOuterOuter = minOuterOuterResistance.clone().shiftRight(1);
+      const halfInnerDual = minInnerDual.clone().shiftRight(1);
+
+      const delta = minOuterDual.clone();
+      if (minInnerOuterResistance.lt(delta))
+        delta.copyFrom(minInnerOuterResistance);
+      if (halfOuterOuter.lt(delta)) delta.copyFrom(halfOuterOuter);
+      if (halfInnerDual.lt(delta)) delta.copyFrom(halfInnerDual);
+
+      if (delta.isZero() && minOuterDual.isZero()) {
+        // An OUTER vertex hit 0 dual — augment to source.
+        return this.augmentFromZeroOuter();
+      }
+
+      // Apply dual adjustment.
+      this.applyDualAdjustment(
+        delta,
+        minOuterDual,
+        minInnerDual,
+        minOuterOuterResistance,
+        minInnerOuterResistance,
+      );
+
+      // Check which limit was reached.
+
+      // Case 1: OUTER vertex dual → 0
+      if (minOuterDual.isZero()) {
+        return this.augmentFromZeroOuter();
+      }
+
+      // Case 2/4: tight inner-outer edge
+      if (minInnerOuterResistance.isZero()) {
+        const result = this.handleTightInnerOuterEdge(
+          minOuterDual,
+          minInnerDual,
+          minOuterOuterResistance,
+          minInnerOuterResistance,
+        );
+        if (result !== undefined) return result;
+        // Continue loop — recalculate minima.
+        this.recalculateMinima(
+          minOuterDual,
+          minInnerDual,
+          minOuterOuterResistance,
+          minInnerOuterResistance,
+        );
+        continue;
+      }
+
+      // Case 3: OUTER↔OUTER edge tight
+      if (minOuterOuterResistance.isZero()) {
+        const result = this.handleTightOuterOuterEdge(
+          minOuterDual,
+          minInnerDual,
+          minOuterOuterResistance,
+          minInnerOuterResistance,
+        );
+        if (result !== undefined) return result;
+        this.recalculateMinima(
+          minOuterDual,
+          minInnerDual,
+          minOuterOuterResistance,
+          minInnerOuterResistance,
+        );
+        continue;
+      }
+
+      // Case 5: INNER blossom dual → 0
+      if (minInnerDual.isZero()) {
+        this.dissolveZeroDualInnerBlossom();
+        this.recalculateMinima(
+          minOuterDual,
+          minInnerDual,
+          minOuterOuterResistance,
+          minInnerOuterResistance,
+        );
+        continue;
+      }
+
+      // No more progress possible.
+      return false;
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Case 1: augment from OUTER vertex with zero dual
+  // ---------------------------------------------------------------------------
+
+  private augmentFromZeroOuter(): boolean {
+    // Find an OUTER vertex with zero dual.
+    for (const rb of this.rootBlossoms) {
+      if (rb.label === Label.OUTER && rb.baseVertex.dualVariable.isZero()) {
+        augmentToSource(rb.baseVertex);
+        return true;
+      }
+    }
+    return false;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Blossom formation (Case 3, same root)
+  // Ported from graph.cpp blossom-forming logic
+  // ---------------------------------------------------------------------------
+
+  private buildPathToRoot(v: Vertex, rb: RootBlossom): Vertex[] {
+    const path: Vertex[] = [];
+    let current: Vertex | undefined = v;
+    while (current && current.rootBlossom !== rb) {
+      path.push(current);
+      current = current.rootBlossom?.labelingVertex;
+    }
+    if (current) path.push(current);
+    return path;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Case 5: dissolve INNER blossom with zero dual
+  // ---------------------------------------------------------------------------
+
+  private dissolveZeroDualInnerBlossom(): void {
+    const snapshot = [...this.rootBlossoms];
+    for (const rb of snapshot) {
+      if (rb.label !== Label.INNER) continue;
+      if (rb.rootChild.isVertex) continue;
+      const pb = rb.rootChild as ParentBlossom;
+      if (!pb.dualVariable.isZero()) continue;
+
+      // Dissolve this blossom: create individual RootBlossoms for each child.
+      const pbIndex = this.parentBlossoms.indexOf(pb);
+      if (pbIndex !== -1) this.parentBlossoms.splice(pbIndex, 1);
+
+      const rbIndex = this.rootBlossoms.indexOf(rb);
+      if (rbIndex !== -1) this.rootBlossoms.splice(rbIndex, 1);
+
+      // Walk the blossom's children and create new RootBlossoms.
+      let child: Blossom | undefined = pb.subblossom;
+      let isOnLabelingPath = true;
+      do {
+        const baseV = isOnLabelingPath
+          ? (child!.vertexToNextSiblingBlossom ?? child!.vertexListHead)
+          : child!.vertexListHead;
+
+        const newRb = new RootBlossom(child!, baseV, undefined, this);
+        newRb.label = isOnLabelingPath ? Label.INNER : Label.FREE;
+        child!.parentBlossom = undefined;
+
+        for (
+          let v: Vertex | undefined = child!.vertexListHead;
+          v;
+          v = v.nextVertex
+        ) {
+          v.rootBlossom = newRb;
+        }
+
+        this.rootBlossoms.push(newRb);
+        this.rootBlossomMinOuterEdgeResistances.push(
+          this.aboveMaxEdgeWeight.clone(),
+        );
+
+        child = child!.nextBlossom;
+        isOnLabelingPath = !isOnLabelingPath;
+      } while (child !== pb.subblossom && child !== undefined);
+    }
+  }
+
+  private formNewBlossom(v1: Vertex, v2: Vertex, rb: RootBlossom): void {
+    // Build the path from v1 to root and from v2 to root, find LCA.
+    const path1 = this.buildPathToRoot(v1, rb);
+    const path2 = this.buildPathToRoot(v2, rb);
+
+    // Find LCA.
+    const inPath1 = new Set(path1.map((p) => p.vertexIndex));
+    let lcaIndex = -1;
+    for (const pv of path2) {
+      if (inPath1.has(pv.vertexIndex)) {
+        lcaIndex = pv.vertexIndex;
+        break;
+      }
+    }
+
+    if (lcaIndex === -1) {
+      // No common ancestor found — treat as cross-edge, augment.
+      augmentToSource(v1, v2);
+      augmentToSource(v2, v1);
+      return;
+    }
+
+    const lcaInPath1 = path1.findIndex((p) => p.vertexIndex === lcaIndex);
+    const lcaInPath2 = path2.findIndex((p) => p.vertexIndex === lcaIndex);
+
+    const cyclePart1 = path1.slice(0, lcaInPath1);
+    const cyclePart2 = path2.slice(0, lcaInPath2).toReversed();
+    const lcaVertex = this.vertices[lcaIndex]!;
+
+    // Create a new ParentBlossom that represents this cycle.
+    const cycleVertices = [v1, ...cyclePart1, lcaVertex, ...cyclePart2, v2];
+
+    const newDual = this.aboveMaxEdgeWeight.clone().and(0);
+    const newParent = new ParentBlossom(
+      newDual,
+      rb,
+      rb.rootChild,
+      rb.rootChild.vertexListHead,
+      rb.rootChild.vertexListTail,
+    );
+
+    // Connect all vertices in the cycle to the new parent.
+    for (const cv of cycleVertices) {
+      cv.parentBlossom = newParent;
+    }
+
+    this.parentBlossoms.push(newParent);
+    rb.rootChild = newParent;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Case 2/4: tight inner-outer edge
+  // ---------------------------------------------------------------------------
+
+  private handleTightInnerOuterEdge(
+    minOuterDual: DynamicUint,
+    minInnerDual: DynamicUint,
+    minOuterOuterResistance: DynamicUint,
+    minInnerOuterResistance: DynamicUint,
+  ): boolean | undefined {
+    for (const rb of this.rootBlossoms) {
+      if (rb.label === Label.OUTER) continue;
+
+      for (
+        let v: Vertex | undefined = rb.rootChild.vertexListHead;
+        v;
+        v = v.nextVertex
+      ) {
+        if (v.minOuterEdge !== undefined && v.minOuterEdgeResistance.isZero()) {
+          const outerV = v.minOuterEdge;
+
+          if (rb.label === Label.ZERO) {
+            // Case 2: ZERO vertex — tight edge, augment both directions.
+            augmentToSource(v, outerV);
+            augmentToSource(outerV, v);
+            return true;
+          } else {
+            // Case 4: FREE vertex — label it INNER, label its match OUTER.
+            rb.label = Label.INNER;
+            rb.labeledVertex = v;
+            rb.labelingVertex = outerV;
+
+            // The match of the base of rb becomes OUTER.
+            if (rb.baseVertexMatch) {
+              const matchRb = rb.baseVertexMatch.rootBlossom!;
+              if (matchRb.label === Label.FREE) {
+                matchRb.label = Label.OUTER;
+                matchRb.labeledVertex = rb.baseVertexMatch;
+                matchRb.labelingVertex = rb.baseVertex;
+
+                // Update minOuterDual.
+                if (
+                  minOuterDual.compareTo(this.aboveMaxEdgeWeight) === 0 ||
+                  rb.baseVertexMatch.dualVariable.lt(minOuterDual)
+                ) {
+                  minOuterDual.copyFrom(rb.baseVertexMatch.dualVariable);
+                }
+
+                // Re-initialize inner-outer edges for the new OUTER blossom.
+                this.updateInnerOuterEdgesForNewOuter(
+                  matchRb,
+                  minInnerOuterResistance,
+                );
+
+                // Re-initialize outer-outer edges for the new OUTER blossom.
+                this.updateOuterOuterEdgesForNewOuter(
+                  matchRb,
+                  minOuterOuterResistance,
+                );
+              }
+            }
+
+            void minInnerDual;
+            return undefined; // continue loop
+          }
+        }
+      }
+    }
+    return undefined;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Case 3: tight outer-outer edge
+  // ---------------------------------------------------------------------------
+
+  private handleTightOuterOuterEdge(
+    minOuterDual: DynamicUint,
+    minInnerDual: DynamicUint,
+    minOuterOuterResistance: DynamicUint,
+    minInnerOuterResistance: DynamicUint,
+  ): boolean | undefined {
+    // Find the OUTER blossom with zero minOuterEdgeResistance.
+    for (const rb1 of this.rootBlossoms) {
+      if (rb1.label !== Label.OUTER) continue;
+      if (!rb1.minOuterEdgeResistance.isZero()) continue;
+
+      let bestV1: Vertex | undefined;
+      let bestV2: Vertex | undefined;
+
+      outer: for (const rb2 of this.rootBlossoms) {
+        if (rb2 === rb1 || rb2.label !== Label.OUTER) continue;
+        for (
+          let v1: Vertex | undefined = rb1.rootChild.vertexListHead;
+          v1;
+          v1 = v1.nextVertex
+        ) {
+          for (
+            let v2: Vertex | undefined = rb2.rootChild.vertexListHead;
+            v2;
+            v2 = v2.nextVertex
+          ) {
+            if (v1.vertexIndex === v2.vertexIndex) continue;
+            const r = resistance(v1, v2);
+            if (r.isZero()) {
+              bestV1 = v1;
+              bestV2 = v2;
+              break outer;
+            }
+          }
+        }
+      }
+
+      if (bestV1 === undefined || bestV2 === undefined) continue;
+
+      const rb2 = bestV2.rootBlossom!;
+
+      if (rb1 === rb2) {
+        // Same root — form a new blossom.
+        this.formNewBlossom(bestV1, bestV2, rb1);
+        void minOuterDual;
+        void minInnerDual;
+        void minOuterOuterResistance;
+        void minInnerOuterResistance;
+        return undefined;
+      } else {
+        // Different roots — augment.
+        augmentToSource(bestV1, bestV2);
+        augmentToSource(bestV2, bestV1);
+        return true;
+      }
+    }
+    return undefined;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Initialization helpers
+  // ---------------------------------------------------------------------------
+
+  private initializeInnerOuterEdges(): void {
+    for (const rb of this.rootBlossoms) {
+      if (rb.label === Label.OUTER) continue;
+      for (
+        let v: Vertex | undefined = rb.rootChild.vertexListHead;
+        v;
+        v = v.nextVertex
+      ) {
+        for (const outerRb of this.rootBlossoms) {
+          if (outerRb.label !== Label.OUTER) continue;
+          for (
+            let outerV: Vertex | undefined = outerRb.rootChild.vertexListHead;
+            outerV;
+            outerV = outerV.nextVertex
+          ) {
+            if (v.vertexIndex === outerV.vertexIndex) continue;
+            const r = resistance(v, outerV);
+            if (
+              v.minOuterEdge === undefined ||
+              r.lt(v.minOuterEdgeResistance)
+            ) {
+              v.minOuterEdge = outerV;
+              v.minOuterEdgeResistance.copyFrom(r);
+            }
+          }
+        }
+      }
+    }
+  }
+
+  private initializeOuterOuterEdges(): void {
+    for (const rb of this.rootBlossoms) {
+      if (rb.label !== Label.OUTER) continue;
+      for (const otherRb of this.rootBlossoms) {
+        if (otherRb === rb) continue;
+        if (otherRb.label !== Label.OUTER) continue;
+        this.updateOuterOuterEdge(rb, otherRb);
+      }
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Recalculate minima after structural changes
+  // ---------------------------------------------------------------------------
+
+  private recalculateMinima(
+    minOuterDual: DynamicUint,
+    minInnerDual: DynamicUint,
+    minOuterOuterResistance: DynamicUint,
+    minInnerOuterResistance: DynamicUint,
+  ): void {
+    minOuterDual.copyFrom(this.aboveMaxEdgeWeight);
+    minInnerDual.copyFrom(this.aboveMaxEdgeWeight);
+    minOuterOuterResistance.copyFrom(this.aboveMaxEdgeWeight);
+    minInnerOuterResistance.copyFrom(this.aboveMaxEdgeWeight);
+
+    for (const rb of this.rootBlossoms) {
+      if (rb.label === Label.OUTER) {
+        if (rb.baseVertex.dualVariable.lt(minOuterDual)) {
+          minOuterDual.copyFrom(rb.baseVertex.dualVariable);
+        }
+        if (rb.minOuterEdgeResistance.lt(minOuterOuterResistance)) {
+          minOuterOuterResistance.copyFrom(rb.minOuterEdgeResistance);
+        }
+      } else if (rb.label === Label.INNER) {
+        if (!rb.rootChild.isVertex) {
+          const pb = rb.rootChild as ParentBlossom;
+          if (pb.dualVariable.lt(minInnerDual)) {
+            minInnerDual.copyFrom(pb.dualVariable);
+          }
+        }
+      } else {
+        for (
+          let v: Vertex | undefined = rb.rootChild.vertexListHead;
+          v;
+          v = v.nextVertex
+        ) {
+          if (
+            v.minOuterEdge !== undefined &&
+            v.minOuterEdgeResistance.lt(minInnerOuterResistance)
+          ) {
+            minInnerOuterResistance.copyFrom(v.minOuterEdgeResistance);
+          }
+        }
+      }
+    }
+  }
+
+  private updateInnerOuterEdgesForNewOuter(
+    newOuterRb: RootBlossom,
+    minInnerOuterResistance: DynamicUint,
+  ): void {
+    for (const rb of this.rootBlossoms) {
+      if (rb === newOuterRb || rb.label === Label.OUTER) continue;
+      for (
+        let v: Vertex | undefined = rb.rootChild.vertexListHead;
+        v;
+        v = v.nextVertex
+      ) {
+        for (
+          let outerV: Vertex | undefined = newOuterRb.rootChild.vertexListHead;
+          outerV;
+          outerV = outerV.nextVertex
+        ) {
+          if (v.vertexIndex === outerV.vertexIndex) continue;
+          const r = resistance(v, outerV);
+          if (v.minOuterEdge === undefined || r.lt(v.minOuterEdgeResistance)) {
+            v.minOuterEdge = outerV;
+            v.minOuterEdgeResistance.copyFrom(r);
+            if (r.lt(minInnerOuterResistance)) {
+              minInnerOuterResistance.copyFrom(r);
+            }
+          }
+        }
+      }
+    }
+  }
+
+  private updateOuterOuterEdge(rb1: RootBlossom, rb2: RootBlossom): void {
+    for (
+      let v1: Vertex | undefined = rb1.rootChild.vertexListHead;
+      v1;
+      v1 = v1.nextVertex
+    ) {
+      for (
+        let v2: Vertex | undefined = rb2.rootChild.vertexListHead;
+        v2;
+        v2 = v2.nextVertex
+      ) {
+        if (v1.vertexIndex === v2.vertexIndex) continue;
+        const r = resistance(v1, v2);
+        if (
+          rb1.minOuterEdgeResistance.compareTo(this.aboveMaxEdgeWeight) === 0 ||
+          r.lt(rb1.minOuterEdgeResistance)
+        ) {
+          rb1.minOuterEdgeResistance.copyFrom(r);
+          rb1.minOuterEdges[v2.vertexIndex] = v1;
+        }
+      }
+    }
+  }
+
+  private updateOuterOuterEdgesForNewOuter(
+    newOuterRb: RootBlossom,
+    minOuterOuterResistance: DynamicUint,
+  ): void {
+    for (const rb of this.rootBlossoms) {
+      if (rb === newOuterRb || rb.label !== Label.OUTER) continue;
+      this.updateOuterOuterEdge(rb, newOuterRb);
+      this.updateOuterOuterEdge(newOuterRb, rb);
+      if (rb.minOuterEdgeResistance.lt(minOuterOuterResistance)) {
+        minOuterOuterResistance.copyFrom(rb.minOuterEdgeResistance);
+      }
+      if (newOuterRb.minOuterEdgeResistance.lt(minOuterOuterResistance)) {
+        minOuterOuterResistance.copyFrom(newOuterRb.minOuterEdgeResistance);
+      }
+    }
+  }
+}
+
+export { Graph };

--- a/src/matching/graph.ts
+++ b/src/matching/graph.ts
@@ -124,7 +124,7 @@ class Graph implements GraphLike {
 
     // 3. Create the Vertex.
     const zero = this.aboveMaxEdgeWeight.clone().and(0);
-    const vertex = new Vertex(index, zero);
+    const vertex = new Vertex(index, zero, this.aboveMaxEdgeWeight);
     vertex.dualVariable = dual;
     this.vertices.push(vertex);
 

--- a/src/matching/graph.ts
+++ b/src/matching/graph.ts
@@ -429,8 +429,10 @@ class Graph implements GraphLike {
         if (rb0 !== undefined) {
           for (const rb1 of this.rootBlossoms) {
             if (rb1.label !== Label.OUTER || rb1 === rb0) continue;
-            const v0 = rb0.minOuterEdges[rb1.baseVertex.vertexIndex];
-            const v1 = rb1.minOuterEdges[rb0.baseVertex.vertexIndex];
+            const v0: Vertex | undefined =
+              rb0.minOuterEdges[rb1.baseVertex.vertexIndex];
+            const v1: Vertex | undefined =
+              rb1.minOuterEdges[rb0.baseVertex.vertexIndex];
             if (
               v0 !== undefined &&
               v1 !== undefined &&

--- a/src/matching/graph.ts
+++ b/src/matching/graph.ts
@@ -28,9 +28,8 @@ import type { Blossom, GraphLike } from './blossom.js';
 // ---------------------------------------------------------------------------
 
 /**
- * Compute resistance into a pre-allocated DynamicUint (zero allocation).
+ * Compute resistance into pre-allocated DynamicUint (zero allocation).
  * resistance(u, v) = u.dual + v.dual - w(u, v)
- * C++ equivalent: vertex.resistance(result, other)
  */
 function resistanceInto(out: DynamicUint, u: Vertex, v: Vertex): void {
   out.copyFrom(u.dualVariable);
@@ -96,7 +95,7 @@ class Graph implements GraphLike {
   /** All active RootBlossoms. Implements GraphLike.rootBlossoms. */
   rootBlossoms: RootBlossom[] = [];
 
-  /** Pre-allocated scratch for resistance calculations (zero-alloc hot path). */
+  /** Pre-allocated scratch for resistance calculations. */
   private readonly resistanceStorage: DynamicUint;
 
   constructor(maxEdgeWeight: DynamicUint) {
@@ -863,24 +862,31 @@ class Graph implements GraphLike {
    * For each non-OUTER blossom vertex, find cheapest edge to any OUTER vertex.
    */
   private initializeInnerOuterEdges(): void {
-    // Pre-collect outer vertices (C++ graph.cpp:240-248).
-    const outerVertices: Vertex[] = [];
-    for (const v of this.vertices) {
-      if (v.rootBlossom!.label === Label.OUTER) {
-        outerVertices.push(v);
-      }
-    }
-
     const rs = this.resistanceStorage;
-    for (const v of this.vertices) {
-      if (v.rootBlossom!.label === Label.OUTER) continue;
-      v.minOuterEdgeResistance.copyFrom(this.aboveMaxEdgeWeight);
-      v.minOuterEdge = undefined;
-      for (const outerV of outerVertices) {
-        resistanceInto(rs, outerV, v);
-        if (rs.lt(v.minOuterEdgeResistance)) {
-          v.minOuterEdgeResistance.copyFrom(rs);
-          v.minOuterEdge = outerV;
+    for (const rb of this.rootBlossoms) {
+      if (rb.label === Label.OUTER) continue;
+      for (
+        let v: Vertex | undefined = rb.rootChild.vertexListHead;
+        v;
+        v = v.nextVertex
+      ) {
+        for (const outerRb of this.rootBlossoms) {
+          if (outerRb.label !== Label.OUTER) continue;
+          for (
+            let outerV: Vertex | undefined = outerRb.rootChild.vertexListHead;
+            outerV;
+            outerV = outerV.nextVertex
+          ) {
+            if (v.vertexIndex === outerV.vertexIndex) continue;
+            resistanceInto(rs, v, outerV);
+            if (
+              v.minOuterEdge === undefined ||
+              rs.lt(v.minOuterEdgeResistance)
+            ) {
+              v.minOuterEdge = outerV;
+              v.minOuterEdgeResistance.copyFrom(rs);
+            }
+          }
         }
       }
     }
@@ -893,10 +899,9 @@ class Graph implements GraphLike {
   private initializeOuterOuterEdges(): void {
     for (const rb of this.rootBlossoms) {
       if (rb.label !== Label.OUTER) continue;
-      rb.minOuterEdgeResistance.copyFrom(this.aboveMaxEdgeWeight);
       for (const otherRb of this.rootBlossoms) {
-        if (otherRb === rb || otherRb.label !== Label.OUTER) continue;
-        rb.minOuterEdges[otherRb.baseVertex.vertexIndex] = undefined;
+        if (otherRb === rb) continue;
+        if (otherRb.label !== Label.OUTER) continue;
         this.updateOuterOuterEdgePair(rb, otherRb);
       }
     }
@@ -907,11 +912,10 @@ class Graph implements GraphLike {
    * other OUTER blossoms (single-blossom variant, C++ initializeOuterOuterEdges(blossom)).
    */
   private initializeOuterOuterEdgesForBlossom(newOuterRb: RootBlossom): void {
-    newOuterRb.minOuterEdgeResistance.copyFrom(this.aboveMaxEdgeWeight);
     for (const rb of this.rootBlossoms) {
       if (rb === newOuterRb || rb.label !== Label.OUTER) continue;
-      newOuterRb.minOuterEdges[rb.baseVertex.vertexIndex] = undefined;
       this.updateOuterOuterEdgePair(newOuterRb, rb);
+      this.updateOuterOuterEdgePair(rb, newOuterRb);
     }
   }
 
@@ -923,17 +927,24 @@ class Graph implements GraphLike {
    */
   private updateInnerOuterEdges(newOuterRb: RootBlossom): void {
     const rs = this.resistanceStorage;
-    for (const innerVertex of this.vertices) {
-      if (innerVertex.rootBlossom!.label === Label.OUTER) continue;
+    for (const rb of this.rootBlossoms) {
+      if (rb === newOuterRb || rb.label === Label.OUTER) continue;
       for (
-        let outerV: Vertex | undefined = newOuterRb.rootChild.vertexListHead;
-        outerV;
-        outerV = outerV.nextVertex
+        let v: Vertex | undefined = rb.rootChild.vertexListHead;
+        v;
+        v = v.nextVertex
       ) {
-        resistanceInto(rs, outerV, innerVertex);
-        if (rs.lt(innerVertex.minOuterEdgeResistance)) {
-          innerVertex.minOuterEdgeResistance.copyFrom(rs);
-          innerVertex.minOuterEdge = outerV;
+        for (
+          let outerV: Vertex | undefined = newOuterRb.rootChild.vertexListHead;
+          outerV;
+          outerV = outerV.nextVertex
+        ) {
+          if (v.vertexIndex === outerV.vertexIndex) continue;
+          resistanceInto(rs, v, outerV);
+          if (v.minOuterEdge === undefined || rs.lt(v.minOuterEdgeResistance)) {
+            v.minOuterEdge = outerV;
+            v.minOuterEdgeResistance.copyFrom(rs);
+          }
         }
       }
     }
@@ -946,13 +957,7 @@ class Graph implements GraphLike {
    * rb1.minOuterEdgeResistance.
    */
   private updateOuterOuterEdgePair(rb1: RootBlossom, rb2: RootBlossom): void {
-    // Get actual rootBlossoms (C++ graph.cpp:123-126).
-    const actual1 = rb1.rootChild.rootBlossom!;
-    const actual2 = rb2.rootChild.rootBlossom!;
-
     const rs = this.resistanceStorage;
-    const minResistance = this.aboveMaxEdgeWeight.clone();
-
     for (
       let v1: Vertex | undefined = rb1.rootChild.vertexListHead;
       v1;
@@ -963,18 +968,15 @@ class Graph implements GraphLike {
         v2;
         v2 = v2.nextVertex
       ) {
+        if (v1.vertexIndex === v2.vertexIndex) continue;
         resistanceInto(rs, v1, v2);
-        if (rs.lt(minResistance)) {
-          minResistance.copyFrom(rs);
-          // Index by the OTHER blossom's base vertex (C++ graph.cpp:150-155).
-          actual1.minOuterEdges[actual2.baseVertex.vertexIndex] = v1;
-          actual2.minOuterEdges[actual1.baseVertex.vertexIndex] = v2;
-          if (minResistance.lt(actual1.minOuterEdgeResistance)) {
-            actual1.minOuterEdgeResistance.copyFrom(minResistance);
-          }
-          if (minResistance.lt(actual2.minOuterEdgeResistance)) {
-            actual2.minOuterEdgeResistance.copyFrom(minResistance);
-          }
+        if (
+          rb1.minOuterEdgeResistance.lt(this.aboveMaxEdgeWeight)
+            ? rs.lt(rb1.minOuterEdgeResistance)
+            : true
+        ) {
+          rb1.minOuterEdgeResistance.copyFrom(rs);
+          rb1.minOuterEdges[v2.vertexIndex] = v1;
         }
       }
     }

--- a/src/matching/iterable-pool.ts
+++ b/src/matching/iterable-pool.ts
@@ -1,0 +1,138 @@
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
+/**
+ * IterablePool — fixed-capacity object pool with linked-list iteration.
+ *
+ * Matches the allocation/iteration semantics of bbpPairings'
+ * utility::memory::IterablePool. Elements are allocated from a LIFO free
+ * list and appended to a doubly-linked iteration list.
+ *
+ * @internal Not part of the public API.
+ */
+class IterablePool<T> {
+  /** First allocated slot (visible or hidden), or -1 if none. */
+  #allocatedHead = -1;
+
+  /** Per-slot backward link for allocated slots (-1 = none). */
+  readonly #backward: Int32Array;
+
+  /**
+   * Per-slot forward link. For iterable slots: next iterable slot index
+   * (-1 = end). For free slots: next free slot index (-1 = end).
+   * For hidden (allocated non-iterable) slots: next allocated slot index.
+   */
+  readonly #forward: Int32Array;
+
+  /** First visible (iterable) slot, or -1 if none. */
+  #head = -1;
+
+  /** Slot storage. undefined = unallocated. */
+  readonly #slots: (T | undefined)[];
+
+  /** Last allocated slot (visible or hidden), or -1 if none. */
+  #tail = -1;
+
+  /** First unallocated (free) slot, or -1 if none. */
+  #unallocatedHead: number;
+
+  constructor(capacity: number) {
+    this.#slots = Array.from<T | undefined>({ length: capacity }).fill(
+      
+    );
+    this.#forward = new Int32Array(capacity).fill(-1);
+    this.#backward = new Int32Array(capacity).fill(-1);
+    // Initialize free list: 0 → 1 → 2 → ... → capacity-1
+    this.#unallocatedHead = capacity > 0 ? 0 : -1;
+    for (let index = 0; index < capacity - 1; index++) {
+      this.#forward[index] = index + 1;
+    }
+  }
+
+  /** Iterate over visible (non-hidden) elements in linked-list order. */
+  *[Symbol.iterator](): Generator<T> {
+    let slot = this.#head;
+    while (slot !== -1) {
+      yield this.#slots[slot] as T;
+      slot = this.#forward[slot]!;
+    }
+  }
+
+  /** Allocate a slot, store `value`, append to iteration tail. Returns slot index. */
+  construct(value: T): number {
+    const slot = this.#unallocatedHead;
+    if (slot === -1) throw new RangeError('IterablePool: capacity exceeded');
+
+    // Remove from free list
+    this.#unallocatedHead = this.#forward[slot]!;
+
+    // Store value
+    this.#slots[slot] = value;
+
+    // Append to iteration tail
+    this.#backward[slot] = this.#tail;
+    if (this.#tail !== -1) {
+      this.#forward[this.#tail] = slot;
+    }
+    this.#tail = slot;
+    this.#forward[slot] = -1;
+
+    if (this.#head === -1) this.#head = slot;
+    if (this.#allocatedHead === -1) this.#allocatedHead = slot;
+
+    return slot;
+  }
+
+  /** Destroy: remove from lists entirely, return slot to free list. */
+  destroy(slot: number): void {
+    const fwd = this.#forward[slot]!;
+    const bwd = this.#backward[slot]!;
+
+    // Unlink from whatever list it's in
+    if (fwd === -1) {this.#tail = bwd;}
+    else {this.#backward[fwd] = bwd;}
+
+    if (bwd === -1) {this.#allocatedHead = fwd;}
+    else {this.#forward[bwd] = fwd;}
+
+    if (this.#head === slot) this.#head = fwd;
+
+    // Clear value
+    this.#slots[slot] = undefined;
+
+    // Push to free list (LIFO)
+    this.#forward[slot] = this.#unallocatedHead;
+    this.#unallocatedHead = slot;
+  }
+
+  /** Get value at slot index. */
+  get(slot: number): T {
+    return this.#slots[slot] as T;
+  }
+
+  /** Remove from iteration list but keep alive. */
+  hide(slot: number): void {
+    const fwd = this.#forward[slot]!;
+    const bwd = this.#backward[slot]!;
+
+    // Unlink from iteration list
+    if (fwd === -1) {this.#tail = bwd;}
+    else {this.#backward[fwd] = bwd;}
+
+    if (bwd === -1) {this.#allocatedHead = fwd;}
+    else {this.#forward[bwd] = fwd;}
+
+    if (this.#head === slot) this.#head = fwd;
+
+    // Prepend to allocated (non-iterable) head
+    if (this.#allocatedHead !== -1) {
+      this.#backward[this.#allocatedHead] = slot;
+    }
+    this.#forward[slot] = this.#allocatedHead;
+
+    this.#allocatedHead = slot;
+    this.#backward[slot] = -1;
+
+    if (this.#tail === -1) this.#tail = this.#allocatedHead;
+  }
+}
+
+export { IterablePool };

--- a/src/matching/iterable-pool.ts
+++ b/src/matching/iterable-pool.ts
@@ -35,9 +35,7 @@ class IterablePool<T> {
   #unallocatedHead: number;
 
   constructor(capacity: number) {
-    this.#slots = Array.from<T | undefined>({ length: capacity }).fill(
-      
-    );
+    this.#slots = Array.from<T | undefined>({ length: capacity });
     this.#forward = new Int32Array(capacity).fill(-1);
     this.#backward = new Int32Array(capacity).fill(-1);
     // Initialize free list: 0 → 1 → 2 → ... → capacity-1
@@ -87,11 +85,17 @@ class IterablePool<T> {
     const bwd = this.#backward[slot]!;
 
     // Unlink from whatever list it's in
-    if (fwd === -1) {this.#tail = bwd;}
-    else {this.#backward[fwd] = bwd;}
+    if (fwd === -1) {
+      this.#tail = bwd;
+    } else {
+      this.#backward[fwd] = bwd;
+    }
 
-    if (bwd === -1) {this.#allocatedHead = fwd;}
-    else {this.#forward[bwd] = fwd;}
+    if (bwd === -1) {
+      this.#allocatedHead = fwd;
+    } else {
+      this.#forward[bwd] = fwd;
+    }
 
     if (this.#head === slot) this.#head = fwd;
 
@@ -114,11 +118,17 @@ class IterablePool<T> {
     const bwd = this.#backward[slot]!;
 
     // Unlink from iteration list
-    if (fwd === -1) {this.#tail = bwd;}
-    else {this.#backward[fwd] = bwd;}
+    if (fwd === -1) {
+      this.#tail = bwd;
+    } else {
+      this.#backward[fwd] = bwd;
+    }
 
-    if (bwd === -1) {this.#allocatedHead = fwd;}
-    else {this.#forward[bwd] = fwd;}
+    if (bwd === -1) {
+      this.#allocatedHead = fwd;
+    } else {
+      this.#forward[bwd] = fwd;
+    }
 
     if (this.#head === slot) this.#head = fwd;
 

--- a/src/matching/types.ts
+++ b/src/matching/types.ts
@@ -1,0 +1,19 @@
+/**
+ * Label enum for blossom labels used during augmentation.
+ *
+ * Ported from bbpPairings vertex labelling conventions.
+ *
+ * @internal Not part of the public API.
+ */
+const enum Label {
+  /** Exposed vertex with positive dual — root of alternating tree. */
+  OUTER = 0,
+  /** Exposed vertex with zero dual — can augment via zero-resistance edge. */
+  ZERO = 1,
+  /** Matched vertex in alternating tree at odd depth. */
+  INNER = 2,
+  /** Matched vertex not yet reached by alternating tree. */
+  FREE = 3,
+}
+
+export { Label };

--- a/src/matching/vertex.ts
+++ b/src/matching/vertex.ts
@@ -1,0 +1,114 @@
+import type { DynamicUint } from '../dynamic-uint.js';
+
+/**
+ * Per-vertex state for the persistent matching computer.
+ *
+ * Ported from bbpPairings `vertexsig.h` + `verteximpl.h`.
+ *
+ * Dual variable is NOT stored here — it lives in
+ * `graph.vertexDualVariables[vertex.vertexIndex]`.
+ *
+ * Edge weights are stored doubled internally to keep all values integral
+ * when divided for dual-variable arithmetic.
+ *
+ * @internal Not part of the public API.
+ */
+class Vertex {
+  /** Discriminator — always `true` for Vertex, used to distinguish from Blossom in the union type. */
+  readonly isVertex = true as const;
+
+  /** Immutable index identifying this vertex within the graph. */
+  readonly vertexIndex: number;
+
+  /** Edge weights indexed by the other vertex's index (stored doubled). */
+  edgeWeights: DynamicUint[];
+
+  // ---------------------------------------------------------------------------
+  // Augmentation bookkeeping
+  // ---------------------------------------------------------------------------
+
+  /**
+   * The other endpoint of the minimum-resistance outer edge.
+   * `undefined` when no such edge has been recorded.
+   */
+  minOuterEdge: Vertex | undefined;
+
+  /**
+   * Minimum resistance among outgoing outer edges from this vertex.
+   * Initialised to a zero-valued DynamicUint of appropriate word size.
+   */
+  minOuterEdgeResistance: DynamicUint;
+
+  // ---------------------------------------------------------------------------
+  // Blossom child links
+  // ---------------------------------------------------------------------------
+
+  /** Next blossom child link. */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  nextBlossom: any;
+
+  /** Next vertex in the linked list of vertices belonging to the same RootBlossom. */
+  nextVertex: Vertex | undefined;
+
+  // ---------------------------------------------------------------------------
+  // Blossom tree membership
+  // ---------------------------------------------------------------------------
+
+  /**
+   * The immediate parent blossom of this vertex within the blossom tree.
+   * Permissive type — tightened in Task 2 when Blossom classes are introduced.
+   */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  parentBlossom: any;
+
+  /** Previous blossom child link. */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  previousBlossom: any;
+
+  /**
+   * The RootBlossom at the top of the blossom tree containing this vertex.
+   * Permissive type — tightened in Task 2 when Blossom classes are introduced.
+   */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  rootBlossom: any;
+
+  // ---------------------------------------------------------------------------
+  // Vertex linked list through enclosing RootBlossom
+  // ---------------------------------------------------------------------------
+
+  /** Head of the vertex list for the RootBlossom rooted at this vertex (points to self when singleton). */
+  vertexListHead: Vertex;
+
+  /** Tail of the vertex list for the RootBlossom rooted at this vertex (points to self when singleton). */
+  vertexListTail: Vertex;
+
+  // ---------------------------------------------------------------------------
+  // Sibling links within parent blossom
+  // ---------------------------------------------------------------------------
+
+  /** Link to the next sibling blossom within the parent blossom. */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  vertexToNextSiblingBlossom: any;
+
+  /** Link to the previous sibling blossom within the parent blossom. */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  vertexToPreviousSiblingBlossom: any;
+
+  constructor(index: number, zero: DynamicUint) {
+    this.vertexIndex = index;
+    this.edgeWeights = [];
+    this.minOuterEdge = undefined;
+    this.minOuterEdgeResistance = zero.clone();
+    this.nextBlossom = undefined;
+    this.nextVertex = undefined;
+    this.parentBlossom = undefined;
+    this.previousBlossom = undefined;
+    this.rootBlossom = undefined;
+    this.vertexListHead = this;
+    this.vertexListTail = this;
+    this.vertexToNextSiblingBlossom = undefined;
+    this.vertexToPreviousSiblingBlossom = undefined;
+  }
+}
+
+export { Vertex };

--- a/src/matching/vertex.ts
+++ b/src/matching/vertex.ts
@@ -1,12 +1,13 @@
 import type { DynamicUint } from '../dynamic-uint.js';
+import type { Blossom, ParentBlossom, RootBlossom } from './blossom.js';
 
 /**
  * Per-vertex state for the persistent matching computer.
  *
  * Ported from bbpPairings `vertexsig.h` + `verteximpl.h`.
  *
- * Dual variable is NOT stored here — it lives in
- * `graph.vertexDualVariables[vertex.vertexIndex]`.
+ * Dual variable is aliased from `graph.vertexDualVariables[vertex.vertexIndex]`
+ * — both reference the same DynamicUint object.
  *
  * Edge weights are stored doubled internally to keep all values integral
  * when divided for dual-variable arithmetic.
@@ -19,6 +20,12 @@ class Vertex {
 
   /** Immutable index identifying this vertex within the graph. */
   readonly vertexIndex: number;
+
+  /**
+   * Dual variable for this vertex. Alias of `graph.vertexDualVariables[vertexIndex]`.
+   * Set when the vertex is added to the graph (Task 3).
+   */
+  dualVariable!: DynamicUint;
 
   /** Edge weights indexed by the other vertex's index (stored doubled). */
   edgeWeights: DynamicUint[];
@@ -44,8 +51,7 @@ class Vertex {
   // ---------------------------------------------------------------------------
 
   /** Next blossom child link. */
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  nextBlossom: any;
+  nextBlossom: Blossom | undefined;
 
   /** Next vertex in the linked list of vertices belonging to the same RootBlossom. */
   nextVertex: Vertex | undefined;
@@ -54,23 +60,17 @@ class Vertex {
   // Blossom tree membership
   // ---------------------------------------------------------------------------
 
-  /**
-   * The immediate parent blossom of this vertex within the blossom tree.
-   * Permissive type — tightened in Task 2 when Blossom classes are introduced.
-   */
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  parentBlossom: any;
+  /** The immediate parent blossom of this vertex within the blossom tree. */
+  parentBlossom: ParentBlossom | undefined;
 
   /** Previous blossom child link. */
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  previousBlossom: any;
+  previousBlossom: Blossom | undefined;
 
   /**
    * The RootBlossom at the top of the blossom tree containing this vertex.
-   * Permissive type — tightened in Task 2 when Blossom classes are introduced.
+   * `undefined` until this vertex is placed under a RootBlossom.
    */
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  rootBlossom: any;
+  rootBlossom: RootBlossom | undefined;
 
   // ---------------------------------------------------------------------------
   // Vertex linked list through enclosing RootBlossom
@@ -87,12 +87,10 @@ class Vertex {
   // ---------------------------------------------------------------------------
 
   /** Link to the next sibling blossom within the parent blossom. */
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  vertexToNextSiblingBlossom: any;
+  vertexToNextSiblingBlossom: Vertex | undefined;
 
   /** Link to the previous sibling blossom within the parent blossom. */
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  vertexToPreviousSiblingBlossom: any;
+  vertexToPreviousSiblingBlossom: Vertex | undefined;
 
   constructor(index: number, zero: DynamicUint) {
     this.vertexIndex = index;

--- a/src/matching/vertex.ts
+++ b/src/matching/vertex.ts
@@ -92,11 +92,16 @@ class Vertex {
   /** Link to the previous sibling blossom within the parent blossom. */
   vertexToPreviousSiblingBlossom: Vertex | undefined;
 
-  constructor(index: number, zero: DynamicUint) {
+  constructor(
+    index: number,
+    zero: DynamicUint,
+    aboveMaxEdgeWeight?: DynamicUint,
+  ) {
     this.vertexIndex = index;
     this.edgeWeights = [];
     this.minOuterEdge = undefined;
-    this.minOuterEdgeResistance = zero.clone();
+    // C++ verteximpl.h:29 — initialised to aboveMaxEdgeWeight (infinity sentinel).
+    this.minOuterEdgeResistance = (aboveMaxEdgeWeight ?? zero).clone();
     this.nextBlossom = undefined;
     this.nextVertex = undefined;
     this.parentBlossom = undefined;

--- a/src/swiss-team.ts
+++ b/src/swiss-team.ts
@@ -9,6 +9,7 @@ import {
   typeAColorPreference,
 } from './utilities.js';
 
+import type { PairOptions } from './trace.js';
 import type { Game, PairingResult, Player } from './types.js';
 import type { PlayerState } from './utilities.js';
 
@@ -133,20 +134,56 @@ function makeAllocateTeamColors(
  * Swiss Team pairing (FIDE C.04.6).
  * Each round is a single match between teams.
  */
-function pair(players: Player[], games: Game[][]): PairingResult {
+function pair(
+  players: Player[],
+  games: Game[][],
+  options?: PairOptions,
+): PairingResult {
   if (players.length < 2) {
     throw new RangeError('at least 2 players are required');
   }
+
+  const trace = options?.trace;
 
   const states = buildPlayerStates(players, games);
   const ranked = rankByScoreThenTPN(states);
   const byeState = assignLexicographicBye(ranked);
 
-  const toBePaired = ranked.filter((s) => s.id !== byeState?.id);
+  const byeId = byeState?.id;
+
+  if (trace && byeId !== undefined) {
+    trace({
+      playerId: byeId,
+      reason: 'lowest-score-no-prior-bye',
+      system: 'swiss-team',
+      type: 'pairing:bye-assigned',
+    });
+  }
+
+  const toBePaired = ranked.filter((s) => s.id !== byeId);
   const pairings = pairAllBrackets(toBePaired, makeAllocateTeamColors(games));
 
+  if (trace) {
+    for (const p of pairings) {
+      trace({
+        phase: 'main',
+        playerA: p.white,
+        playerB: p.black,
+        system: 'swiss-team',
+        type: 'pairing:pair-finalized',
+      });
+      trace({
+        black: p.black,
+        rule: 'swiss-team-article-4.3',
+        system: 'swiss-team',
+        type: 'pairing:color-allocated',
+        white: p.white,
+      });
+    }
+  }
+
   return {
-    byes: byeState === undefined ? [] : [{ player: byeState.id }],
+    byes: byeId === undefined ? [] : [{ player: byeId }],
     pairings,
   };
 }

--- a/src/team-entry.ts
+++ b/src/team-entry.ts
@@ -2,8 +2,11 @@ export { pair } from './swiss-team.js';
 export type {
   Bye,
   Game,
+  PairOptions,
   Pairing,
   PairingResult,
   Player,
   Result,
+  TraceCallback,
+  TraceEvent,
 } from './types.js';

--- a/src/trace.ts
+++ b/src/trace.ts
@@ -177,6 +177,7 @@ type TraceEvent = BlossomTraceEvent | PairingTraceEvent;
 type TraceCallback = (event: TraceEvent) => void;
 
 interface PairOptions {
+  expectedRounds?: number;
   trace?: TraceCallback;
 }
 

--- a/src/trace.ts
+++ b/src/trace.ts
@@ -1,0 +1,189 @@
+/**
+ * Structured trace events for pairing algorithm observability.
+ *
+ * @module
+ */
+
+// ---------------------------------------------------------------------------
+// Blossom algorithm events
+// ---------------------------------------------------------------------------
+
+interface BlossomStageStart {
+  stage: number;
+  type: 'blossom:stage-start';
+  unmatchedCount: number;
+  vertexCount: number;
+}
+
+interface BlossomAugmentingPath {
+  edgeIndex: number;
+  type: 'blossom:augmenting-path';
+  vertices: number[];
+}
+
+interface BlossomFormed {
+  base: number;
+  blossomIndex: number;
+  childCount: number;
+  type: 'blossom:formed';
+}
+
+interface BlossomExpanded {
+  blossomIndex: number;
+  childCount: number;
+  endstage: boolean;
+  type: 'blossom:expanded';
+}
+
+interface BlossomDualUpdate {
+  delta: string;
+  type: 'blossom:dual-update';
+}
+
+interface BlossomDelta {
+  deltaType: number;
+  deltaValue: string;
+  type: 'blossom:delta';
+}
+
+interface BlossomComplete {
+  matchedCount: number;
+  type: 'blossom:complete';
+  vertexCount: number;
+}
+
+// ---------------------------------------------------------------------------
+// Pairing system events (shared structure)
+// ---------------------------------------------------------------------------
+
+interface ScoreGroupsComputed {
+  groups: { playerIds: string[]; score: number }[];
+  system: string;
+  type: 'pairing:score-groups';
+}
+
+interface ByeAssigned {
+  playerId: string;
+  reason: string;
+  system: string;
+  type: 'pairing:bye-assigned';
+}
+
+interface BlossomInvoked {
+  edgeCount: number;
+  phase: string;
+  system: string;
+  type: 'pairing:blossom-invoked';
+  vertexCount: number;
+}
+
+interface BlossomResult {
+  pairs: [string, string][];
+  phase: string;
+  system: string;
+  type: 'pairing:blossom-result';
+  unmatchedCount: number;
+}
+
+interface EdgeWeightsComputed {
+  edges: {
+    criteria: Record<string, number>;
+    playerA: string;
+    playerB: string;
+    weight: string;
+  }[];
+  phase: string;
+  system: string;
+  type: 'pairing:edge-weights';
+}
+
+interface PairFinalized {
+  phase: string;
+  playerA: string;
+  playerB: string;
+  system: string;
+  type: 'pairing:pair-finalized';
+}
+
+interface ColorAllocated {
+  black: string;
+  rule: string;
+  system: string;
+  type: 'pairing:color-allocated';
+  white: string;
+}
+
+// ---------------------------------------------------------------------------
+// Dutch-specific events
+// ---------------------------------------------------------------------------
+
+interface DutchBracketEnter {
+  bracketScore: number;
+  mdpIds: string[];
+  playerIds: string[];
+  type: 'dutch:bracket-enter';
+}
+
+interface DutchMdpSelected {
+  playerId: string;
+  sourceScore: number;
+  targetScore: number;
+  type: 'dutch:mdp-selected';
+}
+
+interface DutchWeightBoost {
+  newWeight: string;
+  oldWeight: string;
+  playerA: string;
+  playerB: string;
+  reason: string;
+  type: 'dutch:weight-boost';
+}
+
+interface DutchFallback {
+  phase: 'bracket-fallback' | 'global-fallback';
+  remainingCount: number;
+  type: 'dutch:fallback';
+}
+
+// ---------------------------------------------------------------------------
+// Union and callback
+// ---------------------------------------------------------------------------
+
+type BlossomTraceEvent =
+  | BlossomAugmentingPath
+  | BlossomComplete
+  | BlossomDelta
+  | BlossomDualUpdate
+  | BlossomExpanded
+  | BlossomFormed
+  | BlossomStageStart;
+
+type PairingTraceEvent =
+  | BlossomInvoked
+  | BlossomResult
+  | ByeAssigned
+  | ColorAllocated
+  | DutchBracketEnter
+  | DutchFallback
+  | DutchMdpSelected
+  | DutchWeightBoost
+  | EdgeWeightsComputed
+  | PairFinalized
+  | ScoreGroupsComputed;
+
+type TraceEvent = BlossomTraceEvent | PairingTraceEvent;
+
+type TraceCallback = (event: TraceEvent) => void;
+
+interface PairOptions {
+  trace?: TraceCallback;
+}
+
+export type {
+  BlossomTraceEvent,
+  PairOptions,
+  PairingTraceEvent,
+  TraceCallback,
+  TraceEvent,
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -46,3 +46,5 @@ export type {
   Player,
   Result,
 };
+
+export type { PairOptions, TraceCallback, TraceEvent } from './trace.js';

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -115,6 +115,12 @@ function buildPlayerStates(players: Player[], games: Game[][]): PlayerState[] {
         // Forfeit counts as unplayed (C++ playedGames only increments for
         // gameWasPlayed=true; our unplayedRounds is the inverse).
         unplayedRounds++;
+        // C++ eligibleForBye returns false when any unplayed match gives
+        // points >= pointsForWin. A forfeit win gives 1 point = full win.
+        const pointsFromForfeit = isWhite ? game.result : 1 - game.result;
+        if (pointsFromForfeit >= 1) {
+          byeCount++;
+        }
       } else {
         opponents.add(isWhite ? game.black : game.white);
       }

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -93,22 +93,37 @@ function buildPlayerStates(players: Player[], games: Game[][]): PlayerState[] {
 
       // Real game
       const isWhite = game.white === id;
-      colorHistory.push(isWhite ? 'white' : 'black');
+
+      // Forfeit — game was not actually played, no color recorded
+      // (matches bbpPairings: gameWasPlayed = false for +/- results)
+      const isForfeit =
+        game.kind === 'forfeit-win' || game.kind === 'forfeit-loss';
+      colorHistory.push(isForfeit ? undefined : isWhite ? 'white' : 'black');
+
       score += isWhite ? game.result : 1 - game.result;
       opponents.add(isWhite ? game.black : game.white);
 
-      // Float status: compare scores before this round
-      const opponentId = isWhite ? game.black : game.white;
-      const scoresBeforeRound = cumulativeScore[roundIndex];
-      const playerScoreBefore = scoresBeforeRound?.get(id) ?? 0;
-      const opponentScoreBefore = scoresBeforeRound?.get(opponentId) ?? 0;
-
-      if (playerScoreBefore > opponentScoreBefore) {
-        floatHistory.push('down');
-      } else if (playerScoreBefore < opponentScoreBefore) {
-        floatHistory.push('up');
+      // Float status
+      // Forfeit: bbpPairings treats unplayed games specially —
+      // forfeit win (points > loss) = FLOAT_DOWN, otherwise FLOAT_NONE.
+      if (isForfeit) {
+        const wonForfeit =
+          (isWhite && game.kind === 'forfeit-win') ||
+          (!isWhite && game.kind === 'forfeit-loss');
+        floatHistory.push(wonForfeit ? 'down' : undefined);
       } else {
-        floatHistory.push(undefined);
+        const opponentId = isWhite ? game.black : game.white;
+        const scoresBeforeRound = cumulativeScore[roundIndex];
+        const playerScoreBefore = scoresBeforeRound?.get(id) ?? 0;
+        const opponentScoreBefore = scoresBeforeRound?.get(opponentId) ?? 0;
+
+        if (playerScoreBefore > opponentScoreBefore) {
+          floatHistory.push('down');
+        } else if (playerScoreBefore < opponentScoreBefore) {
+          floatHistory.push('up');
+        } else {
+          floatHistory.push(undefined);
+        }
       }
     }
 

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -111,7 +111,11 @@ function buildPlayerStates(players: Player[], games: Game[][]): PlayerState[] {
 
       // Forfeit — game was not actually played, opponent not recorded
       // (matches bbpPairings: forbiddenPairs only added when gameWasPlayed)
-      if (!isForfeit) {
+      if (isForfeit) {
+        // Forfeit counts as unplayed (C++ playedGames only increments for
+        // gameWasPlayed=true; our unplayedRounds is the inverse).
+        unplayedRounds++;
+      } else {
         opponents.add(isWhite ? game.black : game.white);
       }
 

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -49,8 +49,14 @@ function buildPlayerStates(players: Player[], games: Game[][]): PlayerState[] {
   for (const round of games) {
     cumulativeScore.push(new Map(runningScoreMap));
     for (const game of round) {
-      // Skip byes (black === '')
-      if (game.black === '') continue;
+      if (game.black === '') {
+        // Bye: only white receives points
+        runningScoreMap.set(
+          game.white,
+          (runningScoreMap.get(game.white) ?? 0) + game.result,
+        );
+        continue;
+      }
       runningScoreMap.set(
         game.white,
         (runningScoreMap.get(game.white) ?? 0) + game.result,
@@ -86,6 +92,7 @@ function buildPlayerStates(players: Player[], games: Game[][]): PlayerState[] {
       // Bye sentinel: black === ''
       if (game.black === '') {
         byeCount++;
+        score += game.result;
         colorHistory.push(undefined);
         floatHistory.push('down');
         continue;

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -108,7 +108,12 @@ function buildPlayerStates(players: Player[], games: Game[][]): PlayerState[] {
       colorHistory.push(isForfeit ? undefined : isWhite ? 'white' : 'black');
 
       score += isWhite ? game.result : 1 - game.result;
-      opponents.add(isWhite ? game.black : game.white);
+
+      // Forfeit — game was not actually played, opponent not recorded
+      // (matches bbpPairings: forbiddenPairs only added when gameWasPlayed)
+      if (!isForfeit) {
+        opponents.add(isWhite ? game.black : game.white);
+      }
 
       // Float status
       // Forfeit: bbpPairings treats unplayed games specially —

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,7 +17,7 @@
     "strict": true,
     "target": "ESNext"
   },
-  "include": ["src/**/*"],
+  "include": ["src/**/*", "scripts/**/*"],
   "typedocOptions": {
     "entryPoints": ["src/index.ts"],
     "excludeInternal": false,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,7 +17,7 @@
     "strict": true,
     "target": "ESNext"
   },
-  "include": ["src/**/*", "scripts/**/*"],
+  "include": ["src/**/*"],
   "typedocOptions": {
     "entryPoints": ["src/index.ts"],
     "excludeInternal": false,


### PR DESCRIPTION
## Summary

- adds structured trace observability to all `pair()` functions via optional `options.trace` callback
- fixes three blossom/matching bugs that caused wrong pairings
- fixes RTG comparison harness for double-forfeits and absent players

## Trace system

all six pairing systems now accept `pair(players, games, { trace })`. the callback receives typed events for blossom internals (augmenting paths, formations, dual updates) and pairing phases (score groups, bracket enter, MDP selection, pair finalization, color allocation). zero overhead when no callback is provided.

new exported types: `PairOptions`, `TraceCallback`, `TraceEvent`.

**backwards-compatible** — the third parameter is optional, no existing types changed, no exports removed.

## Matching fixes

1. **scan all OUTER vertices for minOuterDualVariable** (`graph.ts`) — the augmentation initialization only checked base vertices of OUTER root blossoms. with compound OUTER blossoms the min-dual vertex may not be the base, causing wrong dual adjustments.

2. **single-prepare in setEdgeWeight** (`matching-computer.ts`) — removed the double-prepare workaround that over-reset blossom state. now matches C++ `computer.cpp`. bug #1 was masked by this workaround.

3. **shiftGrow for edge weight doubling** (`matching-computer.ts`) — `shiftLeft(1)` silently truncated weights that exactly filled their word array, zeroing out edges where both players are bye candidates.

## Test results

- 257/257 unit tests pass
- 30-seed bench: 296/296 perfect rounds (100%)
- 100-seed FIDE RTG: 1010/1011 rounds perfect (99.9%), 58729/58732 pairs
- remaining 1 round is a tiebreaking difference where both matchings have identical total weight