### PR TITLE
fix: zero-bye should not assign downfloat

### DIFF
--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -94,7 +94,9 @@ function buildPlayerStates(players: Player[], games: Game[][]): PlayerState[] {
         byeCount++;
         score += game.result;
         colorHistory.push(undefined);
-        floatHistory.push('down');
+        // C++ getFloat: points > pointsForLoss → FLOAT_DOWN, else FLOAT_NONE.
+        // pointsForLoss is 0, so only byes awarding > 0 points get downfloat.
+        floatHistory.push(game.result > 0 ? 'down' : undefined);
         continue;
       }
 


### PR DESCRIPTION
## Summary

- byes were unconditionally assigned FLOAT_DOWN regardless of points awarded. bbpPairings only assigns FLOAT_DOWN when `points > pointsForLoss`. zero-byes give 0 points = pointsForLoss, so they should get FLOAT_NONE.
- this caused incorrect C14-C17 float history bits in edge weights, inflating within-bracket pair weights for players who received zero-byes and making the blossom prefer pairings that bbpPairings correctly avoids.

## Verification

- 280 unit tests pass
- 50-seed RTG comparison vs bbpPairings: 28660/28660 (100%)
- 8 of 9 endorsement failures from batch 45 CI run resolved (the 9th is a remainder tie-break, not a weight bug)