### PR TITLE
fix: use absolute color imbalance in C11 edge weight

### DIFF
--- a/src/dutch.ts
+++ b/src/dutch.ts
@@ -102,9 +102,7 @@ function absoluteColorPreference(p: PlayerState): boolean {
 }
 
 function strongColorPreference(p: PlayerState): boolean {
-  return (
-    p.preferenceStrength === 'strong' || p.preferenceStrength === 'absolute'
-  );
+  return p.preferenceStrength === 'strong';
 }
 
 function colorPreferencesAreCompatible(
@@ -267,8 +265,8 @@ function computeEdgeWeight(
   // C11
   w.shiftGrow(scoreGroupSizeBits);
   if (lowerInCurrent) {
-    const loCI = lo.colorDiff;
-    const hiCI = hi.colorDiff;
+    const loCI = Math.abs(lo.colorDiff);
+    const hiCI = Math.abs(hi.colorDiff);
     const ok =
       !absoluteColorPreference(lo) ||
       !absoluteColorPreference(hi) ||


### PR DESCRIPTION
## Summary

- **C11 bug**: the color imbalance comparison used `colorDiff` (signed) instead of `Math.abs(colorDiff)`. when both players have negative color differences, the signed comparison (`-2 > -1` is false) picks the wrong player — bbpPairings uses `colorImbalance` (unsigned, `2 > 1` is true). this caused the blossom to prefer a matching that violates strong color preferences.
- **strongColorPreference**: was returning true for both `'strong'` and `'absolute'` preferences. bbpPairings defines `strongColorPreference = !absoluteColorPreference() && colorImbalance != 0` — mutually exclusive with absolute. no impact on this specific failure (C13's `abs && abs` clause masks it), but fixes a latent correctness issue.

## Reproduction

endorsement check against `bbp_seed_983701368_40p_9r.trf` (batch 45, CI run 25262855289). round 9 produced `17-23, 18-4, 14-2` instead of bbpPairings' `17-2, 23-4, 14-18` — 1 strong color preference violation.

## Verification

- 280 unit tests pass
- 50-seed RTG comparison vs bbpPairings: 28660/28660 pairings match (100%)
- endorsement check on the failing TRF: 180/180 pairings match (was 177/180)