### PR TITLE
refactor: consolidate cross-system duplication

### DIFF
--- a/src/burstein.ts
+++ b/src/burstein.ts
@@ -23,6 +23,8 @@
 
 import { maxWeightMatching } from './blossom.js';
 import {
+  FIDE_COLOR_RULES,
+  ROUND_1_COLOR_RULE,
   allocateColor,
   assignBye,
   buildPlayerStates,
@@ -33,7 +35,7 @@ import { buildEdgeWeight } from './weights.js';
 import type { DynamicUint } from './dynamic-uint.js';
 import type { PairOptions, TraceCallback } from './trace.js';
 import type { Game, PairingResult, Player } from './types.js';
-import type { ColorRule, PlayerState } from './utilities.js';
+import type { PlayerState } from './utilities.js';
 import type { BracketContext, Criterion } from './weights.js';
 
 // ---------------------------------------------------------------------------
@@ -106,82 +108,7 @@ function computeSonnebornBerger(
 // FIDE Article 5 colour rules
 // ---------------------------------------------------------------------------
 
-function rankPreference(s: PlayerState['preferenceStrength']): number {
-  if (s === 'absolute') return 3;
-  if (s === 'strong') return 2;
-  if (s === 'mild') return 1;
-  return 0;
-}
-
-const BURSTEIN_COLOR_RULES: ColorRule[] = [
-  // 5.2.1 (round 1): Both players have no history — higher ranked gets initial colour
-  // If odd TPN → white (initial colour); even TPN → black.
-  (hrp, opp) => {
-    const hrpHasHistory = hrp.colorHistory.some((c) => c !== undefined);
-    const oppHasHistory = opp.colorHistory.some((c) => c !== undefined);
-    if (!hrpHasHistory && !oppHasHistory) {
-      return hrp.tpn % 2 === 1 ? 'hrp-white' : 'hrp-black';
-    }
-    return 'continue';
-  },
-  // 5.2.2 Grant both colour preferences (if they differ)
-  (hrp, opp) => {
-    if (
-      hrp.preferredColor !== undefined &&
-      opp.preferredColor !== undefined &&
-      hrp.preferredColor !== opp.preferredColor
-    ) {
-      return hrp.preferredColor === 'white' ? 'hrp-white' : 'hrp-black';
-    }
-    return 'continue';
-  },
-  // 5.2.3 Grant stronger preference; both absolute → wider colorDiff wins
-  (hrp, opp) => {
-    const hrpS = rankPreference(hrp.preferenceStrength);
-    const oppS = rankPreference(opp.preferenceStrength);
-
-    if (hrpS > oppS && hrp.preferredColor !== undefined) {
-      return hrp.preferredColor === 'white' ? 'hrp-white' : 'hrp-black';
-    }
-    if (oppS > hrpS && opp.preferredColor !== undefined) {
-      return opp.preferredColor === 'white' ? 'hrp-black' : 'hrp-white';
-    }
-    // Both absolute: wider colorDiff wins
-    if (hrpS === 3 && oppS === 3) {
-      const hrpAbs = Math.abs(hrp.colorDiff);
-      const oppAbs = Math.abs(opp.colorDiff);
-      if (hrpAbs > oppAbs && hrp.preferredColor !== undefined) {
-        return hrp.preferredColor === 'white' ? 'hrp-white' : 'hrp-black';
-      }
-      if (oppAbs > hrpAbs && opp.preferredColor !== undefined) {
-        return opp.preferredColor === 'white' ? 'hrp-black' : 'hrp-white';
-      }
-    }
-    return 'continue';
-  },
-  // 5.2.4 Alternate from most recent divergent round
-  (hrp, opp) => {
-    const minLength = Math.min(
-      hrp.colorHistory.length,
-      opp.colorHistory.length,
-    );
-    for (let index = minLength - 1; index >= 0; index--) {
-      const h = hrp.colorHistory[index];
-      const o = opp.colorHistory[index];
-      if (h !== undefined && o !== undefined && h !== o) {
-        return h === 'white' ? 'hrp-black' : 'hrp-white';
-      }
-    }
-    return 'continue';
-  },
-  // 5.2.5 Grant the colour preference of the higher ranked player (HRP)
-  (hrp) => {
-    if (hrp.preferredColor !== undefined) {
-      return hrp.preferredColor === 'white' ? 'hrp-white' : 'hrp-black';
-    }
-    return 'continue';
-  },
-];
+const BURSTEIN_COLOR_RULES = [ROUND_1_COLOR_RULE, ...FIDE_COLOR_RULES];
 
 // ---------------------------------------------------------------------------
 // Burstein ranking comparator

--- a/src/burstein.ts
+++ b/src/burstein.ts
@@ -21,33 +21,21 @@
  * 8. Assign bye (odd player count) via `assignBye`.
  */
 
-import { maxWeightMatching } from './blossom.js';
+import { buildBlossomEdges, runBlossom } from './pairing-helpers.js';
 import {
   FIDE_COLOR_RULES,
   ROUND_1_COLOR_RULE,
   allocateColor,
   assignBye,
   buildPlayerStates,
+  normaliseGames,
   scoreGroups,
 } from './utilities.js';
-import { buildEdgeWeight } from './weights.js';
 
-import type { DynamicUint } from './dynamic-uint.js';
-import type { PairOptions, TraceCallback } from './trace.js';
+import type { PairOptions } from './trace.js';
 import type { Game, PairingResult, Player } from './types.js';
 import type { PlayerState } from './utilities.js';
 import type { BracketContext, Criterion } from './weights.js';
-
-// ---------------------------------------------------------------------------
-// Game normalisation — convert legacy bye sentinel (black === white) to the
-// canonical new sentinel (black === '').
-// ---------------------------------------------------------------------------
-
-function normaliseGames(games: Game[][]): Game[][] {
-  return games.map((round) =>
-    round.map((g) => (g.black === g.white ? { ...g, black: '' } : g)),
-  );
-}
 
 // ---------------------------------------------------------------------------
 // Tiebreak computations
@@ -255,72 +243,6 @@ const BURSTEIN_CRITERIA: Criterion[] = [
 ];
 
 // ---------------------------------------------------------------------------
-// Edge-building helpers
-// ---------------------------------------------------------------------------
-
-function buildEdges(
-  players: PlayerState[],
-  context: BursteinContext,
-): [number, number, DynamicUint][] {
-  const edges: [number, number, DynamicUint][] = [];
-  for (let index = 0; index < players.length; index++) {
-    for (let index_ = index + 1; index_ < players.length; index_++) {
-      const a = players.at(index);
-      const b = players.at(index_);
-      if (a === undefined || b === undefined) continue;
-      const weight = buildEdgeWeight(BURSTEIN_CRITERIA, a, b, context);
-      if (!weight.isZero()) {
-        edges.push([index, index_, weight]);
-      }
-    }
-  }
-  return edges;
-}
-
-function runBlossom(
-  players: PlayerState[],
-  edges: [number, number, DynamicUint][],
-  maxcardinality = true,
-  trace?: TraceCallback,
-): Map<string, string> {
-  if (players.length === 0) return new Map();
-  if (trace) {
-    trace({
-      edgeCount: edges.length,
-      phase: 'main',
-      system: 'burstein',
-      type: 'pairing:blossom-invoked',
-      vertexCount: players.length,
-    });
-  }
-  const matching = maxWeightMatching(edges, maxcardinality, trace);
-  const result = new Map<string, string>();
-  for (const [index, index_] of matching.entries()) {
-    if (index_ !== undefined && index_ !== -1 && index_ > index) {
-      const a = players.at(index);
-      const b = players.at(index_);
-      if (a === undefined || b === undefined) continue;
-      result.set(a.id, b.id);
-      result.set(b.id, a.id);
-    }
-  }
-  if (trace) {
-    const pairs: [string, string][] = [];
-    for (const [a, b] of result) {
-      if (a < b) pairs.push([a, b]);
-    }
-    trace({
-      pairs,
-      phase: 'main',
-      system: 'burstein',
-      type: 'pairing:blossom-result',
-      unmatchedCount: players.length - pairs.length * 2,
-    });
-  }
-  return result;
-}
-
-// ---------------------------------------------------------------------------
 // Main pair function
 // ---------------------------------------------------------------------------
 
@@ -442,8 +364,8 @@ function pair(
     trace({ groups, system: 'burstein', type: 'pairing:score-groups' });
   }
 
-  const edges = buildEdges(pairedPool, globalContext);
-  const matching = runBlossom(pairedPool, edges, true, trace);
+  const edges = buildBlossomEdges(pairedPool, BURSTEIN_CRITERIA, globalContext);
+  const matching = runBlossom(pairedPool, edges, 'burstein', true, trace);
 
   const allPairedTuples: [PlayerState, PlayerState][] = [];
   const seen = new Set<string>();

--- a/src/dubov.ts
+++ b/src/dubov.ts
@@ -17,7 +17,7 @@
  * 6. Assign bye (odd player count) via `assignBye`.
  */
 
-import { maxWeightMatching } from './blossom.js';
+import { buildBlossomEdges, runBlossom } from './pairing-helpers.js';
 import {
   FIDE_COLOR_RULES,
   ROUND_1_COLOR_RULE,
@@ -26,10 +26,8 @@ import {
   buildPlayerStates,
   scoreGroups,
 } from './utilities.js';
-import { buildEdgeWeight } from './weights.js';
 
-import type { DynamicUint } from './dynamic-uint.js';
-import type { PairOptions, TraceCallback } from './trace.js';
+import type { PairOptions } from './trace.js';
 import type { Game, PairingResult, Player } from './types.js';
 import type { PlayerState } from './utilities.js';
 import type { BracketContext, Criterion } from './weights.js';
@@ -253,72 +251,6 @@ const DUBOV_CRITERIA: Criterion[] = [
 ];
 
 // ---------------------------------------------------------------------------
-// Edge-building helpers
-// ---------------------------------------------------------------------------
-
-function buildEdges(
-  players: PlayerState[],
-  context: DubovContext,
-): [number, number, DynamicUint][] {
-  const edges: [number, number, DynamicUint][] = [];
-  for (let index = 0; index < players.length; index++) {
-    for (let index_ = index + 1; index_ < players.length; index_++) {
-      const a = players.at(index);
-      const b = players.at(index_);
-      if (a === undefined || b === undefined) continue;
-      const weight = buildEdgeWeight(DUBOV_CRITERIA, a, b, context);
-      if (!weight.isZero()) {
-        edges.push([index, index_, weight]);
-      }
-    }
-  }
-  return edges;
-}
-
-function runBlossom(
-  players: PlayerState[],
-  edges: [number, number, DynamicUint][],
-  maxcardinality = true,
-  trace?: TraceCallback,
-): Map<string, string> {
-  if (players.length === 0) return new Map();
-  if (trace) {
-    trace({
-      edgeCount: edges.length,
-      phase: 'main',
-      system: 'dubov',
-      type: 'pairing:blossom-invoked',
-      vertexCount: players.length,
-    });
-  }
-  const matching = maxWeightMatching(edges, maxcardinality, trace);
-  const result = new Map<string, string>();
-  for (const [index, index_] of matching.entries()) {
-    if (index_ !== undefined && index_ !== -1 && index_ > index) {
-      const a = players.at(index);
-      const b = players.at(index_);
-      if (a === undefined || b === undefined) continue;
-      result.set(a.id, b.id);
-      result.set(b.id, a.id);
-    }
-  }
-  if (trace) {
-    const pairs: [string, string][] = [];
-    for (const [a, b] of result) {
-      if (a < b) pairs.push([a, b]);
-    }
-    trace({
-      pairs,
-      phase: 'main',
-      system: 'dubov',
-      type: 'pairing:blossom-result',
-      unmatchedCount: players.length - pairs.length * 2,
-    });
-  }
-  return result;
-}
-
-// ---------------------------------------------------------------------------
 // Main pair function
 // ---------------------------------------------------------------------------
 
@@ -433,8 +365,8 @@ function pair(
     trace({ groups, system: 'dubov', type: 'pairing:score-groups' });
   }
 
-  const edges = buildEdges(pairedPool, globalContext);
-  const matching = runBlossom(pairedPool, edges, true, trace);
+  const edges = buildBlossomEdges(pairedPool, DUBOV_CRITERIA, globalContext);
+  const matching = runBlossom(pairedPool, edges, 'dubov', true, trace);
 
   const allPairedTuples: [PlayerState, PlayerState][] = [];
   const seen = new Set<string>();

--- a/src/dubov.ts
+++ b/src/dubov.ts
@@ -19,6 +19,8 @@
 
 import { maxWeightMatching } from './blossom.js';
 import {
+  FIDE_COLOR_RULES,
+  ROUND_1_COLOR_RULE,
   allocateColor,
   assignBye,
   buildPlayerStates,
@@ -29,7 +31,7 @@ import { buildEdgeWeight } from './weights.js';
 import type { DynamicUint } from './dynamic-uint.js';
 import type { PairOptions, TraceCallback } from './trace.js';
 import type { Game, PairingResult, Player } from './types.js';
-import type { ColorRule, PlayerState } from './utilities.js';
+import type { PlayerState } from './utilities.js';
 import type { BracketContext, Criterion } from './weights.js';
 
 // ---------------------------------------------------------------------------
@@ -62,81 +64,7 @@ function computeARO(state: PlayerState, players: Player[]): number {
 // FIDE Article 5 colour rules
 // ---------------------------------------------------------------------------
 
-function rankPreference(s: PlayerState['preferenceStrength']): number {
-  if (s === 'absolute') return 3;
-  if (s === 'strong') return 2;
-  if (s === 'mild') return 1;
-  return 0;
-}
-
-const DUBOV_COLOR_RULES: ColorRule[] = [
-  // 5.2.1 (round 1): Both players have no history — odd TPN gets initial colour (white)
-  (hrp, opp) => {
-    const hrpHasHistory = hrp.colorHistory.some((c) => c !== undefined);
-    const oppHasHistory = opp.colorHistory.some((c) => c !== undefined);
-    if (!hrpHasHistory && !oppHasHistory) {
-      return hrp.tpn % 2 === 1 ? 'hrp-white' : 'hrp-black';
-    }
-    return 'continue';
-  },
-  // 5.2.2 Grant both colour preferences (if they differ)
-  (hrp, opp) => {
-    if (
-      hrp.preferredColor !== undefined &&
-      opp.preferredColor !== undefined &&
-      hrp.preferredColor !== opp.preferredColor
-    ) {
-      return hrp.preferredColor === 'white' ? 'hrp-white' : 'hrp-black';
-    }
-    return 'continue';
-  },
-  // 5.2.3 Grant stronger preference; both absolute → wider colorDiff wins
-  (hrp, opp) => {
-    const hrpS = rankPreference(hrp.preferenceStrength);
-    const oppS = rankPreference(opp.preferenceStrength);
-
-    if (hrpS > oppS && hrp.preferredColor !== undefined) {
-      return hrp.preferredColor === 'white' ? 'hrp-white' : 'hrp-black';
-    }
-    if (oppS > hrpS && opp.preferredColor !== undefined) {
-      return opp.preferredColor === 'white' ? 'hrp-black' : 'hrp-white';
-    }
-    // Both absolute: wider colorDiff wins
-    if (hrpS === 3 && oppS === 3) {
-      const hrpAbs = Math.abs(hrp.colorDiff);
-      const oppAbs = Math.abs(opp.colorDiff);
-      if (hrpAbs > oppAbs && hrp.preferredColor !== undefined) {
-        return hrp.preferredColor === 'white' ? 'hrp-white' : 'hrp-black';
-      }
-      if (oppAbs > hrpAbs && opp.preferredColor !== undefined) {
-        return opp.preferredColor === 'white' ? 'hrp-black' : 'hrp-white';
-      }
-    }
-    return 'continue';
-  },
-  // 5.2.4 Alternate from most recent divergent round
-  (hrp, opp) => {
-    const minLength = Math.min(
-      hrp.colorHistory.length,
-      opp.colorHistory.length,
-    );
-    for (let index = minLength - 1; index >= 0; index--) {
-      const h = hrp.colorHistory[index];
-      const o = opp.colorHistory[index];
-      if (h !== undefined && o !== undefined && h !== o) {
-        return h === 'white' ? 'hrp-black' : 'hrp-white';
-      }
-    }
-    return 'continue';
-  },
-  // 5.2.5 Grant HRP's preference
-  (hrp) => {
-    if (hrp.preferredColor !== undefined) {
-      return hrp.preferredColor === 'white' ? 'hrp-white' : 'hrp-black';
-    }
-    return 'continue';
-  },
-];
+const DUBOV_COLOR_RULES = [ROUND_1_COLOR_RULE, ...FIDE_COLOR_RULES];
 
 // Rank comparator for allocateColor: lower TPN = higher rank in Dubov
 function dubovRankCompare(a: PlayerState, b: PlayerState): number {

--- a/src/dutch.ts
+++ b/src/dutch.ts
@@ -21,77 +21,20 @@
 import { maxWeightMatching } from './blossom.js';
 import { DynamicUint } from './dynamic-uint.js';
 import { MatchingComputer } from './matching-computer.js';
-import { allocateColor, buildPlayerStates, scoreGroups } from './utilities.js';
+import {
+  FIDE_COLOR_RULES,
+  allocateColor,
+  buildPlayerStates,
+  scoreGroups,
+} from './utilities.js';
 
 import type { PairOptions } from './trace.js';
 import type { Game, PairingResult, Player } from './types.js';
-import type { ColorRule, PlayerState } from './utilities.js';
+import type { PlayerState } from './utilities.js';
 
 // ---------------------------------------------------------------------------
 // FIDE Article 5.2 colour rules
 // ---------------------------------------------------------------------------
-
-function rankPreference(s: PlayerState['preferenceStrength']): number {
-  if (s === 'absolute') return 3;
-  if (s === 'strong') return 2;
-  if (s === 'mild') return 1;
-  return 0;
-}
-
-const DUTCH_COLOR_RULES: ColorRule[] = [
-  (hrp, opp) => {
-    if (
-      hrp.preferredColor !== undefined &&
-      opp.preferredColor !== undefined &&
-      hrp.preferredColor !== opp.preferredColor
-    ) {
-      return hrp.preferredColor === 'white' ? 'hrp-white' : 'hrp-black';
-    }
-    return 'continue';
-  },
-  (hrp, opp) => {
-    const hrpS = rankPreference(hrp.preferenceStrength);
-    const oppS = rankPreference(opp.preferenceStrength);
-    if (hrpS > oppS && hrp.preferredColor !== undefined) {
-      return hrp.preferredColor === 'white' ? 'hrp-white' : 'hrp-black';
-    }
-    if (oppS > hrpS && opp.preferredColor !== undefined) {
-      return opp.preferredColor === 'white' ? 'hrp-black' : 'hrp-white';
-    }
-    if (hrpS === 3 && oppS === 3) {
-      const hrpAbs = Math.abs(hrp.colorDiff);
-      const oppAbs = Math.abs(opp.colorDiff);
-      if (hrpAbs > oppAbs && hrp.preferredColor !== undefined) {
-        return hrp.preferredColor === 'white' ? 'hrp-white' : 'hrp-black';
-      }
-      if (oppAbs > hrpAbs && opp.preferredColor !== undefined) {
-        return opp.preferredColor === 'white' ? 'hrp-black' : 'hrp-white';
-      }
-    }
-    return 'continue';
-  },
-  (hrp, opp) => {
-    const minLength = Math.min(
-      hrp.colorHistory.length,
-      opp.colorHistory.length,
-    );
-    for (let index = minLength - 1; index >= 0; index--) {
-      const h = hrp.colorHistory[index];
-      const o = opp.colorHistory[index];
-      if (h !== undefined && o !== undefined && h !== o) {
-        return h === 'white' ? 'hrp-black' : 'hrp-white';
-      }
-    }
-    return 'continue';
-  },
-  (hrp) => {
-    if (hrp.preferredColor !== undefined) {
-      return hrp.preferredColor === 'white' ? 'hrp-white' : 'hrp-black';
-    }
-    return 'continue';
-  },
-  (hrp) => (hrp.tpn % 2 === 1 ? 'hrp-white' : 'hrp-black'),
-];
 
 function dutchRankCompare(a: PlayerState, b: PlayerState): number {
   return a.tpn - b.tpn;
@@ -1743,7 +1686,7 @@ function pair(
   }
 
   const pairings = result.map(([a, b]) =>
-    allocateColor(a, b, DUTCH_COLOR_RULES, dutchRankCompare),
+    allocateColor(a, b, FIDE_COLOR_RULES, dutchRankCompare),
   );
 
   if (trace) {

--- a/src/lim.ts
+++ b/src/lim.ts
@@ -25,6 +25,7 @@
 
 import { maxWeightMatching } from './blossom.js';
 import {
+  FIDE_COLOR_RULES,
   allocateColor,
   assignBye,
   buildPlayerStates,
@@ -35,81 +36,8 @@ import { buildEdgeWeight } from './weights.js';
 import type { DynamicUint } from './dynamic-uint.js';
 import type { PairOptions, TraceCallback } from './trace.js';
 import type { Game, PairingResult, Player } from './types.js';
-import type { ColorRule, PlayerState } from './utilities.js';
+import type { PlayerState } from './utilities.js';
 import type { BracketContext, Criterion } from './weights.js';
-
-// ---------------------------------------------------------------------------
-// FIDE Article 5.2 colour rules (same as Dutch)
-// ---------------------------------------------------------------------------
-
-function rankPreference(s: PlayerState['preferenceStrength']): number {
-  if (s === 'absolute') return 3;
-  if (s === 'strong') return 2;
-  if (s === 'mild') return 1;
-  return 0;
-}
-
-const LIM_COLOR_RULES: ColorRule[] = [
-  // 5.2.1 Grant both colour preferences (if they differ)
-  (hrp, opp) => {
-    if (
-      hrp.preferredColor !== undefined &&
-      opp.preferredColor !== undefined &&
-      hrp.preferredColor !== opp.preferredColor
-    ) {
-      return hrp.preferredColor === 'white' ? 'hrp-white' : 'hrp-black';
-    }
-    return 'continue';
-  },
-  // 5.2.2 Grant stronger preference; both absolute → wider colorDiff wins
-  (hrp, opp) => {
-    const hrpS = rankPreference(hrp.preferenceStrength);
-    const oppS = rankPreference(opp.preferenceStrength);
-
-    if (hrpS > oppS && hrp.preferredColor !== undefined) {
-      return hrp.preferredColor === 'white' ? 'hrp-white' : 'hrp-black';
-    }
-    if (oppS > hrpS && opp.preferredColor !== undefined) {
-      return opp.preferredColor === 'white' ? 'hrp-black' : 'hrp-white';
-    }
-    // Both absolute: wider colorDiff wins
-    if (hrpS === 3 && oppS === 3) {
-      const hrpAbs = Math.abs(hrp.colorDiff);
-      const oppAbs = Math.abs(opp.colorDiff);
-      if (hrpAbs > oppAbs && hrp.preferredColor !== undefined) {
-        return hrp.preferredColor === 'white' ? 'hrp-white' : 'hrp-black';
-      }
-      if (oppAbs > hrpAbs && opp.preferredColor !== undefined) {
-        return opp.preferredColor === 'white' ? 'hrp-black' : 'hrp-white';
-      }
-    }
-    return 'continue';
-  },
-  // 5.2.3 Alternate from most recent divergent round
-  (hrp, opp) => {
-    const minLength = Math.min(
-      hrp.colorHistory.length,
-      opp.colorHistory.length,
-    );
-    for (let index = minLength - 1; index >= 0; index--) {
-      const h = hrp.colorHistory[index];
-      const o = opp.colorHistory[index];
-      if (h !== undefined && o !== undefined && h !== o) {
-        return h === 'white' ? 'hrp-black' : 'hrp-white';
-      }
-    }
-    return 'continue';
-  },
-  // 5.2.4 Grant HRP's preference
-  (hrp) => {
-    if (hrp.preferredColor !== undefined) {
-      return hrp.preferredColor === 'white' ? 'hrp-white' : 'hrp-black';
-    }
-    return 'continue';
-  },
-  // 5.2.5 Odd TPN → initial colour (white)
-  (hrp) => (hrp.tpn % 2 === 1 ? 'hrp-white' : 'hrp-black'),
-];
 
 // Rank comparator for allocateColor: lower TPN = higher rank
 function limRankCompare(a: PlayerState, b: PlayerState): number {
@@ -542,7 +470,7 @@ function pair(
   // Allocate colours
   // -------------------------------------------------------------------------
   const pairings = allPairedTuples.map(([a, b]) =>
-    allocateColor(a, b, LIM_COLOR_RULES, limRankCompare),
+    allocateColor(a, b, FIDE_COLOR_RULES, limRankCompare),
   );
 
   if (trace) {

--- a/src/lim.ts
+++ b/src/lim.ts
@@ -23,18 +23,17 @@
  * 6. Allocate colours for every pair via FIDE Article 5.
  */
 
-import { maxWeightMatching } from './blossom.js';
+import { buildBlossomEdges, runBlossom } from './pairing-helpers.js';
 import {
   FIDE_COLOR_RULES,
   allocateColor,
   assignBye,
   buildPlayerStates,
+  normaliseGames,
   scoreGroups,
 } from './utilities.js';
-import { buildEdgeWeight } from './weights.js';
 
-import type { DynamicUint } from './dynamic-uint.js';
-import type { PairOptions, TraceCallback } from './trace.js';
+import type { PairOptions } from './trace.js';
 import type { Game, PairingResult, Player } from './types.js';
 import type { PlayerState } from './utilities.js';
 import type { BracketContext, Criterion } from './weights.js';
@@ -258,100 +257,7 @@ const LIM_CRITERIA: Criterion[] = [
       return Math.max(0, 3 - violations);
     },
   },
-];
-
-// ---------------------------------------------------------------------------
-// Edge-building helpers
-// ---------------------------------------------------------------------------
-
-/**
- * Build a complete graph for a set of players.
- * Returns [indexA, indexB, weight] tuples for maxWeightMatching.
- * Edges with zero weight (C1 rematches) are omitted so that
- * maxcardinality mode never forces a rematch.
- */
-function buildEdges(
-  players: PlayerState[],
-  context: LimContextFull,
-): [number, number, DynamicUint][] {
-  const edges: [number, number, DynamicUint][] = [];
-  for (let index = 0; index < players.length; index++) {
-    for (let index_ = index + 1; index_ < players.length; index_++) {
-      const a = players.at(index);
-      const b = players.at(index_);
-      if (a === undefined || b === undefined) continue;
-      const weight = buildEdgeWeight(LIM_CRITERIA, a, b, context);
-      if (!weight.isZero()) {
-        edges.push([index, index_, weight]);
-      }
-    }
-  }
-  return edges;
-}
-
-/**
- * Run blossom on edges and return a Map<id, id> of matched pairs.
- */
-function runBlossom(
-  players: PlayerState[],
-  edges: [number, number, DynamicUint][],
-  maxcardinality = true,
-  trace?: TraceCallback,
-): Map<string, string> {
-  if (players.length === 0) return new Map();
-  if (trace) {
-    trace({
-      edgeCount: edges.length,
-      phase: 'main',
-      system: 'lim',
-      type: 'pairing:blossom-invoked',
-      vertexCount: players.length,
-    });
-  }
-  const matching = maxWeightMatching(edges, maxcardinality, trace);
-  const result = new Map<string, string>();
-  for (const [index, index_] of matching.entries()) {
-    if (index_ !== undefined && index_ !== -1 && index_ > index) {
-      const a = players.at(index);
-      const b = players.at(index_);
-      if (a === undefined || b === undefined) continue;
-      result.set(a.id, b.id);
-      result.set(b.id, a.id);
-    }
-  }
-  if (trace) {
-    const pairs: [string, string][] = [];
-    for (const [a, b] of result) {
-      if (a < b) pairs.push([a, b]);
-    }
-    trace({
-      pairs,
-      phase: 'main',
-      system: 'lim',
-      type: 'pairing:blossom-result',
-      unmatchedCount: players.length - pairs.length * 2,
-    });
-  }
-  return result;
-}
-
-// ---------------------------------------------------------------------------
-// Bye sentinel normalisation
-// ---------------------------------------------------------------------------
-
-/**
- * Normalise games so that the old `black === white` bye sentinel is converted
- * to the canonical `black === ''` sentinel expected by buildPlayerStates.
- */
-function normaliseGames(games: Game[][]): Game[][] {
-  return games.map((round) =>
-    round.map((game) =>
-      game.black === game.white ? { ...game, black: '' } : game,
-    ),
-  );
-}
-
-// ---------------------------------------------------------------------------
+]; // ---------------------------------------------------------------------------
 // Main pair function
 // ---------------------------------------------------------------------------
 
@@ -438,8 +344,8 @@ function pair(
     },
   };
 
-  const edges = buildEdges(pairedPool, globalContext);
-  const matching = runBlossom(pairedPool, edges, true, trace);
+  const edges = buildBlossomEdges(pairedPool, LIM_CRITERIA, globalContext);
+  const matching = runBlossom(pairedPool, edges, 'lim', true, trace);
 
   const allPairedTuples: [PlayerState, PlayerState][] = [];
   const seen = new Set<string>();

--- a/src/pairing-helpers.ts
+++ b/src/pairing-helpers.ts
@@ -1,0 +1,91 @@
+/**
+ * @internal
+ * Shared helpers for single-pass blossom-based pairing systems
+ * (Dubov, Burstein, Lim).
+ *
+ * Provides `buildBlossomEdges` and `runBlossom` — the two steps that are
+ * identical across all single-pass systems except for the criteria array,
+ * context, and system tag used in trace events.
+ */
+import { maxWeightMatching } from './blossom.js';
+import { buildEdgeWeight } from './weights.js';
+
+import type { DynamicUint } from './dynamic-uint.js';
+import type { TraceCallback } from './trace.js';
+import type { PlayerState } from './utilities.js';
+import type { BracketContext, Criterion } from './weights.js';
+
+/**
+ * Build a complete graph for a set of players.
+ * Returns [indexA, indexB, weight] tuples for maxWeightMatching.
+ * Edges with zero weight (C1 rematches) are omitted so that
+ * maxcardinality mode never forces a rematch.
+ */
+function buildBlossomEdges(
+  players: PlayerState[],
+  criteria: Criterion[],
+  context: BracketContext,
+): [number, number, DynamicUint][] {
+  const edges: [number, number, DynamicUint][] = [];
+  for (let index = 0; index < players.length; index++) {
+    for (let index_ = index + 1; index_ < players.length; index_++) {
+      const a = players.at(index);
+      const b = players.at(index_);
+      if (a === undefined || b === undefined) continue;
+      const weight = buildEdgeWeight(criteria, a, b, context);
+      if (!weight.isZero()) {
+        edges.push([index, index_, weight]);
+      }
+    }
+  }
+  return edges;
+}
+
+/**
+ * Run blossom on edges and return a Map<id, id> of matched pairs.
+ */
+function runBlossom(
+  players: PlayerState[],
+  edges: [number, number, DynamicUint][],
+  system: string,
+  maxcardinality = true,
+  trace?: TraceCallback,
+): Map<string, string> {
+  if (players.length === 0) return new Map();
+  if (trace) {
+    trace({
+      edgeCount: edges.length,
+      phase: 'main',
+      system,
+      type: 'pairing:blossom-invoked',
+      vertexCount: players.length,
+    });
+  }
+  const matching = maxWeightMatching(edges, maxcardinality, trace);
+  const result = new Map<string, string>();
+  for (const [index, index_] of matching.entries()) {
+    if (index_ !== undefined && index_ !== -1 && index_ > index) {
+      const a = players.at(index);
+      const b = players.at(index_);
+      if (a === undefined || b === undefined) continue;
+      result.set(a.id, b.id);
+      result.set(b.id, a.id);
+    }
+  }
+  if (trace) {
+    const pairs: [string, string][] = [];
+    for (const [a, b] of result) {
+      if (a < b) pairs.push([a, b]);
+    }
+    trace({
+      pairs,
+      phase: 'main',
+      system,
+      type: 'pairing:blossom-result',
+      unmatchedCount: players.length - pairs.length * 2,
+    });
+  }
+  return result;
+}
+
+export { buildBlossomEdges, runBlossom };

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -430,6 +430,20 @@ const FIDE_COLOR_RULES: ColorRule[] = [
 ];
 
 // ---------------------------------------------------------------------------
+// Game normalisation
+// ---------------------------------------------------------------------------
+
+/**
+ * Normalise games so that the old `black === white` bye sentinel is converted
+ * to the canonical `black === ''` sentinel expected by buildPlayerStates.
+ */
+function normaliseGames(games: Game[][]): Game[][] {
+  return games.map((round) =>
+    round.map((g) => (g.black === g.white ? { ...g, black: '' } : g)),
+  );
+}
+
+// ---------------------------------------------------------------------------
 // Legacy API — kept for backward compatibility with modules not yet migrated
 // to the PlayerState-based API. These will be removed in tasks 5–11.
 // ---------------------------------------------------------------------------
@@ -720,6 +734,7 @@ export {
   isTopscorer,
   matchColorHistory,
   matchCount,
+  normaliseGames,
   playerScoreGroups,
   rankPlayers,
   ROUND_1_COLOR_RULE,

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -319,6 +319,117 @@ function allocateColor(
 }
 
 // ---------------------------------------------------------------------------
+// FIDE Article 5.2 — shared colour rules
+// ---------------------------------------------------------------------------
+
+/**
+ * Maps preference strength to a numeric rank for comparison in rule 5.2.2.
+ */
+function rankPreference(s: PlayerState['preferenceStrength']): number {
+  if (s === 'absolute') return 3;
+  if (s === 'strong') return 2;
+  if (s === 'mild') return 1;
+  return 0;
+}
+
+/**
+ * Round-1 guard rule for systems whose spec defines Article 5.2.1 as:
+ * "When both players have yet to play a game, if the higher ranked player
+ * has an odd TPN, give them the initial-colour; otherwise the opposite."
+ *
+ * Used by Dubov (C.04.4.1) and Burstein (C.04.4.2). Dutch and Lim do not
+ * need this — their fallback (5.2.5) handles round 1 implicitly.
+ */
+const ROUND_1_COLOR_RULE: ColorRule = (hrp, opp) => {
+  const hrpHasHistory = hrp.colorHistory.some((c) => c !== undefined);
+  const oppHasHistory = opp.colorHistory.some((c) => c !== undefined);
+  if (!hrpHasHistory && !oppHasHistory) {
+    return hrp.tpn % 2 === 1 ? 'hrp-white' : 'hrp-black';
+  }
+  return 'continue';
+};
+
+/**
+ * Common FIDE Article 5.2 colour rules shared by all blossom-based pairing
+ * systems (Dutch, Dubov, Burstein, Lim).
+ *
+ * 5.2.1  Grant both colour preferences (if they differ).
+ * 5.2.2  Grant the stronger preference; both absolute → wider colorDiff wins.
+ * 5.2.3  Alternate from the most recent round where colours diverged.
+ * 5.2.4  Grant the HRP's colour preference.
+ * 5.2.5  Odd TPN → initial colour (white).
+ *
+ * Dubov and Burstein prepend ROUND_1_COLOR_RULE before these rules.
+ */
+// 5.2.1 Grant both colour preferences
+const grantBothPreferences: ColorRule = (hrp, opp) => {
+  if (
+    hrp.preferredColor !== undefined &&
+    opp.preferredColor !== undefined &&
+    hrp.preferredColor !== opp.preferredColor
+  ) {
+    return hrp.preferredColor === 'white' ? 'hrp-white' : 'hrp-black';
+  }
+  return 'continue';
+};
+
+// 5.2.2 Grant stronger preference; both absolute → wider colorDiff wins
+const grantStrongerPreference: ColorRule = (hrp, opp) => {
+  const hrpS = rankPreference(hrp.preferenceStrength);
+  const oppS = rankPreference(opp.preferenceStrength);
+  if (hrpS > oppS && hrp.preferredColor !== undefined) {
+    return hrp.preferredColor === 'white' ? 'hrp-white' : 'hrp-black';
+  }
+  if (oppS > hrpS && opp.preferredColor !== undefined) {
+    return opp.preferredColor === 'white' ? 'hrp-black' : 'hrp-white';
+  }
+  if (hrpS === 3 && oppS === 3) {
+    const hrpAbs = Math.abs(hrp.colorDiff);
+    const oppAbs = Math.abs(opp.colorDiff);
+    if (hrpAbs > oppAbs && hrp.preferredColor !== undefined) {
+      return hrp.preferredColor === 'white' ? 'hrp-white' : 'hrp-black';
+    }
+    if (oppAbs > hrpAbs && opp.preferredColor !== undefined) {
+      return opp.preferredColor === 'white' ? 'hrp-black' : 'hrp-white';
+    }
+  }
+  return 'continue';
+};
+
+// 5.2.3 Alternate from the most recent divergent round
+const alternateFromDivergentRound: ColorRule = (hrp, opp) => {
+  const minLength = Math.min(hrp.colorHistory.length, opp.colorHistory.length);
+  for (let index = minLength - 1; index >= 0; index--) {
+    const h = hrp.colorHistory[index];
+    const o = opp.colorHistory[index];
+    if (h !== undefined && o !== undefined && h !== o) {
+      return h === 'white' ? 'hrp-black' : 'hrp-white';
+    }
+  }
+  return 'continue';
+};
+
+// 5.2.4 Grant the HRP's preference
+const grantHrpPreference: ColorRule = (hrp) => {
+  if (hrp.preferredColor !== undefined) {
+    return hrp.preferredColor === 'white' ? 'hrp-white' : 'hrp-black';
+  }
+  return 'continue';
+};
+
+// 5.2.5 Odd TPN → initial colour (white)
+const tpnFallback: ColorRule = (hrp) =>
+  hrp.tpn % 2 === 1 ? 'hrp-white' : 'hrp-black';
+
+const FIDE_COLOR_RULES: ColorRule[] = [
+  grantBothPreferences,
+  grantStrongerPreference,
+  alternateFromDivergentRound,
+  grantHrpPreference,
+  tpnFallback,
+];
+
+// ---------------------------------------------------------------------------
 // Legacy API — kept for backward compatibility with modules not yet migrated
 // to the PlayerState-based API. These will be removed in tasks 5–11.
 // ---------------------------------------------------------------------------
@@ -602,6 +713,7 @@ export {
   byeScore,
   colorHistory,
   colorPreference,
+  FIDE_COLOR_RULES,
   floatHistory,
   gamesForPlayer,
   hasFaced,
@@ -610,6 +722,7 @@ export {
   matchCount,
   playerScoreGroups,
   rankPlayers,
+  ROUND_1_COLOR_RULE,
   score,
   scoreGroups,
   typeAColorPreference,


### PR DESCRIPTION
## Summary

- extract shared FIDE Article 5.2 color rules (`FIDE_COLOR_RULES`, `ROUND_1_COLOR_RULE`) into `utilities.ts` — Dutch/Lim use them directly, Dubov/Burstein prepend the round-1 guard
- extract `buildBlossomEdges` and `runBlossom` into `pairing-helpers.ts` — identical across Dubov, Burstein, Lim except for criteria and system tag
- move `normaliseGames` to `utilities.ts` — was duplicated in Burstein and Lim

~295 lines of duplication removed. verified against bbpPairings with 100 RTG seeds (58729/58732 pairings match, identical to main).