### PR TITLE
fix: align bye eligibility and unplayed rounds with bbpPairings

### DIFF
--- a/src/__tests__/utilities.spec.ts
+++ b/src/__tests__/utilities.spec.ts
@@ -406,7 +406,7 @@ describe('buildPlayerStates', () => {
       expect(a?.unplayedRounds).toBe(1);
     });
 
-    it('does not count bye rounds as unplayed', () => {
+    it('counts bye rounds as unplayed (C++ gameWasPlayed=false for byes)', () => {
       const byeGames: Game[][] = [[{ black: '', result: 1, white: 'A' }]];
       const states = buildPlayerStates(
         [
@@ -416,7 +416,7 @@ describe('buildPlayerStates', () => {
         byeGames,
       );
       const a = states.find((s) => s.id === 'A');
-      expect(a?.unplayedRounds).toBe(0);
+      expect(a?.unplayedRounds).toBe(1);
     });
   });
 

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -91,9 +91,19 @@ function buildPlayerStates(players: Player[], games: Game[][]): PlayerState[] {
 
       // Bye sentinel: black === ''
       if (game.black === '') {
-        byeCount++;
+        // C++ eligibleForBye: player is ineligible when an unplayed match
+        // awards >= pointsForWin (1) OR is a pairing bye (participatedInPairing
+        // && opponent == self). Half-byes (0.5 pts) and zero-byes (0 pts) do
+        // NOT make a player ineligible for future byes.
+        if (game.result >= 1) {
+          byeCount++;
+        }
         score += game.result;
         colorHistory.push(undefined);
+        // C++ gameWasPlayed is false for all bye types, so byes count as
+        // unplayed rounds (same as forfeits). This affects the C9 criterion
+        // (minimize unplayed games of bye assignee).
+        unplayedRounds++;
         // C++ getFloat: points > pointsForLoss → FLOAT_DOWN, else FLOAT_NONE.
         // pointsForLoss is 0, so only byes awarding > 0 points get downfloat.
         floatHistory.push(game.result > 0 ? 'down' : undefined);


### PR DESCRIPTION
## Summary

- half-byes (0.5 pts) and zero-byes (0 pts) no longer make a player ineligible for future byes — only byes awarding >= 1 point do
- byes now count as unplayed rounds (`gameWasPlayed=false` in C++), fixing C9 criterion (minimize unplayed games of bye assignee)

fixes the last remaining discrepancy in the FIDE endorsement test (5000 seeds) — `bbp_seed_377295570_70p_11r.trf` round 6, where a half-bye recipient was wrongly marked ineligible, causing the feasibility blossom to leave a different player unmatched for the bye.