### PR TITLE
chore: update homepage to echecs.dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "README.md",
     "CHANGELOG.md"
   ],
-  "homepage": "https://github.com/echecsjs/swiss#readme",
+  "homepage": "https://swiss.echecs.dev",
   "keywords": [
     "burstein",
     "chess",


### PR DESCRIPTION
points homepage to the docs site instead of the github repo