### PR TITLE
chore: align .gitignore with canonical template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,9 +11,6 @@ coverage/
 docs/api/*
 !docs/api/.gitkeep
 
-# Worktrees
-/.worktrees/
-
 # Agent planning artifacts
 .superpowers/
 docs/superpowers/


### PR DESCRIPTION
aligns .gitignore to the canonical trf template — removes stale entries