### PR TITLE
feat: import shared types from @echecs/tournament

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,8 +3,9 @@
   "bugs": {
     "url": "https://github.com/echecsjs/swiss/issues"
   },
-  "description": "Swiss chess tournament pairings following FIDE rules. Implements Dutch, Dubov, Burstein, Lim, Double, and Team Swiss systems. Zero dependencies.",
+  "description": "Swiss chess tournament pairings following FIDE rules. Implements Dutch, Dubov, Burstein, Lim, Double, and Team Swiss systems.",
   "devDependencies": {
+    "@echecs/tournament": "^2.1.2",
     "@echecs/trf": "^3.1.1",
     "@eslint/js": "^10.0.1",
     "@typescript-eslint/parser": "^8.57.0",
@@ -74,7 +75,6 @@
     "dutch",
     "fide",
     "lim",
-    "no-dependencies",
     "pairings",
     "swiss",
     "team",
@@ -82,6 +82,9 @@
     "typescript"
   ],
   "license": "MIT",
+  "peerDependencies": {
+    "@echecs/tournament": "^2.0.0"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     devDependencies:
+      '@echecs/tournament':
+        specifier: ^2.1.2
+        version: 2.1.2
       '@echecs/trf':
         specifier: ^3.1.1
         version: 3.4.0
@@ -109,6 +112,10 @@ packages:
   '@bcoe/v8-coverage@1.0.2':
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
     engines: {node: '>=18'}
+
+  '@echecs/tournament@2.1.2':
+    resolution: {integrity: sha512-DYq8Nbc1Dq15ZpQMKWziGmfyxd4RC0jIgWsbVRLM6/q+sPKPjSPxiBtRC8+u5gPr0lKaK5eoZKs295I/W60akA==}
+    engines: {node: '>=20'}
 
   '@echecs/trf@3.4.0':
     resolution: {integrity: sha512-JEhN16qTjU8xZpDzKaILRpn/8BldqaYKiY9qhXcyr3mMYeuk65LAbiCPDDpO9Oe+2TQiNjP3HQfidObUnyuk1w==}
@@ -1882,6 +1889,8 @@ snapshots:
       '@babel/helper-validator-identifier': 8.0.0-rc.3
 
   '@bcoe/v8-coverage@1.0.2': {}
+
+  '@echecs/tournament@2.1.2': {}
 
   '@echecs/trf@3.4.0': {}
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,50 +1,15 @@
 type FloatKind = 'down' | 'up' | undefined;
 
-type GameKind =
-  | 'forfeit-loss'
-  | 'forfeit-win'
-  | 'full-bye'
-  | 'half-bye'
-  | 'pairing-bye'
-  | 'zero-bye';
-
-type Result = 0 | 0.5 | 1;
-
-interface Bye {
-  player: string;
-}
-
-interface Game {
-  black: string;
-  kind?: GameKind;
-  result: Result;
-  white: string;
-}
-
-interface Pairing {
-  black: string;
-  white: string;
-}
-
-interface PairingResult {
-  byes: Bye[];
-  pairings: Pairing[];
-}
-
-interface Player {
-  id: string;
-  rating?: number;
-}
-
 export type {
   Bye,
-  FloatKind,
   Game,
   GameKind,
   Pairing,
   PairingResult,
   Player,
   Result,
-};
+} from '@echecs/tournament';
+
+export type { FloatKind };
 
 export type { PairOptions, TraceCallback, TraceEvent } from './trace.js';


### PR DESCRIPTION
## Summary

- add `@echecs/tournament` as peer dependency (`^2.0.0`) and dev dependency
- re-export `Bye`, `Game`, `GameKind`, `Pairing`, `PairingResult`, `Player`, `Result` from tournament instead of defining locally
- `FloatKind` and trace types stay local — swiss-specific

non-breaking — same shapes, same names, same exports. consumers that already use `@echecs/tournament` get type identity for free.

closes #33, closes #35