### PR TITLE
release: @echecs/swiss@3.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [3.1.3] - 2026-05-04
+
+### Fixed
+
+- Half-byes (0.5 pts) and zero-byes (0 pts) incorrectly made players ineligible
+  for future bye assignment. Only byes awarding >= 1 point (pairing byes, full
+  byes, forfeit wins) should affect eligibility, matching bbpPairings'
+  `eligibleForBye` semantics.
+- Byes were not counted as unplayed rounds. In bbpPairings all bye types have
+  `gameWasPlayed=false`, so they contribute to the C9 criterion (minimize
+  unplayed games of bye assignee). This resolves the last remaining discrepancy
+  in the FIDE endorsement test (5000 seeds).
+
 ## [3.1.2] - 2026-05-04
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -111,5 +111,5 @@
     "test:watch": "pnpm run test --watch"
   },
   "type": "module",
-  "version": "3.1.2"
+  "version": "3.1.3"
 }


### PR DESCRIPTION
## Summary

- fixed bye eligibility: half-byes and zero-byes no longer make players ineligible for future byes
- fixed unplayed rounds: byes now count as unplayed (C++ `gameWasPlayed=false`), correcting the C9 criterion
- resolves the last remaining discrepancy in the FIDE endorsement test (5000 seeds, 100% match)