### PR TITLE
feat!: adapt to @echecs/tournament v3 types

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   },
   "description": "Swiss chess tournament pairings following FIDE rules. Implements Dutch, Dubov, Burstein, Lim, Double, and Team Swiss systems.",
   "devDependencies": {
-    "@echecs/tournament": "^2.1.2",
+    "@echecs/tournament": "^3.1.0",
     "@echecs/trf": "^3.1.1",
     "@eslint/js": "^10.0.1",
     "@typescript-eslint/parser": "^8.57.0",
@@ -83,7 +83,7 @@
   ],
   "license": "MIT",
   "peerDependencies": {
-    "@echecs/tournament": "^2.0.0"
+    "@echecs/tournament": "^3.0.0"
   },
   "publishConfig": {
     "access": "public"
@@ -111,5 +111,5 @@
     "test:watch": "pnpm run test --watch"
   },
   "type": "module",
-  "version": "3.1.3"
+  "version": "4.0.0"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     devDependencies:
       '@echecs/tournament':
-        specifier: ^2.1.2
-        version: 2.1.2
+        specifier: ^3.1.0
+        version: 3.1.0
       '@echecs/trf':
         specifier: ^3.1.1
         version: 3.4.0
@@ -113,9 +113,9 @@ packages:
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
     engines: {node: '>=18'}
 
-  '@echecs/tournament@2.1.2':
-    resolution: {integrity: sha512-DYq8Nbc1Dq15ZpQMKWziGmfyxd4RC0jIgWsbVRLM6/q+sPKPjSPxiBtRC8+u5gPr0lKaK5eoZKs295I/W60akA==}
-    engines: {node: '>=20'}
+  '@echecs/tournament@3.1.0':
+    resolution: {integrity: sha512-eXc0BMjpimolwpcPnuzEClyFZ90TnN2nLEJLJ7UCr4oFCstjI2lUbABnLE7HsKUYg+j7QadgtTR2J+wcflDlwg==}
+    engines: {node: '>=22'}
 
   '@echecs/trf@3.4.0':
     resolution: {integrity: sha512-JEhN16qTjU8xZpDzKaILRpn/8BldqaYKiY9qhXcyr3mMYeuk65LAbiCPDDpO9Oe+2TQiNjP3HQfidObUnyuk1w==}
@@ -2003,7 +2003,7 @@ snapshots:
 
   '@bcoe/v8-coverage@1.0.2': {}
 
-  '@echecs/tournament@2.1.2': {}
+  '@echecs/tournament@3.1.0': {}
 
   '@echecs/trf@3.4.0': {}
 

--- a/src/__tests__/burstein.spec.ts
+++ b/src/__tests__/burstein.spec.ts
@@ -2,22 +2,22 @@ import { describe, expect, it } from 'vitest';
 
 import { pair } from '../burstein.js';
 
-import type { Game, Player } from '../types.js';
+import type { CompletedRound, Player } from '../types.js';
 
 const FOUR_PLAYERS: Player[] = [
-  { id: 'A', rating: 2000 },
-  { id: 'B', rating: 1900 },
-  { id: 'C', rating: 1800 },
-  { id: 'D', rating: 1700 },
+  { id: 'A', points: 0, rank: 1, rating: 2000 },
+  { id: 'B', points: 0, rank: 2, rating: 1900 },
+  { id: 'C', points: 0, rank: 3, rating: 1800 },
+  { id: 'D', points: 0, rank: 4, rating: 1700 },
 ];
 
 describe('burstein', () => {
   describe('round 1', () => {
     it('pairs highest vs lowest, second vs third', () => {
       const result = pair(FOUR_PLAYERS, []);
-      expect(result.pairings).toHaveLength(2);
+      expect(result.games).toHaveLength(2);
       expect(result.byes).toHaveLength(0);
-      const ids = result.pairings.map((p) =>
+      const ids = result.games.map((p) =>
         [p.white, p.black].toSorted().join('-'),
       );
       expect(ids).toContain('A-D');
@@ -33,12 +33,15 @@ describe('burstein', () => {
 
   describe('invariants', () => {
     it('never pairs the same two players twice', () => {
-      const round1Games: Game[] = [
-        { black: 'D', result: 1, white: 'A' },
-        { black: 'C', result: 1, white: 'B' },
-      ];
-      const result = pair(FOUR_PLAYERS, [round1Games]);
-      const pairs = result.pairings.map((p) =>
+      const round1: CompletedRound = {
+        byes: [],
+        games: [
+          { black: 'D', result: 'white', white: 'A' },
+          { black: 'C', result: 'white', white: 'B' },
+        ],
+      };
+      const result = pair(FOUR_PLAYERS, [round1]);
+      const pairs = result.games.map((p) =>
         [p.white, p.black].toSorted().join('-'),
       );
       expect(pairs).not.toContain('A-D');
@@ -47,11 +50,12 @@ describe('burstein', () => {
 
     it('does not give a bye to a player who already had one', () => {
       const threePlayers = FOUR_PLAYERS.slice(0, 3);
-      const round1Games: Game[] = [
-        { black: 'C', result: 1, white: 'C' },
-        { black: 'B', result: 1, white: 'A' },
-      ];
-      const result = pair(threePlayers, [round1Games]);
+      // C got a bye in round 1 (bye sentinel via byes array)
+      const round1: CompletedRound = {
+        byes: [{ kind: 'pairing', player: 'C' }],
+        games: [{ black: 'B', result: 'white', white: 'A' }],
+      };
+      const result = pair(threePlayers, [round1]);
       expect(result.byes[0]?.player).not.toBe('C');
     });
   });

--- a/src/__tests__/double-swiss-utilities.spec.ts
+++ b/src/__tests__/double-swiss-utilities.spec.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import { matchColorHistory, matchCount } from '../utilities.js';
 
-import type { Game } from '../types.js';
+import type { CompletedRound } from '../types.js';
 
 describe('matchCount', () => {
   it('returns 0 when player has no games', () => {
@@ -10,33 +10,44 @@ describe('matchCount', () => {
   });
 
   it('counts each unique real-opponent round as one match', () => {
-    const games: Game[][] = [
-      [
-        { black: 'B', result: 1, white: 'A' },
-        { black: 'A', result: 0, white: 'B' },
-      ],
-      [
-        { black: 'A', result: 1, white: 'B' },
-        { black: 'B', result: 0, white: 'A' },
-      ],
+    const rounds: CompletedRound[] = [
+      {
+        byes: [],
+        games: [
+          { black: 'B', result: 'white', white: 'A' },
+          { black: 'A', result: 'black', white: 'B' },
+        ],
+      },
+      {
+        byes: [],
+        games: [
+          { black: 'A', result: 'white', white: 'B' },
+          { black: 'B', result: 'black', white: 'A' },
+        ],
+      },
     ];
-    expect(matchCount('A', games)).toBe(2);
+    expect(matchCount('A', rounds)).toBe(2);
   });
 
   it('does not count bye rounds', () => {
-    const games: Game[][] = [[{ black: 'A', result: 1, white: 'A' }]];
-    expect(matchCount('A', games)).toBe(0);
+    const rounds: CompletedRound[] = [
+      { byes: [{ kind: 'pairing', player: 'A' }], games: [] },
+    ];
+    expect(matchCount('A', rounds)).toBe(0);
   });
 
   it('does not count bye rounds even when mixed with real games', () => {
-    const games: Game[][] = [
-      [{ black: 'A', result: 1, white: 'A' }],
-      [
-        { black: 'B', result: 1, white: 'A' },
-        { black: 'A', result: 0, white: 'B' },
-      ],
+    const rounds: CompletedRound[] = [
+      { byes: [{ kind: 'pairing', player: 'A' }], games: [] },
+      {
+        byes: [],
+        games: [
+          { black: 'B', result: 'white', white: 'A' },
+          { black: 'A', result: 'black', white: 'B' },
+        ],
+      },
     ];
-    expect(matchCount('A', games)).toBe(1);
+    expect(matchCount('A', rounds)).toBe(1);
   });
 });
 
@@ -48,31 +59,40 @@ describe('matchColorHistory', () => {
   it('returns the color of the first game in each match round', () => {
     // Round 1: A plays white first (game 1), then black (game 2) — first game determines color
     // Round 2: A plays black first
-    const games: Game[][] = [
-      [
-        { black: 'B', result: 1, white: 'A' },
-        { black: 'A', result: 0, white: 'B' },
-      ],
-      [
-        { black: 'A', result: 1, white: 'B' },
-        { black: 'B', result: 0, white: 'A' },
-      ],
+    const rounds: CompletedRound[] = [
+      {
+        byes: [],
+        games: [
+          { black: 'B', result: 'white', white: 'A' },
+          { black: 'A', result: 'black', white: 'B' },
+        ],
+      },
+      {
+        byes: [],
+        games: [
+          { black: 'A', result: 'white', white: 'B' },
+          { black: 'B', result: 'black', white: 'A' },
+        ],
+      },
     ];
-    const result = matchColorHistory('A', games);
+    const result = matchColorHistory('A', rounds);
     expect(result).toHaveLength(2);
     expect(result[0]).toBe('white'); // first game round 1: A is white
     expect(result[1]).toBe('black'); // first game round 2: A is black
   });
 
   it('skips bye rounds', () => {
-    const games: Game[][] = [
-      [{ black: 'A', result: 1, white: 'A' }],
-      [
-        { black: 'B', result: 1, white: 'A' },
-        { black: 'A', result: 0, white: 'B' },
-      ],
+    const rounds: CompletedRound[] = [
+      { byes: [{ kind: 'pairing', player: 'A' }], games: [] },
+      {
+        byes: [],
+        games: [
+          { black: 'B', result: 'white', white: 'A' },
+          { black: 'A', result: 'black', white: 'B' },
+        ],
+      },
     ];
-    const result = matchColorHistory('A', games);
+    const result = matchColorHistory('A', rounds);
     expect(result).toHaveLength(1);
     expect(result[0]).toBe('white');
   });
@@ -80,17 +100,23 @@ describe('matchColorHistory', () => {
   it('returns colors ordered by round index', () => {
     // Round 1 (index 0): A is white first game
     // Round 2 (index 1): A is black first game
-    const games: Game[][] = [
-      [
-        { black: 'B', result: 1, white: 'A' },
-        { black: 'A', result: 0, white: 'B' },
-      ],
-      [
-        { black: 'A', result: 1, white: 'B' },
-        { black: 'B', result: 0, white: 'A' },
-      ],
+    const rounds: CompletedRound[] = [
+      {
+        byes: [],
+        games: [
+          { black: 'B', result: 'white', white: 'A' },
+          { black: 'A', result: 'black', white: 'B' },
+        ],
+      },
+      {
+        byes: [],
+        games: [
+          { black: 'A', result: 'white', white: 'B' },
+          { black: 'B', result: 'black', white: 'A' },
+        ],
+      },
     ];
-    const result = matchColorHistory('A', games);
+    const result = matchColorHistory('A', rounds);
     expect(result).toEqual(['white', 'black']); // round index 0: white, round index 1: black
   });
 });

--- a/src/__tests__/double-swiss.spec.ts
+++ b/src/__tests__/double-swiss.spec.ts
@@ -2,30 +2,30 @@ import { describe, expect, it } from 'vitest';
 
 import { pair } from '../double-swiss.js';
 
-import type { Game, Player } from '../types.js';
+import type { CompletedRound, Player } from '../types.js';
 
-/** Returns true if the given pairings contain a specific pair (order-insensitive). */
+/** Returns true if the given games contain a specific pair (order-insensitive). */
 function hasPair(
-  pairings: ReturnType<typeof pair>['pairings'],
+  games: ReturnType<typeof pair>['games'],
   a: string,
   b: string,
 ): boolean {
-  return pairings.some(
+  return games.some(
     (p) => (p.white === a && p.black === b) || (p.white === b && p.black === a),
   );
 }
 
 const FOUR_PLAYERS: Player[] = [
-  { id: 'A', rating: 2000 },
-  { id: 'B', rating: 1900 },
-  { id: 'C', rating: 1800 },
-  { id: 'D', rating: 1700 },
+  { id: 'A', points: 0, rank: 1, rating: 2000 },
+  { id: 'B', points: 0, rank: 2, rating: 1900 },
+  { id: 'C', points: 0, rank: 3, rating: 1800 },
+  { id: 'D', points: 0, rank: 4, rating: 1700 },
 ];
 
 const THREE_PLAYERS: Player[] = [
-  { id: 'A', rating: 2000 },
-  { id: 'B', rating: 1900 },
-  { id: 'C', rating: 1800 },
+  { id: 'A', points: 0, rank: 1, rating: 2000 },
+  { id: 'B', points: 0, rank: 2, rating: 1900 },
+  { id: 'C', points: 0, rank: 3, rating: 1800 },
 ];
 
 describe('doubleSwiss', () => {
@@ -43,12 +43,12 @@ describe('doubleSwiss', () => {
 
     it('produces correct number of pairings for even players', () => {
       const result = pair(FOUR_PLAYERS, []);
-      expect(result.pairings).toHaveLength(2);
+      expect(result.games).toHaveLength(2);
     });
 
     it('each player appears exactly once across all pairings', () => {
       const result = pair(FOUR_PLAYERS, []);
-      const allIds = result.pairings.flatMap((p) => [p.white, p.black]);
+      const allIds = result.games.flatMap((p) => [p.white, p.black]);
       expect(new Set(allIds).size).toBe(4);
       expect(allIds).toHaveLength(4);
     });
@@ -68,51 +68,57 @@ describe('doubleSwiss', () => {
 
     it('prefers lowest-score player for bye', () => {
       const fivePlayers: Player[] = [
-        { id: 'A', rating: 2000 },
-        { id: 'B', rating: 1900 },
-        { id: 'C', rating: 1800 },
-        { id: 'D', rating: 1700 },
-        { id: 'E', rating: 1600 },
+        { id: 'A', points: 0, rank: 1, rating: 2000 },
+        { id: 'B', points: 0, rank: 2, rating: 1900 },
+        { id: 'C', points: 0, rank: 3, rating: 1800 },
+        { id: 'D', points: 0, rank: 4, rating: 1700 },
+        { id: 'E', points: 0, rank: 5, rating: 1600 },
       ];
       // A and B each get 1 from draws; C and D each get 1 from draws; E=0
-      const round1Games: Game[] = [
-        { black: 'B', result: 0.5, white: 'A' },
-        { black: 'A', result: 0.5, white: 'B' },
-        { black: 'D', result: 0.5, white: 'C' },
-        { black: 'C', result: 0.5, white: 'D' },
-      ];
+      const round1: CompletedRound = {
+        byes: [],
+        games: [
+          { black: 'B', result: 'draw', white: 'A' },
+          { black: 'A', result: 'draw', white: 'B' },
+          { black: 'D', result: 'draw', white: 'C' },
+          { black: 'C', result: 'draw', white: 'D' },
+        ],
+      };
       // Scores: A=1, B=1, C=1, D=1, E=0
       // Only E has score 0 → E gets the bye
-      const result = pair(fivePlayers, [round1Games]);
+      const result = pair(fivePlayers, [round1]);
       expect(result.byes[0]?.player).toBe('E');
     });
 
     it('does not assign bye to player who already received one (C2 rule)', () => {
       // C already received a bye in round 1 — should not get another
-      const round1Games: Game[] = [
-        { black: 'C', result: 1, white: 'C' },
-        { black: 'C', result: 0.5, white: 'C' },
-      ];
-      const result = pair(THREE_PLAYERS, [round1Games]);
+      const round1: CompletedRound = {
+        byes: [{ kind: 'pairing', player: 'C' }],
+        games: [],
+      };
+      const result = pair(THREE_PLAYERS, [round1]);
       expect(result.byes[0]?.player).not.toBe('C');
     });
 
     it('prefers player with most matches played when scores tie', () => {
       // B=0 (1 match), E=0 (0 matches) → B gets bye (more matches)
       const fivePlayers: Player[] = [
-        { id: 'A', rating: 2000 },
-        { id: 'B', rating: 1900 },
-        { id: 'C', rating: 1800 },
-        { id: 'D', rating: 1700 },
-        { id: 'E', rating: 1600 },
+        { id: 'A', points: 0, rank: 1, rating: 2000 },
+        { id: 'B', points: 0, rank: 2, rating: 1900 },
+        { id: 'C', points: 0, rank: 3, rating: 1800 },
+        { id: 'D', points: 0, rank: 4, rating: 1700 },
+        { id: 'E', points: 0, rank: 5, rating: 1600 },
       ];
-      const round1Games: Game[] = [
-        { black: 'B', result: 1, white: 'A' },
-        { black: 'A', result: 0, white: 'B' },
-        { black: 'D', result: 0.5, white: 'C' },
-        { black: 'C', result: 0.5, white: 'D' },
-      ];
-      const result = pair(fivePlayers, [round1Games]);
+      const round1: CompletedRound = {
+        byes: [],
+        games: [
+          { black: 'B', result: 'white', white: 'A' },
+          { black: 'A', result: 'black', white: 'B' },
+          { black: 'D', result: 'draw', white: 'C' },
+          { black: 'C', result: 'draw', white: 'D' },
+        ],
+      };
+      const result = pair(fivePlayers, [round1]);
       expect(result.byes[0]?.player).toBe('B');
     });
   });
@@ -121,93 +127,101 @@ describe('doubleSwiss', () => {
     it('pairs 4 players with no prior games in lexicographic order', () => {
       // Lexicographically first valid pairing: A-C and B-D
       const result = pair(FOUR_PLAYERS, []);
-      expect(hasPair(result.pairings, 'A', 'C')).toBe(true);
-      expect(hasPair(result.pairings, 'B', 'D')).toBe(true);
+      expect(hasPair(result.games, 'A', 'C')).toBe(true);
+      expect(hasPair(result.games, 'B', 'D')).toBe(true);
     });
 
     it('avoids rematches (C1) when finding lexicographic pairing', () => {
       // Prior pairings: A-C and B-D → lex-first is illegal → next lex: A-D and B-C
-      const round1Games: Game[] = [
-        { black: 'C', result: 0.5, white: 'A' },
-        { black: 'A', result: 0.5, white: 'C' },
-        { black: 'D', result: 0.5, white: 'B' },
-        { black: 'B', result: 0.5, white: 'D' },
-      ];
-      const result = pair(FOUR_PLAYERS, [round1Games]);
-      expect(hasPair(result.pairings, 'A', 'D')).toBe(true);
-      expect(hasPair(result.pairings, 'B', 'C')).toBe(true);
+      const round1: CompletedRound = {
+        byes: [],
+        games: [
+          { black: 'C', result: 'draw', white: 'A' },
+          { black: 'A', result: 'draw', white: 'C' },
+          { black: 'D', result: 'draw', white: 'B' },
+          { black: 'B', result: 'draw', white: 'D' },
+        ],
+      };
+      const result = pair(FOUR_PLAYERS, [round1]);
+      expect(hasPair(result.games, 'A', 'D')).toBe(true);
+      expect(hasPair(result.games, 'B', 'C')).toBe(true);
     });
 
     it('pairs 6 players all same score in lexicographic order', () => {
       const sixPlayers: Player[] = [
-        { id: 'A', rating: 2000 },
-        { id: 'B', rating: 1900 },
-        { id: 'C', rating: 1800 },
-        { id: 'D', rating: 1700 },
-        { id: 'E', rating: 1600 },
-        { id: 'F', rating: 1500 },
+        { id: 'A', points: 0, rank: 1, rating: 2000 },
+        { id: 'B', points: 0, rank: 2, rating: 1900 },
+        { id: 'C', points: 0, rank: 3, rating: 1800 },
+        { id: 'D', points: 0, rank: 4, rating: 1700 },
+        { id: 'E', points: 0, rank: 5, rating: 1600 },
+        { id: 'F', points: 0, rank: 6, rating: 1500 },
       ];
       const result = pair(sixPlayers, []);
       expect(result.byes).toHaveLength(0);
-      expect(result.pairings).toHaveLength(3);
-      const allIds = result.pairings.flatMap((p) => [p.white, p.black]);
+      expect(result.games).toHaveLength(3);
+      const allIds = result.games.flatMap((p) => [p.white, p.black]);
       expect(new Set(allIds).size).toBe(6);
       // Lexicographic-first pairing: {A-D, B-E, C-F}
-      expect(hasPair(result.pairings, 'A', 'D')).toBe(true);
-      expect(hasPair(result.pairings, 'B', 'E')).toBe(true);
-      expect(hasPair(result.pairings, 'C', 'F')).toBe(true);
+      expect(hasPair(result.games, 'A', 'D')).toBe(true);
+      expect(hasPair(result.games, 'B', 'E')).toBe(true);
+      expect(hasPair(result.games, 'C', 'F')).toBe(true);
     });
 
     it('pulls upfloater from next score group when top group is odd-sized', () => {
       const fivePlayers: Player[] = [
-        { id: 'A', rating: 2000 },
-        { id: 'B', rating: 1900 },
-        { id: 'C', rating: 1800 },
-        { id: 'D', rating: 1700 },
-        { id: 'E', rating: 1600 },
+        { id: 'A', points: 0, rank: 1, rating: 2000 },
+        { id: 'B', points: 0, rank: 2, rating: 1900 },
+        { id: 'C', points: 0, rank: 3, rating: 1800 },
+        { id: 'D', points: 0, rank: 4, rating: 1700 },
+        { id: 'E', points: 0, rank: 5, rating: 1600 },
       ];
       // A has score 2 (2 wins), B=C=1 (1 draw each), D=E=0
-      const round1Games: Game[] = [
-        { black: 'E', result: 1, white: 'A' },
-        { black: 'A', result: 0, white: 'E' },
-        { black: 'C', result: 0.5, white: 'B' },
-        { black: 'B', result: 0.5, white: 'C' },
-      ];
-      const result = pair(fivePlayers, [round1Games]);
-      expect(result.pairings).toHaveLength(2);
+      const round1: CompletedRound = {
+        byes: [],
+        games: [
+          { black: 'E', result: 'white', white: 'A' },
+          { black: 'A', result: 'black', white: 'E' },
+          { black: 'C', result: 'draw', white: 'B' },
+          { black: 'B', result: 'draw', white: 'C' },
+        ],
+      };
+      const result = pair(fivePlayers, [round1]);
+      expect(result.games).toHaveLength(2);
       expect(result.byes).toHaveLength(1);
       // A must be paired with someone
-      const allIds = result.pairings.flatMap((p) => [p.white, p.black]);
+      const allIds = result.games.flatMap((p) => [p.white, p.black]);
       expect(allIds).toContain('A');
     });
   });
 
   describe('match model', () => {
-    it('bye produces 1 entry in byes array with two game entries in input', () => {
-      const players = [
-        { id: 'A', rating: 2000 },
-        { id: 'B', rating: 1900 },
-        { id: 'C', rating: 1800 },
+    it('bye produces 1 entry in byes array', () => {
+      const players: Player[] = [
+        { id: 'A', points: 0, rank: 1, rating: 2000 },
+        { id: 'B', points: 0, rank: 2, rating: 1900 },
+        { id: 'C', points: 0, rank: 3, rating: 1800 },
       ];
       const result = pair(players, []);
       expect(result.byes).toHaveLength(1);
-      expect(result.pairings).toHaveLength(1);
+      expect(result.games).toHaveLength(1);
     });
   });
 
   describe('invariants', () => {
     it('never pairs the same two players twice across rounds', () => {
       const result1 = pair(FOUR_PLAYERS, []);
-      const round1Games: Game[] = [];
-      for (const p of result1.pairings) {
-        round1Games.push(
-          { black: p.black, result: 0.5, white: p.white },
-          { black: p.white, result: 0.5, white: p.black },
-        );
-      }
-      const result2 = pair(FOUR_PLAYERS, [round1Games]);
-      for (const p2 of result2.pairings) {
-        const isRematch = result1.pairings.some(
+      const round1: CompletedRound = {
+        byes: result1.byes,
+        games: [
+          ...result1.games.flatMap((p) => [
+            { black: p.black, result: 'draw' as const, white: p.white },
+            { black: p.white, result: 'draw' as const, white: p.black },
+          ]),
+        ],
+      };
+      const result2 = pair(FOUR_PLAYERS, [round1]);
+      for (const p2 of result2.games) {
+        const isRematch = result1.games.some(
           (p1) =>
             (p1.white === p2.white && p1.black === p2.black) ||
             (p1.white === p2.black && p1.black === p2.white),
@@ -221,12 +235,12 @@ describe('doubleSwiss', () => {
       expect(result4.byes).toHaveLength(0);
 
       const sixPlayers: Player[] = [
-        { id: 'A', rating: 2000 },
-        { id: 'B', rating: 1900 },
-        { id: 'C', rating: 1800 },
-        { id: 'D', rating: 1700 },
-        { id: 'E', rating: 1600 },
-        { id: 'F', rating: 1500 },
+        { id: 'A', points: 0, rank: 1, rating: 2000 },
+        { id: 'B', points: 0, rank: 2, rating: 1900 },
+        { id: 'C', points: 0, rank: 3, rating: 1800 },
+        { id: 'D', points: 0, rank: 4, rating: 1700 },
+        { id: 'E', points: 0, rank: 5, rating: 1600 },
+        { id: 'F', points: 0, rank: 6, rating: 1500 },
       ];
       const result6 = pair(sixPlayers, []);
       expect(result6.byes).toHaveLength(0);
@@ -234,14 +248,14 @@ describe('doubleSwiss', () => {
 
     it('all players appear exactly once per round (even count)', () => {
       const result = pair(FOUR_PLAYERS, []);
-      const allIds = result.pairings.flatMap((p) => [p.white, p.black]);
+      const allIds = result.games.flatMap((p) => [p.white, p.black]);
       const playerIds = FOUR_PLAYERS.map((p) => p.id).toSorted();
       expect(allIds.toSorted()).toStrictEqual(playerIds);
     });
 
     it('all players appear exactly once per round (odd count)', () => {
       const result = pair(THREE_PLAYERS, []);
-      const pairedIds = result.pairings.flatMap((p) => [p.white, p.black]);
+      const pairedIds = result.games.flatMap((p) => [p.white, p.black]);
       const byeIds = result.byes.map((b) => b.player);
       const allIds = [...pairedIds, ...byeIds].toSorted();
       const playerIds = THREE_PLAYERS.map((p) => p.id).toSorted();
@@ -251,12 +265,12 @@ describe('doubleSwiss', () => {
     it('works with 2 players (minimum)', () => {
       const result = pair(
         [
-          { id: 'A', rating: 2000 },
-          { id: 'B', rating: 1900 },
+          { id: 'A', points: 0, rank: 1, rating: 2000 },
+          { id: 'B', points: 0, rank: 2, rating: 1900 },
         ],
         [],
       );
-      expect(result.pairings).toHaveLength(1);
+      expect(result.games).toHaveLength(1);
       expect(result.byes).toHaveLength(0);
     });
   });
@@ -264,36 +278,38 @@ describe('doubleSwiss', () => {
   describe('multi-round simulation', () => {
     it('can pair 3 rounds of a 6-player tournament', () => {
       const players: Player[] = [
-        { id: 'A', rating: 2100 },
-        { id: 'B', rating: 2000 },
-        { id: 'C', rating: 1900 },
-        { id: 'D', rating: 1800 },
-        { id: 'E', rating: 1700 },
-        { id: 'F', rating: 1600 },
+        { id: 'A', points: 0, rank: 1, rating: 2100 },
+        { id: 'B', points: 0, rank: 2, rating: 2000 },
+        { id: 'C', points: 0, rank: 3, rating: 1900 },
+        { id: 'D', points: 0, rank: 4, rating: 1800 },
+        { id: 'E', points: 0, rank: 5, rating: 1700 },
+        { id: 'F', points: 0, rank: 6, rating: 1600 },
       ];
-      let games: Game[][] = [];
+      let rounds: CompletedRound[] = [];
 
       for (let round = 1; round <= 3; round++) {
-        const result = pair(players, games);
-        expect(result.pairings).toHaveLength(3);
+        const result = pair(players, rounds);
+        expect(result.games).toHaveLength(3);
         expect(result.byes).toHaveLength(0);
 
         // Record games (all draws for simplicity)
-        const roundGames: Game[] = [];
-        for (const p of result.pairings) {
-          roundGames.push(
-            { black: p.black, result: 0.5, white: p.white },
-            { black: p.white, result: 0.5, white: p.black },
-          );
-        }
-        games = [...games, roundGames];
+        const roundCompleted: CompletedRound = {
+          byes: [],
+          games: [
+            ...result.games.flatMap((p) => [
+              { black: p.black, result: 'draw' as const, white: p.white },
+              { black: p.white, result: 'draw' as const, white: p.black },
+            ]),
+          ],
+        };
+        rounds = [...rounds, roundCompleted];
       }
 
       // Verify no rematches across all 3 rounds
       const allPairs = new Set<string>();
-      for (const roundGames of games) {
+      for (const roundData of rounds) {
         const pairs = new Set<string>();
-        for (const g of roundGames) {
+        for (const g of roundData.games) {
           const key = [g.white, g.black].toSorted().join('-');
           pairs.add(key);
         }
@@ -312,11 +328,11 @@ describe('doubleSwiss', () => {
       // HRP: A vs B score tied at 0, A has smaller TPN → A is HRP
       // HRP has odd TPN (1-based = 1) → A gets White
       const players: Player[] = [
-        { id: 'A', rating: 2000 },
-        { id: 'B', rating: 1900 },
+        { id: 'A', points: 0, rank: 1, rating: 2000 },
+        { id: 'B', points: 0, rank: 2, rating: 1900 },
       ];
       const result = pair(players, []);
-      const pairing = result.pairings[0];
+      const pairing = result.games[0];
       expect(pairing).toBeDefined();
       expect(pairing!.white).toBe('A');
       expect(pairing!.black).toBe('B');
@@ -325,19 +341,19 @@ describe('doubleSwiss', () => {
     it('round 1 — HRP with even TPN (4.3.1): HRP gets Black', () => {
       // B received a bye in round 1 → B has higher score → B is HRP with even TPN (2) → B gets Black
       const players: Player[] = [
-        { id: 'A', rating: 2000 },
-        { id: 'B', rating: 1900 },
+        { id: 'A', points: 0, rank: 1, rating: 2000 },
+        { id: 'B', points: 0, rank: 2, rating: 1900 },
       ];
-      const round1Games: Game[] = [
-        // B received a bye in round 1 — gives score but no match color history
-        { black: 'B', result: 1, white: 'B' },
-        { black: 'B', result: 0.5, white: 'B' },
-      ];
-      // Scores: A=0, B=1.5; matchColorHistory: A=[], B=[] (byes excluded)
+      // B received a bye in round 1 — gives score but no match color history
+      const round1: CompletedRound = {
+        byes: [{ kind: 'pairing', player: 'B' }],
+        games: [],
+      };
+      // Scores: A=0, B=1; matchColorHistory: A=[], B=[] (byes excluded)
       // Round 2: A vs B haven't faced each other → paired.
       // B (HRP) has even 1-based TPN (2) → B gets Black → A gets White.
-      const result = pair(players, [round1Games]);
-      const pairing = result.pairings[0];
+      const result = pair(players, [round1]);
+      const pairing = result.games[0];
       expect(pairing).toBeDefined();
       expect(pairing!.white).toBe('A');
       expect(pairing!.black).toBe('B');
@@ -346,31 +362,37 @@ describe('doubleSwiss', () => {
     it('fewer Whites (4.3.2): player with fewer Whites gets White', () => {
       // A has 2 white match colors, B has 0 → B gets White in round 3
       const players: Player[] = [
-        { id: 'A', rating: 2000 },
-        { id: 'B', rating: 1900 },
-        { id: 'C', rating: 1800 },
-        { id: 'D', rating: 1700 },
+        { id: 'A', points: 0, rank: 1, rating: 2000 },
+        { id: 'B', points: 0, rank: 2, rating: 1900 },
+        { id: 'C', points: 0, rank: 3, rating: 1800 },
+        { id: 'D', points: 0, rank: 4, rating: 1700 },
       ];
-      const round1Games: Game[] = [
-        // Round 1: A(white) vs C — A match color = white
-        { black: 'C', result: 0.5, white: 'A' },
-        { black: 'A', result: 0.5, white: 'C' },
-        // Round 1: D(white) vs B — B match color = black
-        { black: 'B', result: 0.5, white: 'D' },
-        { black: 'D', result: 0.5, white: 'B' },
-      ];
-      const round2Games: Game[] = [
-        // Round 2: A(white) vs D — A gets another white match color
-        { black: 'D', result: 0.5, white: 'A' },
-        { black: 'A', result: 0.5, white: 'D' },
-        // Round 2: C(white) vs B — B gets another black match color
-        { black: 'B', result: 0.5, white: 'C' },
-        { black: 'C', result: 0.5, white: 'B' },
-      ];
+      const round1: CompletedRound = {
+        byes: [],
+        games: [
+          // Round 1: A(white) vs C — A match color = white
+          { black: 'C', result: 'draw', white: 'A' },
+          { black: 'A', result: 'draw', white: 'C' },
+          // Round 1: D(white) vs B — B match color = black
+          { black: 'B', result: 'draw', white: 'D' },
+          { black: 'D', result: 'draw', white: 'B' },
+        ],
+      };
+      const round2: CompletedRound = {
+        byes: [],
+        games: [
+          // Round 2: A(white) vs D — A gets another white match color
+          { black: 'D', result: 'draw', white: 'A' },
+          { black: 'A', result: 'draw', white: 'D' },
+          // Round 2: C(white) vs B — B gets another black match color
+          { black: 'B', result: 'draw', white: 'C' },
+          { black: 'C', result: 'draw', white: 'B' },
+        ],
+      };
       // Round 3: only valid pairings avoid rematches: A-B and C-D
       // A has 2 whites, B has 0 whites → 4.3.2: B has fewer whites → B gets White
-      const result = pair(players, [round1Games, round2Games]);
-      const avsBpairing = result.pairings.find(
+      const result = pair(players, [round1, round2]);
+      const avsBpairing = result.games.find(
         (p) =>
           (p.white === 'A' && p.black === 'B') ||
           (p.white === 'B' && p.black === 'A'),
@@ -384,31 +406,37 @@ describe('doubleSwiss', () => {
       // A and B both had match-level colors [white, white] → no divergence → 4.3.4
       // A is HRP (smaller TPN), A last match = white → A gets Black
       const players: Player[] = [
-        { id: 'A', rating: 2000 },
-        { id: 'B', rating: 1900 },
-        { id: 'C', rating: 1800 },
-        { id: 'D', rating: 1700 },
+        { id: 'A', points: 0, rank: 1, rating: 2000 },
+        { id: 'B', points: 0, rank: 2, rating: 1900 },
+        { id: 'C', points: 0, rank: 3, rating: 1800 },
+        { id: 'D', points: 0, rank: 4, rating: 1700 },
       ];
-      const round1Games: Game[] = [
-        // Round 1: A(white) vs C — A gets white match color
-        { black: 'C', result: 0.5, white: 'A' },
-        { black: 'A', result: 0.5, white: 'C' },
-        // Round 1: B(white) vs D — B gets white match color
-        { black: 'D', result: 0.5, white: 'B' },
-        { black: 'B', result: 0.5, white: 'D' },
-      ];
-      const round2Games: Game[] = [
-        // Round 2: A(white) vs D — A gets white match color again
-        { black: 'D', result: 0.5, white: 'A' },
-        { black: 'A', result: 0.5, white: 'D' },
-        // Round 2: B(white) vs C — B gets white match color again
-        { black: 'C', result: 0.5, white: 'B' },
-        { black: 'B', result: 0.5, white: 'C' },
-      ];
+      const round1: CompletedRound = {
+        byes: [],
+        games: [
+          // Round 1: A(white) vs C — A gets white match color
+          { black: 'C', result: 'draw', white: 'A' },
+          { black: 'A', result: 'draw', white: 'C' },
+          // Round 1: B(white) vs D — B gets white match color
+          { black: 'D', result: 'draw', white: 'B' },
+          { black: 'B', result: 'draw', white: 'D' },
+        ],
+      };
+      const round2: CompletedRound = {
+        byes: [],
+        games: [
+          // Round 2: A(white) vs D — A gets white match color again
+          { black: 'D', result: 'draw', white: 'A' },
+          { black: 'A', result: 'draw', white: 'D' },
+          // Round 2: B(white) vs C — B gets white match color again
+          { black: 'C', result: 'draw', white: 'B' },
+          { black: 'B', result: 'draw', white: 'C' },
+        ],
+      };
       // Round 3: A-B paired, matchColorHistory: A=['white','white'], B=['white','white']
       // 4.3.4: A is HRP, last match = white → A gets Black
-      const result = pair(players, [round1Games, round2Games]);
-      const avsBpairing = result.pairings.find(
+      const result = pair(players, [round1, round2]);
+      const avsBpairing = result.games.find(
         (p) =>
           (p.white === 'A' && p.black === 'B') ||
           (p.white === 'B' && p.black === 'A'),

--- a/src/__tests__/dubov.spec.ts
+++ b/src/__tests__/dubov.spec.ts
@@ -2,21 +2,21 @@ import { describe, expect, it } from 'vitest';
 
 import { pair } from '../dubov.js';
 
-import type { Game, Player } from '../types.js';
+import type { CompletedRound, Player } from '../types.js';
 
 const FOUR_PLAYERS: Player[] = [
-  { id: 'A', rating: 2000 },
-  { id: 'B', rating: 1900 },
-  { id: 'C', rating: 1800 },
-  { id: 'D', rating: 1700 },
+  { id: 'A', points: 0, rank: 1, rating: 2000 },
+  { id: 'B', points: 0, rank: 2, rating: 1900 },
+  { id: 'C', points: 0, rank: 3, rating: 1800 },
+  { id: 'D', points: 0, rank: 4, rating: 1700 },
 ];
 
 describe('dubov', () => {
   describe('round 1', () => {
     it('pairs adjacent ranks: 1 vs 2, 3 vs 4', () => {
       const result = pair(FOUR_PLAYERS, []);
-      expect(result.pairings).toHaveLength(2);
-      const ids = result.pairings.map((p) =>
+      expect(result.games).toHaveLength(2);
+      const ids = result.games.map((p) =>
         [p.white, p.black].toSorted().join('-'),
       );
       expect(ids).toContain('A-B');
@@ -32,12 +32,15 @@ describe('dubov', () => {
 
   describe('invariants', () => {
     it('never pairs the same two players twice', () => {
-      const round1Games: Game[] = [
-        { black: 'B', result: 1, white: 'A' },
-        { black: 'D', result: 1, white: 'C' },
-      ];
-      const result = pair(FOUR_PLAYERS, [round1Games]);
-      const pairs = result.pairings.map((p) =>
+      const round1: CompletedRound = {
+        byes: [],
+        games: [
+          { black: 'B', result: 'white', white: 'A' },
+          { black: 'D', result: 'white', white: 'C' },
+        ],
+      };
+      const result = pair(FOUR_PLAYERS, [round1]);
+      const pairs = result.games.map((p) =>
         [p.white, p.black].toSorted().join('-'),
       );
       expect(pairs).not.toContain('A-B');

--- a/src/__tests__/dutch.fixtures.spec.ts
+++ b/src/__tests__/dutch.fixtures.spec.ts
@@ -19,7 +19,7 @@ import issue15 from './fixtures/issue_15.trf?raw';
 import issue7 from './fixtures/issue_7.trf?raw';
 
 import type { TraceEvent } from '../trace.js';
-import type { Game, GameKind, Player } from '../types.js';
+import type { CompletedRound, Player } from '../types.js';
 import type { Tournament } from '@echecs/trf';
 
 // ---------------------------------------------------------------------------
@@ -29,11 +29,13 @@ import type { Tournament } from '@echecs/trf';
 function toSwissPlayers(tournament: Tournament): Player[] {
   return tournament.players.map((p) => ({
     id: String(p.pairingNumber),
+    points: 0,
+    rank: p.pairingNumber,
     rating: p.rating,
   }));
 }
 
-function toSwissGames(tournament: Tournament): Game[][] {
+function toSwissRounds(tournament: Tournament): CompletedRound[] {
   // Find max round
   let maxRound = 0;
   for (const player of tournament.players) {
@@ -44,31 +46,32 @@ function toSwissGames(tournament: Tournament): Game[][] {
     }
   }
 
-  // Build one array per round (1-indexed → 0-indexed)
-  const roundArrays: Game[][] = Array.from({ length: maxRound }, () => []);
+  // Build one CompletedRound per round (1-indexed → 0-indexed)
+  const roundArrays: CompletedRound[] = Array.from(
+    { length: maxRound },
+    () => ({ byes: [], games: [] }),
+  );
 
   for (const player of tournament.players) {
     for (const result of player.results) {
       const roundIndex = result.round - 1;
-      const roundGames = roundArrays[roundIndex];
-      if (roundGames === undefined) continue;
+      const roundData = roundArrays[roundIndex];
+      if (roundData === undefined) continue;
 
       // Bye results (no opponent)
       if (result.opponentId === null) {
-        const byeMap: Record<string, { kind: GameKind; result: 0 | 0.5 | 1 }> =
+        const byeKindMap: Record<string, 'full' | 'half' | 'pairing' | 'zero'> =
           {
-            F: { kind: 'full-bye', result: 1 },
-            H: { kind: 'half-bye', result: 0.5 },
-            U: { kind: 'pairing-bye', result: 1 },
-            Z: { kind: 'zero-bye', result: 0 },
+            F: 'full',
+            H: 'half',
+            U: 'pairing',
+            Z: 'zero',
           };
-        const bye = byeMap[result.result];
-        if (bye) {
-          roundGames.push({
-            black: '',
-            kind: bye.kind,
-            result: bye.result,
-            white: String(player.pairingNumber),
+        const byeKind = byeKindMap[result.result];
+        if (byeKind !== undefined) {
+          roundData.byes.push({
+            kind: byeKind,
+            player: String(player.pairingNumber),
           });
         }
         continue;
@@ -77,20 +80,31 @@ function toSwissGames(tournament: Tournament): Game[][] {
       // Regular games — only record from white's perspective
       if (result.color !== 'w') continue;
 
-      let score: 0 | 0.5 | 1;
+      let gameResult: 'black' | 'draw' | 'white';
+      let isForfeitWin = false;
+      let isForfeitLoss = false;
+
       switch (result.result) {
-        case '1':
-        case '+': {
-          score = 1;
+        case '1': {
+          gameResult = 'white';
           break;
         }
-        case '0':
+        case '+': {
+          gameResult = 'white';
+          isForfeitWin = true;
+          break;
+        }
+        case '0': {
+          gameResult = 'black';
+          break;
+        }
         case '-': {
-          score = 0;
+          gameResult = 'black';
+          isForfeitLoss = true;
           break;
         }
         case '=': {
-          score = 0.5;
+          gameResult = 'draw';
           break;
         }
         default: {
@@ -98,19 +112,28 @@ function toSwissGames(tournament: Tournament): Game[][] {
         }
       }
 
-      const game: Game = {
-        black: String(result.opponentId),
-        result: score,
-        white: String(player.pairingNumber),
-      };
+      const black = String(result.opponentId);
+      const white = String(player.pairingNumber);
 
-      if (result.result === '+') {
-        game.kind = 'forfeit-win';
-      } else if (result.result === '-') {
-        game.kind = 'forfeit-loss';
+      if (isForfeitWin) {
+        // white won, black forfeited
+        roundData.games.push({
+          black,
+          forfeit: 'black',
+          result: 'white',
+          white,
+        });
+      } else if (isForfeitLoss) {
+        // white lost, white forfeited
+        roundData.games.push({
+          black,
+          forfeit: 'white',
+          result: 'black',
+          white,
+        });
+      } else {
+        roundData.games.push({ black, result: gameResult, white });
       }
-
-      roundGames.push(game);
     }
   }
 
@@ -171,9 +194,9 @@ describe('dutch fixture: dutch_2025_C5', () => {
   const targetRound = 3;
   const excluded = preAssignedIds(tournament, targetRound);
   const players = toSwissPlayers(tournament).filter((p) => !excluded.has(p.id));
-  // games up to (not including) round 3 → first 2 rounds
-  const allGames = toSwissGames(tournament);
-  const gamesBefore = allGames.slice(0, targetRound - 1);
+  // rounds up to (not including) round 3 → first 2 rounds
+  const allRounds = toSwissRounds(tournament);
+  const roundsBefore = allRounds.slice(0, targetRound - 1);
 
   it('excludes pre-assigned players (P4 has Z-bye)', () => {
     expect(excluded.has('4')).toBe(true);
@@ -181,15 +204,15 @@ describe('dutch fixture: dutch_2025_C5', () => {
   });
 
   it('produces 2 pairings and 1 bye for round 3 (5 pairable players)', () => {
-    const result = pair(players, gamesBefore);
-    expect(result.pairings).toHaveLength(2);
+    const result = pair(players, roundsBefore);
+    expect(result.games).toHaveLength(2);
     expect(result.byes).toHaveLength(1);
   });
 
   it('produces the correct pairings for round 3 (FIDE Dutch C5): 1 vs 5, 3 vs 2, bye to 6', () => {
-    const result = pair(players, gamesBefore);
+    const result = pair(players, roundsBefore);
     const pairingSet = new Set(
-      result.pairings.map((p) => [p.white, p.black].toSorted().join('-')),
+      result.games.map((p) => [p.white, p.black].toSorted().join('-')),
     );
     expect(pairingSet).toContain('1-5');
     expect(pairingSet).toContain('2-3');
@@ -206,8 +229,8 @@ describe('dutch fixture: dutch_2025_C9', () => {
   const targetRound = 3;
   const excluded = preAssignedIds(tournament, targetRound);
   const players = toSwissPlayers(tournament).filter((p) => !excluded.has(p.id));
-  const allGames = toSwissGames(tournament);
-  const gamesBefore = allGames.slice(0, targetRound - 1);
+  const allRounds = toSwissRounds(tournament);
+  const roundsBefore = allRounds.slice(0, targetRound - 1);
 
   it('has no pre-assigned players for round 3', () => {
     expect(excluded.size).toBe(0);
@@ -215,15 +238,15 @@ describe('dutch fixture: dutch_2025_C9', () => {
   });
 
   it('produces 2 pairings and 1 bye for round 3 (5 pairable players)', () => {
-    const result = pair(players, gamesBefore);
-    expect(result.pairings).toHaveLength(2);
+    const result = pair(players, roundsBefore);
+    expect(result.games).toHaveLength(2);
     expect(result.byes).toHaveLength(1);
   });
 
   it('produces the correct pairings for round 3 (FIDE Dutch C9): 2 vs 1, 3 vs 5, bye to 4', () => {
-    const result = pair(players, gamesBefore);
+    const result = pair(players, roundsBefore);
     const pairingSet = new Set(
-      result.pairings.map((p) => [p.white, p.black].toSorted().join('-')),
+      result.games.map((p) => [p.white, p.black].toSorted().join('-')),
     );
     expect(pairingSet).toContain('1-2');
     expect(pairingSet).toContain('3-5');
@@ -240,22 +263,22 @@ describe('dutch fixture: issue_7', () => {
   const targetRound = 15;
   const excluded = preAssignedIds(tournament, targetRound);
   const players = toSwissPlayers(tournament).filter((p) => !excluded.has(p.id));
-  const allGames = toSwissGames(tournament);
-  const gamesBefore = allGames.slice(0, targetRound - 1);
+  const allRounds = toSwissRounds(tournament);
+  const roundsBefore = allRounds.slice(0, targetRound - 1);
 
   it('produces 30 pairings and no byes for round 15', () => {
-    const result = pair(players, gamesBefore);
-    expect(result.pairings).toHaveLength(30);
+    const result = pair(players, roundsBefore);
+    expect(result.games).toHaveLength(30);
     expect(result.byes).toHaveLength(0);
   });
 
   it('produces no rematches in round 15', () => {
-    const result = pair(players, gamesBefore);
+    const result = pair(players, roundsBefore);
     // Forfeit games are not considered prior opponents per FIDE/bbpPairings
-    const played = gamesBefore
-      .flat()
-      .filter((g) => g.kind !== 'forfeit-win' && g.kind !== 'forfeit-loss');
-    for (const pairing of result.pairings) {
+    const played = roundsBefore
+      .flatMap((r) => r.games)
+      .filter((g) => g.forfeit === undefined);
+    for (const pairing of result.games) {
       const alreadyFaced = played.some(
         (g) =>
           (g.white === pairing.white && g.black === pairing.black) ||
@@ -270,7 +293,7 @@ describe('dutch fixture: issue_7', () => {
 
   it('does not spin the bracket loop when unmatched players remain', () => {
     const events: TraceEvent[] = [];
-    pair(players, gamesBefore, { trace: (event) => events.push(event) });
+    pair(players, roundsBefore, { trace: (event) => events.push(event) });
 
     const bracketEnters = events.filter(
       (event) => event.type === 'dutch:bracket-enter',
@@ -280,7 +303,7 @@ describe('dutch fixture: issue_7', () => {
 
   it('finalizes each remainder pair individually with blossom re-runs', () => {
     const events: TraceEvent[] = [];
-    pair(players, gamesBefore, { trace: (event) => events.push(event) });
+    pair(players, roundsBefore, { trace: (event) => events.push(event) });
 
     const remainderFinalizations = events.filter(
       (event) =>
@@ -352,9 +375,9 @@ describe('dutch fixture: issue_7', () => {
       expected.map(([w, b]) => [w, b].toSorted().join('-')),
     );
 
-    const result = pair(players, gamesBefore);
+    const result = pair(players, roundsBefore);
     const actualSet = new Set(
-      result.pairings.map((p) => [p.white, p.black].toSorted().join('-')),
+      result.games.map((p) => [p.white, p.black].toSorted().join('-')),
     );
 
     expect(actualSet).toEqual(expectedSet);
@@ -371,39 +394,39 @@ describe('dutch fixture: issue_7', () => {
 // ---------------------------------------------------------------------------
 describe('dutch fixture: issue_15', () => {
   const tournament = loadFixture('issue_15');
-  const allGames = toSwissGames(tournament);
+  const allRounds = toSwissRounds(tournament);
 
   for (let round = 1; round <= 11; round++) {
     it(
       `pairs round ${round} without crashing (180 players)`,
       { timeout: 120_000 },
       () => {
-        // Games played before this round
-        const gamesBefore = allGames.slice(0, round - 1);
+        // Rounds played before this round
+        const roundsBefore = allRounds.slice(0, round - 1);
         const excluded = preAssignedIds(tournament, round);
         const players = toSwissPlayers(tournament).filter(
           (p) => !excluded.has(p.id),
         );
-        const result = pair(players, gamesBefore);
+        const result = pair(players, roundsBefore);
         // 180 players, even count → 90 pairings, 0 byes
-        expect(result.pairings).toHaveLength(90);
+        expect(result.games).toHaveLength(90);
         expect(result.byes).toHaveLength(0);
       },
     );
   }
 
   it('produces no rematches in round 11', { timeout: 120_000 }, () => {
-    const gamesBefore = allGames.slice(0, 10);
+    const roundsBefore = allRounds.slice(0, 10);
     const excluded = preAssignedIds(tournament, 11);
     const players = toSwissPlayers(tournament).filter(
       (p) => !excluded.has(p.id),
     );
-    const result = pair(players, gamesBefore);
+    const result = pair(players, roundsBefore);
     // Forfeit games are not considered prior opponents per FIDE/bbpPairings
-    const played = gamesBefore
-      .flat()
-      .filter((g) => g.kind !== 'forfeit-win' && g.kind !== 'forfeit-loss');
-    for (const pairing of result.pairings) {
+    const played = roundsBefore
+      .flatMap((r) => r.games)
+      .filter((g) => g.forfeit === undefined);
+    for (const pairing of result.games) {
       const alreadyFaced = played.some(
         (g) =>
           (g.white === pairing.white && g.black === pairing.black) ||

--- a/src/__tests__/dutch.spec.ts
+++ b/src/__tests__/dutch.spec.ts
@@ -2,25 +2,25 @@ import { describe, expect, it } from 'vitest';
 
 import { pair } from '../dutch.js';
 
-import type { Game, Player } from '../types.js';
+import type { CompletedRound, Player } from '../types.js';
 
 const FOUR_PLAYERS: Player[] = [
-  { id: 'A', rating: 2000 },
-  { id: 'B', rating: 1900 },
-  { id: 'C', rating: 1800 },
-  { id: 'D', rating: 1700 },
+  { id: 'A', points: 0, rank: 1, rating: 2000 },
+  { id: 'B', points: 0, rank: 2, rating: 1900 },
+  { id: 'C', points: 0, rank: 3, rating: 1800 },
+  { id: 'D', points: 0, rank: 4, rating: 1700 },
 ];
 
 describe('dutch', () => {
   describe('round 1', () => {
     it('pairs top half vs bottom half within score group', () => {
       const result = pair(FOUR_PLAYERS, []);
-      expect(result.pairings).toHaveLength(2);
+      expect(result.games).toHaveLength(2);
       expect(result.byes).toHaveLength(0);
       // Top half: A, B; Bottom half: C, D
       // Each pairing must cross the boundary
       const topHalf = new Set(['A', 'B']);
-      for (const pairing of result.pairings) {
+      for (const pairing of result.games) {
         expect(topHalf.has(pairing.white) !== topHalf.has(pairing.black)).toBe(
           true,
         );
@@ -36,12 +36,15 @@ describe('dutch', () => {
 
   describe('invariants', () => {
     it('never pairs the same two players twice', () => {
-      const round1Games: Game[] = [
-        { black: 'C', result: 1, white: 'A' },
-        { black: 'D', result: 1, white: 'B' },
-      ];
-      const result = pair(FOUR_PLAYERS, [round1Games]);
-      const pairs = result.pairings.map((p) =>
+      const round1: CompletedRound = {
+        byes: [],
+        games: [
+          { black: 'C', result: 'white', white: 'A' },
+          { black: 'D', result: 'white', white: 'B' },
+        ],
+      };
+      const result = pair(FOUR_PLAYERS, [round1]);
+      const pairs = result.games.map((p) =>
         [p.white, p.black].toSorted().join('-'),
       );
       expect(pairs).not.toContain('A-C');
@@ -50,7 +53,7 @@ describe('dutch', () => {
 
     it('produces a complete pairing (all players appear exactly once)', () => {
       const result = pair(FOUR_PLAYERS, []);
-      const allIds = result.pairings.flatMap((p) => [p.white, p.black]);
+      const allIds = result.games.flatMap((p) => [p.white, p.black]);
       expect(new Set(allIds).size).toBe(4);
       expect(allIds).toHaveLength(4);
     });

--- a/src/__tests__/lim.spec.ts
+++ b/src/__tests__/lim.spec.ts
@@ -2,15 +2,15 @@ import { describe, expect, it } from 'vitest';
 
 import { pair } from '../lim.js';
 
-import type { Game, Player } from '../types.js';
+import type { CompletedRound, Player } from '../types.js';
 
 const SIX_PLAYERS: Player[] = [
-  { id: 'A', rating: 2000 },
-  { id: 'B', rating: 1900 },
-  { id: 'C', rating: 1800 },
-  { id: 'D', rating: 1700 },
-  { id: 'E', rating: 1600 },
-  { id: 'F', rating: 1500 },
+  { id: 'A', points: 0, rank: 1, rating: 2000 },
+  { id: 'B', points: 0, rank: 2, rating: 1900 },
+  { id: 'C', points: 0, rank: 3, rating: 1800 },
+  { id: 'D', points: 0, rank: 4, rating: 1700 },
+  { id: 'E', points: 0, rank: 5, rating: 1600 },
+  { id: 'F', points: 0, rank: 6, rating: 1500 },
 ];
 
 const FOUR_PLAYERS: Player[] = SIX_PLAYERS.slice(0, 4);
@@ -25,9 +25,9 @@ describe('lim', () => {
   describe('round 1 — top half vs bottom half', () => {
     it('pairs 4 players: 1v3, 2v4', () => {
       const result = pair(FOUR_PLAYERS, []);
-      expect(result.pairings).toHaveLength(2);
+      expect(result.games).toHaveLength(2);
       expect(result.byes).toHaveLength(0);
-      const ids = result.pairings.map((p) =>
+      const ids = result.games.map((p) =>
         [p.white, p.black].toSorted().join('-'),
       );
       expect(ids).toContain('A-C');
@@ -36,9 +36,9 @@ describe('lim', () => {
 
     it('pairs 6 players: 1v4, 2v5, 3v6', () => {
       const result = pair(SIX_PLAYERS, []);
-      expect(result.pairings).toHaveLength(3);
+      expect(result.games).toHaveLength(3);
       expect(result.byes).toHaveLength(0);
-      const ids = result.pairings.map((p) =>
+      const ids = result.games.map((p) =>
         [p.white, p.black].toSorted().join('-'),
       );
       expect(ids).toContain('A-D');
@@ -52,16 +52,17 @@ describe('lim', () => {
       const result = pair(FOUR_PLAYERS.slice(0, 3), []);
       expect(result.byes).toHaveLength(1);
       expect(result.byes[0]?.player).toBe('C');
-      expect(result.pairings).toHaveLength(1);
+      expect(result.games).toHaveLength(1);
     });
 
     it('does not give a bye to a player who already had one', () => {
       const threePlayers = FOUR_PLAYERS.slice(0, 3);
-      const round1Games: Game[] = [
-        { black: 'C', result: 1, white: 'C' },
-        { black: 'B', result: 1, white: 'A' },
-      ];
-      const result = pair(threePlayers, [round1Games]);
+      // C got a bye in round 1
+      const round1: CompletedRound = {
+        byes: [{ kind: 'pairing', player: 'C' }],
+        games: [{ black: 'B', result: 'white', white: 'A' }],
+      };
+      const result = pair(threePlayers, [round1]);
       expect(result.byes[0]?.player).not.toBe('C');
     });
   });
@@ -69,15 +70,16 @@ describe('lim', () => {
   describe('exchange rules — rematches avoided', () => {
     it('exchanges to avoid rematch in scoregroup', () => {
       // A beat C in round 1; so A cannot face C again.
-      // Default pairing in scoregroup {1pt}: A vs C — must exchange to A vs D or B vs C.
-      const round1Games: Game[] = [
-        { black: 'C', result: 1, white: 'A' },
-        { black: 'D', result: 0, white: 'B' },
-      ];
+      const round1: CompletedRound = {
+        byes: [],
+        games: [
+          { black: 'C', result: 'white', white: 'A' },
+          { black: 'D', result: 'black', white: 'B' },
+        ],
+      };
       // After round 1: A=1, B=0, C=0, D=1
-      // scoregroup 1: A and D; scoregroup 0: B and C
-      const result = pair(FOUR_PLAYERS, [round1Games]);
-      const pairs = result.pairings.map((p) =>
+      const result = pair(FOUR_PLAYERS, [round1]);
+      const pairs = result.games.map((p) =>
         [p.white, p.black].toSorted().join('-'),
       );
       // A vs D is valid (didn't play); B vs C is valid (didn't play)
@@ -86,25 +88,22 @@ describe('lim', () => {
     });
 
     it('forces an exchange when top pairing is a rematch', () => {
-      // All 4 players have 1 point but A already played C (the proposed pair 1v3)
-      // (Making everyone have the same score so they're all in one group)
-      const round1Games: Game[] = [
-        { black: 'C', result: 0.5, white: 'A' },
-        { black: 'B', result: 0.5, white: 'D' },
-      ];
-      // All at 0.5 pts — one scoregroup
-      // Proposed: A vs C (rematch!) and D vs B (rematch!)
-      // Must exchange: try A vs B and C vs D (or A vs D and B vs C)
-      const result = pair(FOUR_PLAYERS, [round1Games]);
-      const pairs = result.pairings.map((p) =>
+      // All 4 players have 0.5 but A already played C (the proposed pair 1v3)
+      const round1: CompletedRound = {
+        byes: [],
+        games: [
+          { black: 'C', result: 'draw', white: 'A' },
+          { black: 'B', result: 'draw', white: 'D' },
+        ],
+      };
+      const result = pair(FOUR_PLAYERS, [round1]);
+      const pairs = result.games.map((p) =>
         [p.white, p.black].toSorted().join('-'),
       );
       // No rematches
+      const playedPairs = ['A-C', 'B-D'];
       for (const pairKey of pairs) {
-        const wasPlayed = round1Games.some(
-          (g) => [g.white, g.black].toSorted().join('-') === pairKey,
-        );
-        expect(wasPlayed).toBe(false);
+        expect(playedPairs).not.toContain(pairKey);
       }
     });
   });
@@ -113,7 +112,7 @@ describe('lim', () => {
     it('every player is paired or has a bye in round 1 (4 players)', () => {
       const result = pair(FOUR_PLAYERS, []);
       const allIds = new Set<string>();
-      for (const p of result.pairings) {
+      for (const p of result.games) {
         allIds.add(p.white);
         allIds.add(p.black);
       }
@@ -128,7 +127,7 @@ describe('lim', () => {
     it('every player is paired or has a bye in round 1 (6 players)', () => {
       const result = pair(SIX_PLAYERS, []);
       const allIds = new Set<string>();
-      for (const p of result.pairings) {
+      for (const p of result.games) {
         allIds.add(p.white);
         allIds.add(p.black);
       }
@@ -144,14 +143,16 @@ describe('lim', () => {
   describe('color allocation — alternation', () => {
     it('gives White to player who played Black in the previous round', () => {
       // Round 1: A(w) vs B(b) → draw; C(w) vs D(b) → draw
-      // All at 0.5 pts; B and D played black, A and C played white
-      const round1Games: Game[] = [
-        { black: 'B', result: 0.5, white: 'A' },
-        { black: 'D', result: 0.5, white: 'C' },
-      ];
+      const round1: CompletedRound = {
+        byes: [],
+        games: [
+          { black: 'B', result: 'draw', white: 'A' },
+          { black: 'D', result: 'draw', white: 'C' },
+        ],
+      };
       // All at 0.5 pts — one scoregroup; B played black → should get white in round 2
-      const result = pair(FOUR_PLAYERS, [round1Games]);
-      const bPairing = result.pairings.find(
+      const result = pair(FOUR_PLAYERS, [round1]);
+      const bPairing = result.games.find(
         (p) => p.white === 'B' || p.black === 'B',
       );
       expect(bPairing).toBeDefined();
@@ -163,17 +164,22 @@ describe('lim', () => {
       // Round 1: A(w) vs B(b) → A wins; C(w) vs D(b) → D wins
       // Round 2: A(w) vs D(b) → A wins; B(w) vs C(b) → B wins
       // A: white, white → must get black in round 3
-      // Scores: A=2, B=1, C=0, D=0
-      const round1Games: Game[] = [
-        { black: 'B', result: 1, white: 'A' },
-        { black: 'D', result: 0, white: 'C' },
-      ];
-      const round2Games: Game[] = [
-        { black: 'D', result: 1, white: 'A' },
-        { black: 'C', result: 1, white: 'B' },
-      ];
-      const result = pair(FOUR_PLAYERS, [round1Games, round2Games]);
-      const aPairing = result.pairings.find(
+      const round1: CompletedRound = {
+        byes: [],
+        games: [
+          { black: 'B', result: 'white', white: 'A' },
+          { black: 'D', result: 'black', white: 'C' },
+        ],
+      };
+      const round2: CompletedRound = {
+        byes: [],
+        games: [
+          { black: 'D', result: 'white', white: 'A' },
+          { black: 'C', result: 'white', white: 'B' },
+        ],
+      };
+      const result = pair(FOUR_PLAYERS, [round1, round2]);
+      const aPairing = result.games.find(
         (p) => p.white === 'A' || p.black === 'A',
       );
       expect(aPairing).toBeDefined();
@@ -186,16 +192,22 @@ describe('lim', () => {
       // Round 1: A(w) vs B(b) → A wins; C(w) vs D(b) → D wins
       // Round 2: A(w) vs D(b) → A wins; B(w) vs C(b) → B wins
       // A played white in rounds 1 and 2; in round 3, A must play black
-      const round1Games: Game[] = [
-        { black: 'B', result: 1, white: 'A' },
-        { black: 'D', result: 0, white: 'C' },
-      ];
-      const round2Games: Game[] = [
-        { black: 'D', result: 1, white: 'A' },
-        { black: 'C', result: 1, white: 'B' },
-      ];
-      const result = pair(FOUR_PLAYERS, [round1Games, round2Games]);
-      const aPairing = result.pairings.find(
+      const round1: CompletedRound = {
+        byes: [],
+        games: [
+          { black: 'B', result: 'white', white: 'A' },
+          { black: 'D', result: 'black', white: 'C' },
+        ],
+      };
+      const round2: CompletedRound = {
+        byes: [],
+        games: [
+          { black: 'D', result: 'white', white: 'A' },
+          { black: 'C', result: 'white', white: 'B' },
+        ],
+      };
+      const result = pair(FOUR_PLAYERS, [round1, round2]);
+      const aPairing = result.games.find(
         (p) => p.white === 'A' || p.black === 'A',
       );
       expect(aPairing).toBeDefined();
@@ -206,18 +218,19 @@ describe('lim', () => {
   describe('no rematches invariant', () => {
     it('never pairs the same two players twice across 2 rounds', () => {
       const round1Result = pair(FOUR_PLAYERS, []);
-      const round1Games: Game[] = round1Result.pairings.map((p) => ({
-        black: p.black,
-        result: 1 as const,
-        white: p.white,
-      }));
-      const round2Result = pair(FOUR_PLAYERS, [round1Games]);
+      const round1: CompletedRound = {
+        byes: round1Result.byes,
+        games: round1Result.games.map((p) => ({
+          black: p.black,
+          result: 'white' as const,
+          white: p.white,
+        })),
+      };
+      const round2Result = pair(FOUR_PLAYERS, [round1]);
       const round1Pairs = new Set(
-        round1Result.pairings.map((p) =>
-          [p.white, p.black].toSorted().join('-'),
-        ),
+        round1Result.games.map((p) => [p.white, p.black].toSorted().join('-')),
       );
-      for (const p of round2Result.pairings) {
+      for (const p of round2Result.games) {
         const key = [p.white, p.black].toSorted().join('-');
         expect(round1Pairs.has(key)).toBe(false);
       }
@@ -227,16 +240,18 @@ describe('lim', () => {
   describe('bi-directional scoregroup order', () => {
     it('processes highest and lowest scoregroups before median', () => {
       // After round 1: A=1, B=0.5, C=0.5, D=0, E=0.5, F=0.5
-      // median = 0.5; order: 1 → 0 → 0.5
-      const round1Games: Game[] = [
-        { black: 'D', result: 1, white: 'A' },
-        { black: 'E', result: 0.5, white: 'B' },
-        { black: 'F', result: 0.5, white: 'C' },
-      ];
+      const round1: CompletedRound = {
+        byes: [],
+        games: [
+          { black: 'D', result: 'white', white: 'A' },
+          { black: 'E', result: 'draw', white: 'B' },
+          { black: 'F', result: 'draw', white: 'C' },
+        ],
+      };
       // This test just verifies the function runs without error and returns valid pairings
-      const result = pair(SIX_PLAYERS, [round1Games]);
+      const result = pair(SIX_PLAYERS, [round1]);
       const allIds = new Set<string>();
-      for (const p of result.pairings) {
+      for (const p of result.games) {
         allIds.add(p.white);
         allIds.add(p.black);
       }
@@ -251,15 +266,15 @@ describe('lim', () => {
 
   describe('multi-round simulation', () => {
     it('pairs 6 players through 3 rounds with no rematches', () => {
-      let games: Game[][] = [];
+      let rounds: CompletedRound[] = [];
       const allPairings: [string, string][] = [];
 
       for (let round = 1; round <= 3; round++) {
-        const result = pair(SIX_PLAYERS, games);
-        expect(result.pairings.length + result.byes.length).toBeGreaterThan(0);
+        const result = pair(SIX_PLAYERS, rounds);
+        expect(result.games.length + result.byes.length).toBeGreaterThan(0);
 
         // Check no rematches
-        for (const p of result.pairings) {
+        for (const p of result.games) {
           const key = [p.white, p.black].toSorted().join('-') as string;
           const alreadyPlayed = allPairings.some(
             ([a, b]) => [a, b].toSorted().join('-') === key,
@@ -270,7 +285,7 @@ describe('lim', () => {
 
         // All players appear exactly once
         const roundIds = new Set<string>();
-        for (const p of result.pairings) {
+        for (const p of result.games) {
           expect(roundIds.has(p.white)).toBe(false);
           expect(roundIds.has(p.black)).toBe(false);
           roundIds.add(p.white);
@@ -283,31 +298,29 @@ describe('lim', () => {
         expect(roundIds.size).toBe(SIX_PLAYERS.length);
 
         // Simulate results: white always wins
-        const roundGames: Game[] = [
-          ...result.pairings.map((p) => ({
-            black: p.black,
-            result: 1 as const,
-            white: p.white,
-          })),
-          ...result.byes.map((b) => ({
-            black: b.player,
-            result: 1 as const,
-            white: b.player,
-          })),
-        ];
-        games = [...games, roundGames];
+        const roundCompleted: CompletedRound = {
+          byes: result.byes,
+          games: [
+            ...result.games.map((p) => ({
+              black: p.black,
+              result: 'white' as const,
+              white: p.white,
+            })),
+          ],
+        };
+        rounds = [...rounds, roundCompleted];
       }
     });
 
     it('pairs 4 players through 3 rounds with no rematches', () => {
-      let games: Game[][] = [];
+      let rounds: CompletedRound[] = [];
 
       for (let round = 1; round <= 3; round++) {
-        const result = pair(FOUR_PLAYERS, games);
+        const result = pair(FOUR_PLAYERS, rounds);
 
         // All players appear exactly once
         const roundIds = new Set<string>();
-        for (const p of result.pairings) {
+        for (const p of result.games) {
           expect(roundIds.has(p.white)).toBe(false);
           expect(roundIds.has(p.black)).toBe(false);
           roundIds.add(p.white);
@@ -320,19 +333,15 @@ describe('lim', () => {
         expect(roundIds.size).toBe(FOUR_PLAYERS.length);
 
         // Simulate results: draw
-        const roundGames: Game[] = [
-          ...result.pairings.map((p) => ({
+        const roundCompleted: CompletedRound = {
+          byes: result.byes,
+          games: result.games.map((p) => ({
             black: p.black,
-            result: 0.5 as const,
+            result: 'draw' as const,
             white: p.white,
           })),
-          ...result.byes.map((b) => ({
-            black: b.player,
-            result: 1 as const,
-            white: b.player,
-          })),
-        ];
-        games = [...games, roundGames];
+        };
+        rounds = [...rounds, roundCompleted];
       }
     });
   });

--- a/src/__tests__/swiss-team-utilities.spec.ts
+++ b/src/__tests__/swiss-team-utilities.spec.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import { typeAColorPreference } from '../utilities.js';
 
-import type { Game } from '../types.js';
+import type { CompletedRound } from '../types.js';
 
 describe('typeAColorPreference', () => {
   it('returns undefined when no games played', () => {
@@ -11,79 +11,79 @@ describe('typeAColorPreference', () => {
 
   it("returns 'white' when CD < -1 (0 whites, 3 blacks → CD = -3)", () => {
     // 3 black games → whites=0, blacks=3, CD = 0-3 = -3
-    const games: Game[][] = [
-      [{ black: 'A', result: 0, white: 'B' }],
-      [{ black: 'A', result: 1, white: 'B' }],
-      [{ black: 'A', result: 0.5, white: 'B' }],
+    const rounds: CompletedRound[] = [
+      { byes: [], games: [{ black: 'A', result: 'black', white: 'B' }] },
+      { byes: [], games: [{ black: 'A', result: 'white', white: 'B' }] },
+      { byes: [], games: [{ black: 'A', result: 'draw', white: 'B' }] },
     ];
-    expect(typeAColorPreference('A', games)).toBe('white');
+    expect(typeAColorPreference('A', rounds)).toBe('white');
   });
 
   it("returns 'white' when CD is 0 and last two matches were black", () => {
     // History: white, black, black, white, black, black → whites=3, blacks=3, CD=0, last two=black,black
-    const games: Game[][] = [
-      [{ black: 'B', result: 1, white: 'A' }],
-      [{ black: 'A', result: 0, white: 'B' }],
-      [{ black: 'A', result: 0, white: 'B' }],
-      [{ black: 'B', result: 1, white: 'A' }],
-      [{ black: 'A', result: 0, white: 'B' }],
-      [{ black: 'A', result: 0, white: 'B' }],
+    const rounds: CompletedRound[] = [
+      { byes: [], games: [{ black: 'B', result: 'white', white: 'A' }] },
+      { byes: [], games: [{ black: 'A', result: 'black', white: 'B' }] },
+      { byes: [], games: [{ black: 'A', result: 'black', white: 'B' }] },
+      { byes: [], games: [{ black: 'B', result: 'white', white: 'A' }] },
+      { byes: [], games: [{ black: 'A', result: 'black', white: 'B' }] },
+      { byes: [], games: [{ black: 'A', result: 'black', white: 'B' }] },
     ];
-    expect(typeAColorPreference('A', games)).toBe('white');
+    expect(typeAColorPreference('A', rounds)).toBe('white');
   });
 
   it("returns 'white' when CD is -1 and last two matches were black", () => {
     // whites=1, blacks=2, CD=-1, last two=black,black
-    const games: Game[][] = [
-      [{ black: 'B', result: 1, white: 'A' }],
-      [{ black: 'A', result: 0, white: 'B' }],
-      [{ black: 'A', result: 0, white: 'B' }],
+    const rounds: CompletedRound[] = [
+      { byes: [], games: [{ black: 'B', result: 'white', white: 'A' }] },
+      { byes: [], games: [{ black: 'A', result: 'black', white: 'B' }] },
+      { byes: [], games: [{ black: 'A', result: 'black', white: 'B' }] },
     ];
-    expect(typeAColorPreference('A', games)).toBe('white');
+    expect(typeAColorPreference('A', rounds)).toBe('white');
   });
 
   it("returns 'black' when CD > +1 (3 whites, 0 blacks → CD = +3)", () => {
     // 3 white games → whites=3, blacks=0, CD = 3-0 = 3
-    const games: Game[][] = [
-      [{ black: 'B', result: 1, white: 'A' }],
-      [{ black: 'B', result: 0, white: 'A' }],
-      [{ black: 'B', result: 0.5, white: 'A' }],
+    const rounds: CompletedRound[] = [
+      { byes: [], games: [{ black: 'B', result: 'white', white: 'A' }] },
+      { byes: [], games: [{ black: 'B', result: 'black', white: 'A' }] },
+      { byes: [], games: [{ black: 'B', result: 'draw', white: 'A' }] },
     ];
-    expect(typeAColorPreference('A', games)).toBe('black');
+    expect(typeAColorPreference('A', rounds)).toBe('black');
   });
 
   it("returns 'black' when CD is 0 and last two matches were white", () => {
     // whites=3, blacks=3, last two=white,white
-    const games: Game[][] = [
-      [{ black: 'A', result: 0, white: 'B' }],
-      [{ black: 'B', result: 1, white: 'A' }],
-      [{ black: 'B', result: 1, white: 'A' }],
-      [{ black: 'A', result: 0, white: 'B' }],
-      [{ black: 'B', result: 1, white: 'A' }],
-      [{ black: 'B', result: 1, white: 'A' }],
+    const rounds: CompletedRound[] = [
+      { byes: [], games: [{ black: 'A', result: 'black', white: 'B' }] },
+      { byes: [], games: [{ black: 'B', result: 'white', white: 'A' }] },
+      { byes: [], games: [{ black: 'B', result: 'white', white: 'A' }] },
+      { byes: [], games: [{ black: 'A', result: 'black', white: 'B' }] },
+      { byes: [], games: [{ black: 'B', result: 'white', white: 'A' }] },
+      { byes: [], games: [{ black: 'B', result: 'white', white: 'A' }] },
     ];
-    expect(typeAColorPreference('A', games)).toBe('black');
+    expect(typeAColorPreference('A', rounds)).toBe('black');
   });
 
   it("returns 'black' when CD is +1 and last two matches were white", () => {
     // whites=2, blacks=1, CD=1, last two=white,white
-    const games: Game[][] = [
-      [{ black: 'A', result: 0, white: 'B' }],
-      [{ black: 'B', result: 1, white: 'A' }],
-      [{ black: 'B', result: 1, white: 'A' }],
+    const rounds: CompletedRound[] = [
+      { byes: [], games: [{ black: 'A', result: 'black', white: 'B' }] },
+      { byes: [], games: [{ black: 'B', result: 'white', white: 'A' }] },
+      { byes: [], games: [{ black: 'B', result: 'white', white: 'A' }] },
     ];
-    expect(typeAColorPreference('A', games)).toBe('black');
+    expect(typeAColorPreference('A', rounds)).toBe('black');
   });
 
   it('returns undefined when CD is 0 and last two differ', () => {
     // whites=2, blacks=2, CD=0, last two=[white,black]
-    const games: Game[][] = [
-      [{ black: 'B', result: 1, white: 'A' }],
-      [{ black: 'A', result: 0, white: 'B' }],
-      [{ black: 'B', result: 1, white: 'A' }],
-      [{ black: 'A', result: 0, white: 'B' }],
+    const rounds: CompletedRound[] = [
+      { byes: [], games: [{ black: 'B', result: 'white', white: 'A' }] },
+      { byes: [], games: [{ black: 'A', result: 'black', white: 'B' }] },
+      { byes: [], games: [{ black: 'B', result: 'white', white: 'A' }] },
+      { byes: [], games: [{ black: 'A', result: 'black', white: 'B' }] },
     ];
     // history: white, black, white, black → CD=0, last two=[white,black]
-    expect(typeAColorPreference('A', games)).toBeUndefined();
+    expect(typeAColorPreference('A', rounds)).toBeUndefined();
   });
 });

--- a/src/__tests__/swiss-team.spec.ts
+++ b/src/__tests__/swiss-team.spec.ts
@@ -2,30 +2,30 @@ import { describe, expect, it } from 'vitest';
 
 import { pair } from '../swiss-team.js';
 
-import type { Game, Player } from '../types.js';
+import type { CompletedRound, Player } from '../types.js';
 
-/** Returns true if the given pairings contain a specific pair (order-insensitive). */
+/** Returns true if the given games contain a specific pair (order-insensitive). */
 function hasPair(
-  pairings: ReturnType<typeof pair>['pairings'],
+  games: ReturnType<typeof pair>['games'],
   a: string,
   b: string,
 ): boolean {
-  return pairings.some(
+  return games.some(
     (p) => (p.white === a && p.black === b) || (p.white === b && p.black === a),
   );
 }
 
 const FOUR_TEAMS: Player[] = [
-  { id: 'A', rating: 2000 },
-  { id: 'B', rating: 1900 },
-  { id: 'C', rating: 1800 },
-  { id: 'D', rating: 1700 },
+  { id: 'A', points: 0, rank: 1, rating: 2000 },
+  { id: 'B', points: 0, rank: 2, rating: 1900 },
+  { id: 'C', points: 0, rank: 3, rating: 1800 },
+  { id: 'D', points: 0, rank: 4, rating: 1700 },
 ];
 
 const THREE_TEAMS: Player[] = [
-  { id: 'A', rating: 2000 },
-  { id: 'B', rating: 1900 },
-  { id: 'C', rating: 1800 },
+  { id: 'A', points: 0, rank: 1, rating: 2000 },
+  { id: 'B', points: 0, rank: 2, rating: 1900 },
+  { id: 'C', points: 0, rank: 3, rating: 1800 },
 ];
 
 describe('swissTeam', () => {
@@ -43,12 +43,12 @@ describe('swissTeam', () => {
 
     it('produces correct number of pairings for 4 teams', () => {
       const result = pair(FOUR_TEAMS, []);
-      expect(result.pairings).toHaveLength(2);
+      expect(result.games).toHaveLength(2);
     });
 
     it('each team appears exactly once across all pairings', () => {
       const result = pair(FOUR_TEAMS, []);
-      const allIds = result.pairings.flatMap((p) => [p.white, p.black]);
+      const allIds = result.games.flatMap((p) => [p.white, p.black]);
       expect(new Set(allIds).size).toBe(4);
       expect(allIds).toHaveLength(4);
     });
@@ -69,35 +69,41 @@ describe('swissTeam', () => {
   describe('PAB (bye) assignment', () => {
     it('prefers lowest-score team for bye', () => {
       const fiveTeams: Player[] = [
-        { id: 'A', rating: 2000 },
-        { id: 'B', rating: 1900 },
-        { id: 'C', rating: 1800 },
-        { id: 'D', rating: 1700 },
-        { id: 'E', rating: 1600 },
+        { id: 'A', points: 0, rank: 1, rating: 2000 },
+        { id: 'B', points: 0, rank: 2, rating: 1900 },
+        { id: 'C', points: 0, rank: 3, rating: 1800 },
+        { id: 'D', points: 0, rank: 4, rating: 1700 },
+        { id: 'E', points: 0, rank: 5, rating: 1600 },
       ];
       // A, B, C, D all scored 1 from draws; E has score 0
-      const round1Games: Game[] = [
-        { black: 'B', result: 0.5, white: 'A' },
-        { black: 'D', result: 0.5, white: 'C' },
-      ];
-      const result = pair(fiveTeams, [round1Games]);
+      const round1: CompletedRound = {
+        byes: [],
+        games: [
+          { black: 'B', result: 'draw', white: 'A' },
+          { black: 'D', result: 'draw', white: 'C' },
+        ],
+      };
+      const result = pair(fiveTeams, [round1]);
       expect(result.byes[0]?.player).toBe('E');
     });
 
     it('prefers team with most matches played when scores tie (lowest score)', () => {
       // B=0 (1 match), E=0 (0 matches) → B gets bye
       const fiveTeams: Player[] = [
-        { id: 'A', rating: 2000 },
-        { id: 'B', rating: 1900 },
-        { id: 'C', rating: 1800 },
-        { id: 'D', rating: 1700 },
-        { id: 'E', rating: 1600 },
+        { id: 'A', points: 0, rank: 1, rating: 2000 },
+        { id: 'B', points: 0, rank: 2, rating: 1900 },
+        { id: 'C', points: 0, rank: 3, rating: 1800 },
+        { id: 'D', points: 0, rank: 4, rating: 1700 },
+        { id: 'E', points: 0, rank: 5, rating: 1600 },
       ];
-      const round1Games: Game[] = [
-        { black: 'B', result: 1, white: 'A' },
-        { black: 'D', result: 0.5, white: 'C' },
-      ];
-      const result = pair(fiveTeams, [round1Games]);
+      const round1: CompletedRound = {
+        byes: [],
+        games: [
+          { black: 'B', result: 'white', white: 'A' },
+          { black: 'D', result: 'draw', white: 'C' },
+        ],
+      };
+      const result = pair(fiveTeams, [round1]);
       expect(result.byes[0]?.player).toBe('B');
     });
 
@@ -108,8 +114,11 @@ describe('swissTeam', () => {
     });
 
     it('does not assign bye to team that already received one (C2 rule)', () => {
-      const round1Games: Game[] = [{ black: 'C', result: 1, white: 'C' }];
-      const result = pair(THREE_TEAMS, [round1Games]);
+      const round1: CompletedRound = {
+        byes: [{ kind: 'pairing', player: 'C' }],
+        games: [],
+      };
+      const result = pair(THREE_TEAMS, [round1]);
       expect(result.byes[0]?.player).not.toBe('C');
     });
   });
@@ -117,11 +126,11 @@ describe('swissTeam', () => {
   describe('color allocation — 4.3.1 (no history, TPN-based)', () => {
     it('round 1: first-team with odd 1-based TPN gets White', () => {
       const players: Player[] = [
-        { id: 'A', rating: 2000 },
-        { id: 'B', rating: 1900 },
+        { id: 'A', points: 0, rank: 1, rating: 2000 },
+        { id: 'B', points: 0, rank: 2, rating: 1900 },
       ];
       const result = pair(players, []);
-      const pairing = result.pairings[0];
+      const pairing = result.games[0];
       expect(pairing).toBeDefined();
       expect(pairing!.white).toBe('A');
       expect(pairing!.black).toBe('B');
@@ -129,15 +138,16 @@ describe('swissTeam', () => {
 
     it('round 1: first-team with even 1-based TPN gets Black', () => {
       const players: Player[] = [
-        { id: 'A', rating: 2000 },
-        { id: 'B', rating: 1900 },
+        { id: 'A', points: 0, rank: 1, rating: 2000 },
+        { id: 'B', points: 0, rank: 2, rating: 1900 },
       ];
-      const round1Games: Game[] = [
-        // B received a bye in round 1 — gives score but no match color history
-        { black: 'B', result: 1, white: 'B' },
-      ];
-      const result = pair(players, [round1Games]);
-      const pairing = result.pairings[0];
+      // B received a bye in round 1 — gives score but no match color history
+      const round1: CompletedRound = {
+        byes: [{ kind: 'pairing', player: 'B' }],
+        games: [],
+      };
+      const result = pair(players, [round1]);
+      const pairing = result.games[0];
       expect(pairing).toBeDefined();
       // B is first-team with even 1-based TPN (2) → B gets Black → A gets White
       expect(pairing!.white).toBe('A');
@@ -149,16 +159,16 @@ describe('swissTeam', () => {
     it('grants preference when only one team has Type A preference', () => {
       // A had 3 blacks (CD = -3) → Type A preference for White; B has no games
       const players: Player[] = [
-        { id: 'A', rating: 2000 },
-        { id: 'B', rating: 1900 },
+        { id: 'A', points: 0, rank: 1, rating: 2000 },
+        { id: 'B', points: 0, rank: 2, rating: 1900 },
       ];
-      const games: Game[][] = [
-        [{ black: 'A', result: 0.5, white: 'X' }],
-        [{ black: 'A', result: 0.5, white: 'X' }],
-        [{ black: 'A', result: 0.5, white: 'X' }],
+      const rounds: CompletedRound[] = [
+        { byes: [], games: [{ black: 'A', result: 'draw', white: 'X' }] },
+        { byes: [], games: [{ black: 'A', result: 'draw', white: 'X' }] },
+        { byes: [], games: [{ black: 'A', result: 'draw', white: 'X' }] },
       ];
-      const result = pair(players, games);
-      const pairing = result.pairings[0];
+      const result = pair(players, rounds);
+      const pairing = result.games[0];
       expect(pairing).toBeDefined();
       expect(pairing!.white).toBe('A');
     });
@@ -166,25 +176,34 @@ describe('swissTeam', () => {
     it('grants opposing preference when both have Type A preference for opposite colors', () => {
       // A had 3 blacks → wants White; B had 3 whites → wants Black
       const players: Player[] = [
-        { id: 'A', rating: 2000 },
-        { id: 'B', rating: 1900 },
+        { id: 'A', points: 0, rank: 1, rating: 2000 },
+        { id: 'B', points: 0, rank: 2, rating: 1900 },
       ];
-      const games: Game[][] = [
-        [
-          { black: 'A', result: 0.5, white: 'X' },
-          { black: 'X', result: 0.5, white: 'B' },
-        ],
-        [
-          { black: 'A', result: 0.5, white: 'X' },
-          { black: 'X', result: 0.5, white: 'B' },
-        ],
-        [
-          { black: 'A', result: 0.5, white: 'X' },
-          { black: 'X', result: 0.5, white: 'B' },
-        ],
+      const rounds: CompletedRound[] = [
+        {
+          byes: [],
+          games: [
+            { black: 'A', result: 'draw', white: 'X' },
+            { black: 'X', result: 'draw', white: 'B' },
+          ],
+        },
+        {
+          byes: [],
+          games: [
+            { black: 'A', result: 'draw', white: 'X' },
+            { black: 'X', result: 'draw', white: 'B' },
+          ],
+        },
+        {
+          byes: [],
+          games: [
+            { black: 'A', result: 'draw', white: 'X' },
+            { black: 'X', result: 'draw', white: 'B' },
+          ],
+        },
       ];
-      const result = pair(players, games);
-      const pairing = result.pairings[0];
+      const result = pair(players, rounds);
+      const pairing = result.games[0];
       expect(pairing).toBeDefined();
       expect(pairing!.white).toBe('A');
       expect(pairing!.black).toBe('B');
@@ -195,24 +214,30 @@ describe('swissTeam', () => {
     it('team with lower color difference gets White', () => {
       // A: CD=0, B: CD=+1 → A has lower CD → A gets White
       const players: Player[] = [
-        { id: 'A', rating: 2000 },
-        { id: 'B', rating: 1900 },
+        { id: 'A', points: 0, rank: 1, rating: 2000 },
+        { id: 'B', points: 0, rank: 2, rating: 1900 },
       ];
       // A: white r1, black r2 → CD=0, last two=[white,black]
       // B: white r1, white r2, black r3 → CD=1, last two=[white,black]
-      const games: Game[][] = [
-        [
-          { black: 'X', result: 0.5, white: 'A' },
-          { black: 'X', result: 0.5, white: 'B' },
-        ],
-        [
-          { black: 'A', result: 0.5, white: 'X' },
-          { black: 'X', result: 0.5, white: 'B' },
-        ],
-        [{ black: 'B', result: 0.5, white: 'X' }],
+      const rounds: CompletedRound[] = [
+        {
+          byes: [],
+          games: [
+            { black: 'X', result: 'draw', white: 'A' },
+            { black: 'X', result: 'draw', white: 'B' },
+          ],
+        },
+        {
+          byes: [],
+          games: [
+            { black: 'A', result: 'draw', white: 'X' },
+            { black: 'X', result: 'draw', white: 'B' },
+          ],
+        },
+        { byes: [], games: [{ black: 'B', result: 'draw', white: 'X' }] },
       ];
-      const result = pair(players, games);
-      const pairing = result.pairings[0];
+      const result = pair(players, rounds);
+      const pairing = result.games[0];
       expect(pairing).toBeDefined();
       expect(pairing!.white).toBe('A');
     });
@@ -223,25 +248,31 @@ describe('swissTeam', () => {
       // A matchColorHistory: [white, black] → CD=0, last two=[white,black] → no pref
       // B matchColorHistory: [white, black] → same; no divergence; A last=black → A gets White
       const players: Player[] = [
-        { id: 'A', rating: 2000 },
-        { id: 'B', rating: 1900 },
-        { id: 'C', rating: 1800 },
-        { id: 'D', rating: 1700 },
+        { id: 'A', points: 0, rank: 1, rating: 2000 },
+        { id: 'B', points: 0, rank: 2, rating: 1900 },
+        { id: 'C', points: 0, rank: 3, rating: 1800 },
+        { id: 'D', points: 0, rank: 4, rating: 1700 },
       ];
-      const round1Games: Game[] = [
-        // Round 1: A(white) vs C, B(white) vs D
-        { black: 'C', result: 0.5, white: 'A' },
-        { black: 'D', result: 0.5, white: 'B' },
-      ];
-      const round2Games: Game[] = [
-        // Round 2: A(black) vs D, B(black) vs C
-        { black: 'A', result: 0.5, white: 'D' },
-        { black: 'B', result: 0.5, white: 'C' },
-      ];
+      const round1: CompletedRound = {
+        byes: [],
+        games: [
+          // Round 1: A(white) vs C, B(white) vs D
+          { black: 'C', result: 'draw', white: 'A' },
+          { black: 'D', result: 'draw', white: 'B' },
+        ],
+      };
+      const round2: CompletedRound = {
+        byes: [],
+        games: [
+          // Round 2: A(black) vs D, B(black) vs C
+          { black: 'A', result: 'draw', white: 'D' },
+          { black: 'B', result: 'draw', white: 'C' },
+        ],
+      };
       // Round 3: A hasn't faced B → can be paired
       // 4.3.8: alternate first-team(A) from last round: last=black → A gets White
-      const result = pair(players, [round1Games, round2Games]);
-      const pairing = result.pairings.find(
+      const result = pair(players, [round1, round2]);
+      const pairing = result.games.find(
         (p) =>
           (p.white === 'A' && p.black === 'B') ||
           (p.white === 'B' && p.black === 'A'),
@@ -254,14 +285,17 @@ describe('swissTeam', () => {
   describe('no rematches invariant', () => {
     it('never pairs the same two teams twice across rounds (4 teams, 2 rounds)', () => {
       const result1 = pair(FOUR_TEAMS, []);
-      const round1Games: Game[] = result1.pairings.map((p) => ({
-        black: p.black,
-        result: 0.5 as const,
-        white: p.white,
-      }));
-      const result2 = pair(FOUR_TEAMS, [round1Games]);
-      for (const p2 of result2.pairings) {
-        const isRematch = result1.pairings.some(
+      const round1: CompletedRound = {
+        byes: result1.byes,
+        games: result1.games.map((p) => ({
+          black: p.black,
+          result: 'draw' as const,
+          white: p.white,
+        })),
+      };
+      const result2 = pair(FOUR_TEAMS, [round1]);
+      for (const p2 of result2.games) {
+        const isRematch = result1.games.some(
           (p1) =>
             (p1.white === p2.white && p1.black === p2.black) ||
             (p1.white === p2.black && p1.black === p2.white),
@@ -274,33 +308,36 @@ describe('swissTeam', () => {
   describe('multi-round simulation', () => {
     it('can pair 3 rounds of a 6-team tournament with no rematches', () => {
       const players: Player[] = [
-        { id: 'A', rating: 2100 },
-        { id: 'B', rating: 2000 },
-        { id: 'C', rating: 1900 },
-        { id: 'D', rating: 1800 },
-        { id: 'E', rating: 1700 },
-        { id: 'F', rating: 1600 },
+        { id: 'A', points: 0, rank: 1, rating: 2100 },
+        { id: 'B', points: 0, rank: 2, rating: 2000 },
+        { id: 'C', points: 0, rank: 3, rating: 1900 },
+        { id: 'D', points: 0, rank: 4, rating: 1800 },
+        { id: 'E', points: 0, rank: 5, rating: 1700 },
+        { id: 'F', points: 0, rank: 6, rating: 1600 },
       ];
-      let games: Game[][] = [];
+      let rounds: CompletedRound[] = [];
 
       for (let round = 1; round <= 3; round++) {
-        const result = pair(players, games);
-        expect(result.pairings).toHaveLength(3);
+        const result = pair(players, rounds);
+        expect(result.games).toHaveLength(3);
         expect(result.byes).toHaveLength(0);
 
         // Record games (all draws for simplicity)
-        const roundGames: Game[] = result.pairings.map((p) => ({
-          black: p.black,
-          result: 0.5 as const,
-          white: p.white,
-        }));
-        games = [...games, roundGames];
+        const roundCompleted: CompletedRound = {
+          byes: [],
+          games: result.games.map((p) => ({
+            black: p.black,
+            result: 'draw' as const,
+            white: p.white,
+          })),
+        };
+        rounds = [...rounds, roundCompleted];
       }
 
       // Verify no rematches across all 3 rounds
       const allPairs = new Set<string>();
-      for (const roundGames of games) {
-        for (const g of roundGames) {
+      for (const roundData of rounds) {
+        for (const g of roundData.games) {
           const key = [g.white, g.black].toSorted().join('-');
           expect(allPairs.has(key)).toBe(false);
           allPairs.add(key);
@@ -313,8 +350,8 @@ describe('swissTeam', () => {
     it('pairs 4 teams with no prior games in lexicographic order', () => {
       // Same lexicographic first pairing as double-swiss: A-C and B-D
       const result = pair(FOUR_TEAMS, []);
-      expect(hasPair(result.pairings, 'A', 'C')).toBe(true);
-      expect(hasPair(result.pairings, 'B', 'D')).toBe(true);
+      expect(hasPair(result.games, 'A', 'C')).toBe(true);
+      expect(hasPair(result.games, 'B', 'D')).toBe(true);
     });
   });
 });

--- a/src/__tests__/trace.spec.ts
+++ b/src/__tests__/trace.spec.ts
@@ -16,7 +16,7 @@ import { pair as teamPair } from '../swiss-team.js';
 import dutchC5 from './fixtures/dutch_2025_C5.trf?raw';
 
 import type { TraceEvent } from '../trace.js';
-import type { Game, Player } from '../types.js';
+import type { CompletedRound, Player } from '../types.js';
 import type { Tournament } from '@echecs/trf';
 
 // ---------------------------------------------------------------------------
@@ -32,11 +32,13 @@ function edges(
 function toSwissPlayers(tournament: Tournament): Player[] {
   return tournament.players.map((p) => ({
     id: String(p.pairingNumber),
+    points: 0,
+    rank: p.pairingNumber,
     rating: p.rating,
   }));
 }
 
-function toSwissGames(tournament: Tournament): Game[][] {
+function toSwissRounds(tournament: Tournament): CompletedRound[] {
   let maxRound = 0;
   for (const player of tournament.players) {
     for (const result of player.results) {
@@ -46,27 +48,30 @@ function toSwissGames(tournament: Tournament): Game[][] {
     }
   }
 
-  const roundArrays: Game[][] = Array.from({ length: maxRound }, () => []);
+  const roundArrays: CompletedRound[] = Array.from(
+    { length: maxRound },
+    () => ({ byes: [], games: [] }),
+  );
 
   for (const player of tournament.players) {
     for (const result of player.results) {
       if (result.color !== 'w' || result.opponentId === null) {
         continue;
       }
-      let score: 0 | 0.5 | 1;
+      let gameResult: 'black' | 'draw' | 'white';
       switch (result.result) {
         case '1':
         case '+': {
-          score = 1;
+          gameResult = 'white';
           break;
         }
         case '0':
         case '-': {
-          score = 0;
+          gameResult = 'black';
           break;
         }
         case '=': {
-          score = 0.5;
+          gameResult = 'draw';
           break;
         }
         default: {
@@ -74,11 +79,11 @@ function toSwissGames(tournament: Tournament): Game[][] {
         }
       }
       const roundIndex = result.round - 1;
-      const roundGames = roundArrays[roundIndex];
-      if (roundGames !== undefined) {
-        roundGames.push({
+      const roundData = roundArrays[roundIndex];
+      if (roundData !== undefined) {
+        roundData.games.push({
           black: String(result.opponentId),
-          result: score,
+          result: gameResult,
           white: String(player.pairingNumber),
         });
       }
@@ -143,11 +148,11 @@ describe('dutch trace', () => {
   it('emits expected event types for C5 fixture', () => {
     const tournament = parse(dutchC5)!;
     const players = toSwissPlayers(tournament);
-    const allGames = toSwissGames(tournament);
-    const priorGames = allGames.slice(0, 2);
+    const allRounds = toSwissRounds(tournament);
+    const priorRounds = allRounds.slice(0, 2);
 
     const events: TraceEvent[] = [];
-    pair(players, priorGames, { trace: (event) => events.push(event) });
+    pair(players, priorRounds, { trace: (event) => events.push(event) });
 
     const types = new Set(events.map((event) => event.type));
 
@@ -161,12 +166,12 @@ describe('dutch trace', () => {
   it('produces the same pairings with and without trace', () => {
     const tournament = parse(dutchC5)!;
     const players = toSwissPlayers(tournament);
-    const allGames = toSwissGames(tournament);
-    const priorGames = allGames.slice(0, 2);
+    const allRounds = toSwissRounds(tournament);
+    const priorRounds = allRounds.slice(0, 2);
 
-    const withoutTrace = pair(players, priorGames);
+    const withoutTrace = pair(players, priorRounds);
     const events: TraceEvent[] = [];
-    const withTrace = pair(players, priorGames, {
+    const withTrace = pair(players, priorRounds, {
       trace: (event) => events.push(event),
     });
 
@@ -181,10 +186,10 @@ describe('dutch trace', () => {
 
 describe('trace smoke tests', () => {
   const players: Player[] = [
-    { id: '1', rating: 2000 },
-    { id: '2', rating: 1900 },
-    { id: '3', rating: 1800 },
-    { id: '4', rating: 1700 },
+    { id: '1', points: 0, rank: 1, rating: 2000 },
+    { id: '2', points: 0, rank: 2, rating: 1900 },
+    { id: '3', points: 0, rank: 3, rating: 1800 },
+    { id: '4', points: 0, rank: 4, rating: 1700 },
   ];
 
   it('dubov emits trace events', () => {

--- a/src/__tests__/utilities.spec.ts
+++ b/src/__tests__/utilities.spec.ts
@@ -7,27 +7,33 @@ import {
   scoreGroups,
 } from '../utilities.js';
 
-import type { Game, Player } from '../types.js';
+import type { CompletedRound, Player } from '../types.js';
 import type { PlayerState } from '../utilities.js';
 
 const PLAYERS: Player[] = [
-  { id: 'A', rating: 2000 },
-  { id: 'B', rating: 1900 },
-  { id: 'C', rating: 1800 },
-  { id: 'D', rating: 1700 },
+  { id: 'A', points: 0, rank: 1, rating: 2000 },
+  { id: 'B', points: 0, rank: 2, rating: 1900 },
+  { id: 'C', points: 0, rank: 3, rating: 1800 },
+  { id: 'D', points: 0, rank: 4, rating: 1700 },
 ];
 
 // Round 1: A(w) 1-0 B, C(w) 0-1 D
 // Round 2: C(w) 0.5-0.5 A, D(w) 0-1 B
-const GAMES: Game[][] = [
-  [
-    { black: 'B', result: 1, white: 'A' },
-    { black: 'D', result: 0, white: 'C' },
-  ],
-  [
-    { black: 'A', result: 0.5, white: 'C' },
-    { black: 'B', result: 0, white: 'D' },
-  ],
+const GAMES: CompletedRound[] = [
+  {
+    byes: [],
+    games: [
+      { black: 'B', result: 'white', white: 'A' },
+      { black: 'D', result: 'black', white: 'C' },
+    ],
+  },
+  {
+    byes: [],
+    games: [
+      { black: 'A', result: 'draw', white: 'C' },
+      { black: 'B', result: 'black', white: 'D' },
+    ],
+  },
 ];
 
 // ---------------------------------------------------------------------------
@@ -73,7 +79,7 @@ describe('buildPlayerStates', () => {
     });
 
     it('computes B score as 1 (lost R1 as black, won R2 as black)', () => {
-      // B: R1 black, white(A) result=1 → B gets 1-1=0; R2 black, white(D) result=0 → B gets 1-0=1
+      // B: R1 black, white(A) result='white' → B gets 0; R2 black, white(D) result='black' → B gets 1
       const states = buildPlayerStates(PLAYERS, GAMES);
       const b = states.find((s) => s.id === 'B');
       expect(b?.score).toBe(1);
@@ -86,38 +92,47 @@ describe('buildPlayerStates', () => {
     });
 
     it('computes D score as 1 (won R1 as black, lost R2 as white)', () => {
-      // D: R1 black, white(C) result=0 → D gets 1-0=1; R2 white, result=0 → D gets 0
+      // D: R1 black, white(C) result='black' → D gets 1; R2 white, result='black' → D gets 0
       const states = buildPlayerStates(PLAYERS, GAMES);
       const d = states.find((s) => s.id === 'D');
       expect(d?.score).toBe(1);
     });
 
     it('returns 0 for player with no games', () => {
-      const states = buildPlayerStates([{ id: 'Z' }], []);
+      const states = buildPlayerStates([{ id: 'Z', points: 0, rank: 1 }], []);
       expect(states[0]?.score).toBe(0);
     });
 
     it('counts pairing-bye score (1 point)', () => {
-      const byeGames: Game[][] = [
-        [{ black: '', kind: 'pairing-bye', result: 1, white: 'A' }],
+      const byeRounds: CompletedRound[] = [
+        { byes: [{ kind: 'pairing', player: 'A' }], games: [] },
       ];
-      const states = buildPlayerStates([{ id: 'A' }], byeGames);
+      const states = buildPlayerStates(
+        [{ id: 'A', points: 0, rank: 1 }],
+        byeRounds,
+      );
       expect(states[0]?.score).toBe(1);
     });
 
     it('counts half-bye score (0.5 points)', () => {
-      const byeGames: Game[][] = [
-        [{ black: '', kind: 'half-bye', result: 0.5, white: 'A' }],
+      const byeRounds: CompletedRound[] = [
+        { byes: [{ kind: 'half', player: 'A' }], games: [] },
       ];
-      const states = buildPlayerStates([{ id: 'A' }], byeGames);
+      const states = buildPlayerStates(
+        [{ id: 'A', points: 0, rank: 1 }],
+        byeRounds,
+      );
       expect(states[0]?.score).toBe(0.5);
     });
 
     it('counts zero-bye score (0 points)', () => {
-      const byeGames: Game[][] = [
-        [{ black: '', kind: 'zero-bye', result: 0, white: 'A' }],
+      const byeRounds: CompletedRound[] = [
+        { byes: [{ kind: 'zero', player: 'A' }], games: [] },
       ];
-      const states = buildPlayerStates([{ id: 'A' }], byeGames);
+      const states = buildPlayerStates(
+        [{ id: 'A', points: 0, rank: 1 }],
+        byeRounds,
+      );
       expect(states[0]?.score).toBe(0);
     });
   });
@@ -129,22 +144,32 @@ describe('buildPlayerStates', () => {
       expect(a?.opponents).toEqual(new Set(['B', 'C']));
     });
 
-    it('does not include bye sentinel as opponent', () => {
-      const byeGames: Game[][] = [[{ black: '', result: 1, white: 'A' }]];
-      const states = buildPlayerStates([{ id: 'A' }], byeGames);
+    it('does not include bye as opponent', () => {
+      const byeRounds: CompletedRound[] = [
+        { byes: [{ kind: 'pairing', player: 'A' }], games: [] },
+      ];
+      const states = buildPlayerStates(
+        [{ id: 'A', points: 0, rank: 1 }],
+        byeRounds,
+      );
       expect(states[0]?.opponents.size).toBe(0);
     });
 
     it('does not include forfeit opponent', () => {
-      const games: Game[][] = [
-        [{ black: 'B', kind: 'forfeit-win', result: 1, white: 'A' }],
+      const rounds: CompletedRound[] = [
+        {
+          byes: [],
+          games: [
+            { black: 'B', forfeit: 'black', result: 'white', white: 'A' },
+          ],
+        },
       ];
       const states = buildPlayerStates(
         [
-          { id: 'A', rating: 2000 },
-          { id: 'B', rating: 1900 },
+          { id: 'A', points: 0, rank: 1, rating: 2000 },
+          { id: 'B', points: 0, rank: 2, rating: 1900 },
         ],
-        games,
+        rounds,
       );
       expect(states.find((s) => s.id === 'A')?.opponents.size).toBe(0);
       expect(states.find((s) => s.id === 'B')?.opponents.size).toBe(0);
@@ -165,45 +190,56 @@ describe('buildPlayerStates', () => {
     });
 
     it('returns undefined for rounds where player has no game', () => {
-      const partialGames: Game[][] = [
-        [{ black: 'B', result: 1, white: 'A' }],
-        [{ black: 'D', result: 0, white: 'C' }], // A absent
+      const partialRounds: CompletedRound[] = [
+        {
+          byes: [],
+          games: [{ black: 'B', result: 'white', white: 'A' }],
+        },
+        {
+          byes: [],
+          games: [{ black: 'D', result: 'black', white: 'C' }], // A absent
+        },
       ];
-      const states = buildPlayerStates(PLAYERS, partialGames);
+      const states = buildPlayerStates(PLAYERS, partialRounds);
       const a = states.find((s) => s.id === 'A');
       expect(a?.colorHistory).toEqual(['white', undefined]);
     });
 
     it('returns undefined for bye rounds', () => {
-      const byeGames: Game[][] = [[{ black: '', result: 1, white: 'A' }]];
+      const byeRounds: CompletedRound[] = [
+        { byes: [{ kind: 'pairing', player: 'A' }], games: [] },
+      ];
       const states = buildPlayerStates(
         [
-          { id: 'A', rating: 2000 },
-          { id: 'B', rating: 1900 },
+          { id: 'A', points: 0, rank: 1, rating: 2000 },
+          { id: 'B', points: 0, rank: 2, rating: 1900 },
         ],
-        byeGames,
+        byeRounds,
       );
       const a = states.find((s) => s.id === 'A');
       expect(a?.colorHistory).toEqual([undefined]);
     });
 
     it('returns undefined for forfeit-win rounds', () => {
-      const forfeitGames: Game[][] = [
-        [
-          {
-            black: 'B',
-            kind: 'forfeit-win',
-            result: 1,
-            white: 'A',
-          },
-        ],
+      const forfeitRounds: CompletedRound[] = [
+        {
+          byes: [],
+          games: [
+            {
+              black: 'B',
+              forfeit: 'black',
+              result: 'white',
+              white: 'A',
+            },
+          ],
+        },
       ];
       const states = buildPlayerStates(
         [
-          { id: 'A', rating: 2000 },
-          { id: 'B', rating: 1900 },
+          { id: 'A', points: 0, rank: 1, rating: 2000 },
+          { id: 'B', points: 0, rank: 2, rating: 1900 },
         ],
-        forfeitGames,
+        forfeitRounds,
       );
       const a = states.find((s) => s.id === 'A');
       expect(a?.colorHistory).toEqual([undefined]);
@@ -212,22 +248,25 @@ describe('buildPlayerStates', () => {
     });
 
     it('returns undefined for forfeit-loss rounds', () => {
-      const forfeitGames: Game[][] = [
-        [
-          {
-            black: 'B',
-            kind: 'forfeit-loss',
-            result: 0,
-            white: 'A',
-          },
-        ],
+      const forfeitRounds: CompletedRound[] = [
+        {
+          byes: [],
+          games: [
+            {
+              black: 'B',
+              forfeit: 'white',
+              result: 'black',
+              white: 'A',
+            },
+          ],
+        },
       ];
       const states = buildPlayerStates(
         [
-          { id: 'A', rating: 2000 },
-          { id: 'B', rating: 1900 },
+          { id: 'A', points: 0, rank: 1, rating: 2000 },
+          { id: 'B', points: 0, rank: 2, rating: 1900 },
         ],
-        forfeitGames,
+        forfeitRounds,
       );
       const a = states.find((s) => s.id === 'A');
       expect(a?.colorHistory).toEqual([undefined]);
@@ -260,7 +299,7 @@ describe('buildPlayerStates', () => {
 
   describe('preferenceStrength', () => {
     it('returns "none" for player with no color history', () => {
-      const states = buildPlayerStates([{ id: 'Z' }], []);
+      const states = buildPlayerStates([{ id: 'Z', points: 0, rank: 1 }], []);
       expect(states[0]?.preferenceStrength).toBe('none');
     });
 
@@ -284,29 +323,31 @@ describe('buildPlayerStates', () => {
 
     it('returns "absolute" when last two non-undefined color entries are the same', () => {
       // A plays white in R1 and R2: last two = [white, white]
-      const gamesWW: Game[][] = [
-        [{ black: 'B', result: 1, white: 'A' }],
-        [{ black: 'B', result: 1, white: 'A' }],
+      const rounds: CompletedRound[] = [
+        { byes: [], games: [{ black: 'B', result: 'white', white: 'A' }] },
+        { byes: [], games: [{ black: 'B', result: 'white', white: 'A' }] },
       ];
       const states = buildPlayerStates(
         [
-          { id: 'A', rating: 2000 },
-          { id: 'B', rating: 1900 },
+          { id: 'A', points: 0, rank: 1, rating: 2000 },
+          { id: 'B', points: 0, rank: 2, rating: 1900 },
         ],
-        gamesWW,
+        rounds,
       );
       const a = states.find((s) => s.id === 'A');
       expect(a?.preferenceStrength).toBe('absolute');
     });
 
     it('returns "strong" when |colorDiff|===1', () => {
-      const oneWhiteGames: Game[][] = [[{ black: 'B', result: 1, white: 'A' }]];
+      const rounds: CompletedRound[] = [
+        { byes: [], games: [{ black: 'B', result: 'white', white: 'A' }] },
+      ];
       const states = buildPlayerStates(
         [
-          { id: 'A', rating: 2000 },
-          { id: 'B', rating: 1900 },
+          { id: 'A', points: 0, rank: 1, rating: 2000 },
+          { id: 'B', points: 0, rank: 2, rating: 1900 },
         ],
-        oneWhiteGames,
+        rounds,
       );
       const a = states.find((s) => s.id === 'A');
       // colorDiff = 1-0 = 1, |colorDiff|===1 → strong
@@ -314,15 +355,20 @@ describe('buildPlayerStates', () => {
     });
 
     it('returns "none" when only game was a forfeit', () => {
-      const games: Game[][] = [
-        [{ black: 'B', kind: 'forfeit-win', result: 1, white: 'A' }],
+      const rounds: CompletedRound[] = [
+        {
+          byes: [],
+          games: [
+            { black: 'B', forfeit: 'black', result: 'white', white: 'A' },
+          ],
+        },
       ];
       const states = buildPlayerStates(
         [
-          { id: 'A', rating: 2000 },
-          { id: 'B', rating: 1900 },
+          { id: 'A', points: 0, rank: 1, rating: 2000 },
+          { id: 'B', points: 0, rank: 2, rating: 1900 },
         ],
-        games,
+        rounds,
       );
       expect(states.find((s) => s.id === 'A')?.preferenceStrength).toBe('none');
     });
@@ -330,7 +376,7 @@ describe('buildPlayerStates', () => {
 
   describe('preferredColor', () => {
     it('returns undefined for player with no history', () => {
-      const states = buildPlayerStates([{ id: 'Z' }], []);
+      const states = buildPlayerStates([{ id: 'Z', points: 0, rank: 1 }], []);
       expect(states[0]?.preferredColor).toBeUndefined();
     });
 
@@ -354,15 +400,20 @@ describe('buildPlayerStates', () => {
     });
 
     it('returns undefined when only game was a forfeit', () => {
-      const games: Game[][] = [
-        [{ black: 'B', kind: 'forfeit-win', result: 1, white: 'A' }],
+      const rounds: CompletedRound[] = [
+        {
+          byes: [],
+          games: [
+            { black: 'B', forfeit: 'black', result: 'white', white: 'A' },
+          ],
+        },
       ];
       const states = buildPlayerStates(
         [
-          { id: 'A', rating: 2000 },
-          { id: 'B', rating: 1900 },
+          { id: 'A', points: 0, rank: 1, rating: 2000 },
+          { id: 'B', points: 0, rank: 2, rating: 1900 },
         ],
-        games,
+        rounds,
       );
       expect(states.find((s) => s.id === 'A')?.preferredColor).toBeUndefined();
     });
@@ -376,13 +427,15 @@ describe('buildPlayerStates', () => {
     });
 
     it('returns 1 when player received one bye', () => {
-      const byeGames: Game[][] = [[{ black: '', result: 1, white: 'A' }]];
+      const byeRounds: CompletedRound[] = [
+        { byes: [{ kind: 'pairing', player: 'A' }], games: [] },
+      ];
       const states = buildPlayerStates(
         [
-          { id: 'A', rating: 2000 },
-          { id: 'B', rating: 1900 },
+          { id: 'A', points: 0, rank: 1, rating: 2000 },
+          { id: 'B', points: 0, rank: 2, rating: 1900 },
         ],
-        byeGames,
+        byeRounds,
       );
       const a = states.find((s) => s.id === 'A');
       expect(a?.byeCount).toBe(1);
@@ -397,23 +450,28 @@ describe('buildPlayerStates', () => {
     });
 
     it('returns 1 when player has no game in one round', () => {
-      const partialGames: Game[][] = [
-        [{ black: 'B', result: 1, white: 'A' }],
-        [{ black: 'D', result: 0, white: 'C' }], // A absent
+      const partialRounds: CompletedRound[] = [
+        { byes: [], games: [{ black: 'B', result: 'white', white: 'A' }] },
+        {
+          byes: [],
+          games: [{ black: 'D', result: 'black', white: 'C' }], // A absent
+        },
       ];
-      const states = buildPlayerStates(PLAYERS, partialGames);
+      const states = buildPlayerStates(PLAYERS, partialRounds);
       const a = states.find((s) => s.id === 'A');
       expect(a?.unplayedRounds).toBe(1);
     });
 
     it('counts bye rounds as unplayed (C++ gameWasPlayed=false for byes)', () => {
-      const byeGames: Game[][] = [[{ black: '', result: 1, white: 'A' }]];
+      const byeRounds: CompletedRound[] = [
+        { byes: [{ kind: 'pairing', player: 'A' }], games: [] },
+      ];
       const states = buildPlayerStates(
         [
-          { id: 'A', rating: 2000 },
-          { id: 'B', rating: 1900 },
+          { id: 'A', points: 0, rank: 1, rating: 2000 },
+          { id: 'B', points: 0, rank: 2, rating: 1900 },
         ],
-        byeGames,
+        byeRounds,
       );
       const a = states.find((s) => s.id === 'A');
       expect(a?.unplayedRounds).toBe(1);
@@ -456,23 +514,28 @@ describe('buildPlayerStates', () => {
     });
 
     it('returns undefined for rounds with no game', () => {
-      const partialGames: Game[][] = [
-        [{ black: 'B', result: 1, white: 'A' }],
-        [{ black: 'D', result: 0, white: 'C' }], // A absent
+      const partialRounds: CompletedRound[] = [
+        { byes: [], games: [{ black: 'B', result: 'white', white: 'A' }] },
+        {
+          byes: [],
+          games: [{ black: 'D', result: 'black', white: 'C' }], // A absent
+        },
       ];
-      const states = buildPlayerStates(PLAYERS, partialGames);
+      const states = buildPlayerStates(PLAYERS, partialRounds);
       const a = states.find((s) => s.id === 'A');
       expect(a?.floatHistory[1]).toBeUndefined();
     });
 
     it('returns "down" for bye rounds', () => {
-      const byeGames: Game[][] = [[{ black: '', result: 1, white: 'A' }]];
+      const byeRounds: CompletedRound[] = [
+        { byes: [{ kind: 'pairing', player: 'A' }], games: [] },
+      ];
       const states = buildPlayerStates(
         [
-          { id: 'A', rating: 2000 },
-          { id: 'B', rating: 1900 },
+          { id: 'A', points: 0, rank: 1, rating: 2000 },
+          { id: 'B', points: 0, rank: 2, rating: 1900 },
         ],
-        byeGames,
+        byeRounds,
       );
       const a = states.find((s) => s.id === 'A');
       expect(a?.floatHistory[0]).toBe('down');
@@ -482,28 +545,32 @@ describe('buildPlayerStates', () => {
       // Player A (score 0) beats B (score 1) by forfeit.
       // bbpPairings: gameWasPlayed=false, points > pointsForLoss → FLOAT_DOWN.
       // Without the fix, score comparison would say A floated UP (0 < 1).
-      const r1Games: Game[][] = [
-        [
-          { black: 'B', result: 0, white: 'A' }, // A loses R1 → A=0, B=1
-        ],
+      const r1Rounds: CompletedRound[] = [
+        {
+          byes: [],
+          games: [{ black: 'B', result: 'black', white: 'A' }], // A loses R1 → A=0, B=1
+        },
       ];
-      const r2Games: Game[][] = [
-        ...r1Games,
-        [
-          {
-            black: 'B',
-            kind: 'forfeit-win',
-            result: 1,
-            white: 'A',
-          },
-        ],
+      const r2Rounds: CompletedRound[] = [
+        ...r1Rounds,
+        {
+          byes: [],
+          games: [
+            {
+              black: 'B',
+              forfeit: 'black',
+              result: 'white',
+              white: 'A',
+            },
+          ],
+        },
       ];
       const states = buildPlayerStates(
         [
-          { id: 'A', rating: 2000 },
-          { id: 'B', rating: 1900 },
+          { id: 'A', points: 0, rank: 1, rating: 2000 },
+          { id: 'B', points: 0, rank: 2, rating: 1900 },
         ],
-        r2Games,
+        r2Rounds,
       );
       const a = states.find((s) => s.id === 'A');
       expect(a?.floatHistory[1]).toBe('down');
@@ -513,56 +580,64 @@ describe('buildPlayerStates', () => {
       // Player A (score 1) loses to B (score 0) by forfeit.
       // bbpPairings: gameWasPlayed=false, points = pointsForLoss → FLOAT_NONE.
       // Without the fix, score comparison would say A floated DOWN (1 > 0).
-      const r1Games: Game[][] = [
-        [
-          { black: 'B', result: 1, white: 'A' }, // A wins R1 → A=1, B=0
-        ],
+      const r1Rounds: CompletedRound[] = [
+        {
+          byes: [],
+          games: [{ black: 'B', result: 'white', white: 'A' }], // A wins R1 → A=1, B=0
+        },
       ];
-      const r2Games: Game[][] = [
-        ...r1Games,
-        [
-          {
-            black: 'B',
-            kind: 'forfeit-loss',
-            result: 0,
-            white: 'A',
-          },
-        ],
+      const r2Rounds: CompletedRound[] = [
+        ...r1Rounds,
+        {
+          byes: [],
+          games: [
+            {
+              black: 'B',
+              forfeit: 'white',
+              result: 'black',
+              white: 'A',
+            },
+          ],
+        },
       ];
       const states = buildPlayerStates(
         [
-          { id: 'A', rating: 2000 },
-          { id: 'B', rating: 1900 },
+          { id: 'A', points: 0, rank: 1, rating: 2000 },
+          { id: 'B', points: 0, rank: 2, rating: 1900 },
         ],
-        r2Games,
+        r2Rounds,
       );
       const a = states.find((s) => s.id === 'A');
       expect(a?.floatHistory[1]).toBeUndefined();
     });
 
     it('returns undefined for the loser in a forfeit-win game (black side)', () => {
-      const r1Games: Game[][] = [
-        [
-          { black: 'B', result: 0, white: 'A' }, // A loses R1 → A=0, B=1
-        ],
+      const r1Rounds: CompletedRound[] = [
+        {
+          byes: [],
+          games: [{ black: 'B', result: 'black', white: 'A' }], // A loses R1 → A=0, B=1
+        },
       ];
-      const r2Games: Game[][] = [
-        ...r1Games,
-        [
-          {
-            black: 'B',
-            kind: 'forfeit-win',
-            result: 1,
-            white: 'A',
-          },
-        ],
+      const r2Rounds: CompletedRound[] = [
+        ...r1Rounds,
+        {
+          byes: [],
+          games: [
+            {
+              black: 'B',
+              forfeit: 'black',
+              result: 'white',
+              white: 'A',
+            },
+          ],
+        },
       ];
       const states = buildPlayerStates(
         [
-          { id: 'A', rating: 2000 },
-          { id: 'B', rating: 1900 },
+          { id: 'A', points: 0, rank: 1, rating: 2000 },
+          { id: 'B', points: 0, rank: 2, rating: 1900 },
         ],
-        r2Games,
+        r2Rounds,
       );
       const b = states.find((s) => s.id === 'B');
       // B is the loser (black side of forfeit-win = white won)
@@ -570,28 +645,32 @@ describe('buildPlayerStates', () => {
     });
 
     it('returns "down" for the winner in a forfeit-loss game (black side)', () => {
-      const r1Games: Game[][] = [
-        [
-          { black: 'B', result: 1, white: 'A' }, // A wins R1 → A=1, B=0
-        ],
+      const r1Rounds: CompletedRound[] = [
+        {
+          byes: [],
+          games: [{ black: 'B', result: 'white', white: 'A' }], // A wins R1 → A=1, B=0
+        },
       ];
-      const r2Games: Game[][] = [
-        ...r1Games,
-        [
-          {
-            black: 'B',
-            kind: 'forfeit-loss',
-            result: 0,
-            white: 'A',
-          },
-        ],
+      const r2Rounds: CompletedRound[] = [
+        ...r1Rounds,
+        {
+          byes: [],
+          games: [
+            {
+              black: 'B',
+              forfeit: 'white',
+              result: 'black',
+              white: 'A',
+            },
+          ],
+        },
       ];
       const states = buildPlayerStates(
         [
-          { id: 'A', rating: 2000 },
-          { id: 'B', rating: 1900 },
+          { id: 'A', points: 0, rank: 1, rating: 2000 },
+          { id: 'B', points: 0, rank: 2, rating: 1900 },
         ],
-        r2Games,
+        r2Rounds,
       );
       const b = states.find((s) => s.id === 'B');
       // B is the winner (black side of forfeit-loss = white lost)
@@ -648,66 +727,72 @@ describe('assignBye', () => {
 
   it('returns a player when count is odd', () => {
     const oddPlayers = PLAYERS.slice(0, 3);
-    const oddGames: Game[][] = [
-      [
-        { black: 'B', result: 1, white: 'A' },
-        // C has no opponent in R1
-      ],
+    const oddRounds: CompletedRound[] = [
+      {
+        byes: [],
+        games: [
+          { black: 'B', result: 'white', white: 'A' },
+          // C has no opponent in R1
+        ],
+      },
     ];
-    const states = buildPlayerStates(oddPlayers, oddGames);
-    const result = assignBye(states, oddGames, tiebreakByTpnAsc);
+    const states = buildPlayerStates(oddPlayers, oddRounds);
+    const result = assignBye(states, oddRounds, tiebreakByTpnAsc);
     expect(result).toBeDefined();
   });
 
   it('excludes players who already have a bye', () => {
-    const threePlayers = [
-      { id: 'A', rating: 2000 },
-      { id: 'B', rating: 1900 },
-      { id: 'C', rating: 1800 },
+    const threePlayers: Player[] = [
+      { id: 'A', points: 0, rank: 1, rating: 2000 },
+      { id: 'B', points: 0, rank: 2, rating: 1900 },
+      { id: 'C', points: 0, rank: 3, rating: 1800 },
     ];
     // A already received a bye in R1
-    const gamesWithBye: Game[][] = [
-      [
-        { black: '', result: 1, white: 'A' },
-        { black: 'C', result: 1, white: 'B' },
-      ],
+    const roundsWithBye: CompletedRound[] = [
+      {
+        byes: [{ kind: 'pairing', player: 'A' }],
+        games: [{ black: 'C', result: 'white', white: 'B' }],
+      },
     ];
-    const states = buildPlayerStates(threePlayers, gamesWithBye);
-    const result = assignBye(states, gamesWithBye, tiebreakByTpnAsc);
+    const states = buildPlayerStates(threePlayers, roundsWithBye);
+    const result = assignBye(states, roundsWithBye, tiebreakByTpnAsc);
     // A has byeCount=1, so should not be selected if B or C are eligible
     expect(result?.id).not.toBe('A');
   });
 
   it('uses tiebreak comparator when multiple lowest-score players tied', () => {
-    const threePlayers = [
-      { id: 'A', rating: 2000 },
-      { id: 'B', rating: 1900 },
-      { id: 'C', rating: 1800 },
+    const threePlayers: Player[] = [
+      { id: 'A', points: 0, rank: 1, rating: 2000 },
+      { id: 'B', points: 0, rank: 2, rating: 1900 },
+      { id: 'C', points: 0, rank: 3, rating: 1800 },
     ];
-    const noGames: Game[][] = [];
-    const states = buildPlayerStates(threePlayers, noGames);
+    const noRounds: CompletedRound[] = [];
+    const states = buildPlayerStates(threePlayers, noRounds);
     // All score 0; tiebreak by TPN descending → highest TPN (C=3) first → gets bye
-    const result = assignBye(states, noGames, tiebreakByTpnDesc);
+    const result = assignBye(states, noRounds, tiebreakByTpnDesc);
     expect(result?.id).toBe('C');
   });
 
   it('falls back to all players if none have byeCount===0', () => {
-    const threePlayers = [
-      { id: 'A', rating: 2000 },
-      { id: 'B', rating: 1900 },
-      { id: 'C', rating: 1800 },
+    const threePlayers: Player[] = [
+      { id: 'A', points: 0, rank: 1, rating: 2000 },
+      { id: 'B', points: 0, rank: 2, rating: 1900 },
+      { id: 'C', points: 0, rank: 3, rating: 1800 },
     ];
     // All players had byes
-    const allByeGames: Game[][] = [
-      [
-        { black: '', result: 1, white: 'A' },
-        { black: '', result: 1, white: 'B' },
-        { black: '', result: 1, white: 'C' },
-      ],
+    const allByeRounds: CompletedRound[] = [
+      {
+        byes: [
+          { kind: 'pairing', player: 'A' },
+          { kind: 'pairing', player: 'B' },
+          { kind: 'pairing', player: 'C' },
+        ],
+        games: [],
+      },
     ];
-    const states = buildPlayerStates(threePlayers, allByeGames);
+    const states = buildPlayerStates(threePlayers, allByeRounds);
     // All have byeCount=1, so fallback to all players
-    const result = assignBye(states, allByeGames, tiebreakByTpnAsc);
+    const result = assignBye(states, allByeRounds, tiebreakByTpnAsc);
     expect(result).toBeDefined();
   });
 });

--- a/src/burstein-entry.ts
+++ b/src/burstein-entry.ts
@@ -1,12 +1,12 @@
 export { pair } from './burstein.js';
 export type {
   Bye,
+  CompletedRound,
   Game,
   PairOptions,
   Pairing,
-  PairingResult,
+  Pairings,
   Player,
-  Result,
   TraceCallback,
   TraceEvent,
 } from './types.js';

--- a/src/burstein.ts
+++ b/src/burstein.ts
@@ -28,12 +28,11 @@ import {
   allocateColor,
   assignBye,
   buildPlayerStates,
-  normaliseGames,
   scoreGroups,
 } from './utilities.js';
 
 import type { PairOptions } from './trace.js';
-import type { Game, PairingResult, Player } from './types.js';
+import type { CompletedRound, Game, Pairings, Player } from './types.js';
 import type { PlayerState } from './utilities.js';
 import type { BracketContext, Criterion } from './weights.js';
 
@@ -62,6 +61,18 @@ function computeBuchholz(
 }
 
 /**
+ * Returns the numeric score (0, 0.5, or 1) earned by `player` in a game.
+ */
+function gameScore(player: string, game: Game): number {
+  if (game.result === 'draw') return 0.5;
+  if (game.result === 'none') return 0;
+  return (game.result === 'white' && game.white === player) ||
+    (game.result === 'black' && game.black === player)
+    ? 1
+    : 0;
+}
+
+/**
  * Computes Sonneborn-Berger index for a player: sum of (result * opponent score).
  * Win against opponent → add opponent's score.
  * Draw against opponent → add 0.5 * opponent's score.
@@ -69,22 +80,21 @@ function computeBuchholz(
  */
 function computeSonnebornBerger(
   state: PlayerState,
-  games: Game[][],
+  rounds: CompletedRound[],
   stateById: Map<string, PlayerState>,
 ): number {
   let sum = 0;
-  for (const round of games) {
-    for (const g of round) {
-      if (g.black === '') continue;
+  for (const round of rounds) {
+    for (const g of round.games) {
       if (g.white === state.id) {
         const opp = stateById.get(g.black);
         if (opp !== undefined) {
-          sum += g.result * opp.score;
+          sum += gameScore(state.id, g) * opp.score;
         }
       } else if (g.black === state.id) {
         const opp = stateById.get(g.white);
         if (opp !== undefined) {
-          sum += (1 - g.result) * opp.score;
+          sum += gameScore(state.id, g) * opp.score;
         }
       }
     }
@@ -248,21 +258,18 @@ const BURSTEIN_CRITERIA: Criterion[] = [
 
 function pair(
   players: Player[],
-  games: Game[][],
+  rounds: CompletedRound[],
   options?: PairOptions,
-): PairingResult {
+): Pairings {
   if (players.length < 2) {
     throw new RangeError('at least 2 players are required');
   }
 
   const trace = options?.trace;
 
-  const totalRounds = games.length + 1;
+  const totalRounds = rounds.length + 1;
 
-  // Normalise legacy bye sentinel (black === white) to canonical (black === '')
-  const normalisedGames = normaliseGames(games);
-
-  const states = buildPlayerStates(players, normalisedGames);
+  const states = buildPlayerStates(players, rounds);
 
   // Build O(1) lookup by id
   const stateById = new Map<string, PlayerState>();
@@ -273,10 +280,7 @@ function pair(
   const sbById = new Map<string, number>();
   for (const state of states) {
     buchholzById.set(state.id, computeBuchholz(state, stateById));
-    sbById.set(
-      state.id,
-      computeSonnebornBerger(state, normalisedGames, stateById),
-    );
+    sbById.set(state.id, computeSonnebornBerger(state, rounds, stateById));
   }
 
   // Burstein ranking: score DESC, Buchholz DESC, SB DESC, TPN ASC
@@ -314,7 +318,7 @@ function pair(
 
   let byeState: PlayerState | undefined;
   if (needsBye) {
-    byeState = assignBye(sorted, normalisedGames, bursteinByeTiebreak);
+    byeState = assignBye(sorted, rounds, bursteinByeTiebreak);
   }
 
   const byeId = byeState?.id;
@@ -400,12 +404,12 @@ function pair(
     return bursteinRankCompare(a, b, buchholzById, sbById);
   }
 
-  const pairings = allPairedTuples.map(([a, b]) =>
+  const games = allPairedTuples.map(([a, b]) =>
     allocateColor(a, b, BURSTEIN_COLOR_RULES, rankCompare),
   );
 
   if (trace) {
-    for (const p of pairings) {
+    for (const p of games) {
       trace({
         black: p.black,
         rule: 'burstein-article-5.2',
@@ -417,8 +421,8 @@ function pair(
   }
 
   return {
-    byes: byeId === undefined ? [] : [{ player: byeId }],
-    pairings,
+    byes: byeId === undefined ? [] : [{ kind: 'pairing', player: byeId }],
+    games,
   };
 }
 

--- a/src/double-entry.ts
+++ b/src/double-entry.ts
@@ -1,12 +1,12 @@
 export { pair } from './double-swiss.js';
 export type {
   Bye,
+  CompletedRound,
   Game,
   PairOptions,
   Pairing,
-  PairingResult,
+  Pairings,
   Player,
-  Result,
   TraceCallback,
   TraceEvent,
 } from './types.js';

--- a/src/double-swiss.ts
+++ b/src/double-swiss.ts
@@ -6,7 +6,7 @@ import {
 import { buildPlayerStates, matchColorHistory } from './utilities.js';
 
 import type { PairOptions } from './trace.js';
-import type { Game, PairingResult, Player } from './types.js';
+import type { CompletedRound, Pairings, Player } from './types.js';
 import type { PlayerState } from './utilities.js';
 
 /**
@@ -19,7 +19,7 @@ import type { PlayerState } from './utilities.js';
  * Then applies rules 4.3.1 through 4.3.5 in descending priority.
  */
 function makeAllocateDoubleColors(
-  games: Game[][],
+  rounds: CompletedRound[],
 ): (a: PlayerState, b: PlayerState) => { black: string; white: string } {
   return function allocateDoubleColors(
     a: PlayerState,
@@ -29,8 +29,8 @@ function makeAllocateDoubleColors(
     const hrpIsA = a.score > b.score || (a.score === b.score && a.tpn < b.tpn);
     const [hrp, opp] = hrpIsA ? [a, b] : [b, a];
 
-    const hrpHistory = matchColorHistory(hrp.id, games);
-    const oppHistory = matchColorHistory(opp.id, games);
+    const hrpHistory = matchColorHistory(hrp.id, rounds);
+    const oppHistory = matchColorHistory(opp.id, rounds);
 
     // Helper: give HRP white.
     const hrpWhite = (): { black: string; white: string } => ({
@@ -100,16 +100,16 @@ function makeAllocateDoubleColors(
  */
 function pair(
   players: Player[],
-  games: Game[][],
+  rounds: CompletedRound[],
   options?: PairOptions,
-): PairingResult {
+): Pairings {
   if (players.length < 2) {
     throw new RangeError('at least 2 players are required');
   }
 
   const trace = options?.trace;
 
-  const states = buildPlayerStates(players, games);
+  const states = buildPlayerStates(players, rounds);
   const ranked = rankByScoreThenTPN(states);
   const byeState = assignLexicographicBye(ranked);
 
@@ -125,10 +125,10 @@ function pair(
   }
 
   const toBePaired = ranked.filter((s) => s.id !== byeId);
-  const pairings = pairAllBrackets(toBePaired, makeAllocateDoubleColors(games));
+  const games = pairAllBrackets(toBePaired, makeAllocateDoubleColors(rounds));
 
   if (trace) {
-    for (const p of pairings) {
+    for (const p of games) {
       trace({
         phase: 'main',
         playerA: p.white,
@@ -147,8 +147,8 @@ function pair(
   }
 
   return {
-    byes: byeId === undefined ? [] : [{ player: byeId }],
-    pairings,
+    byes: byeId === undefined ? [] : [{ kind: 'pairing', player: byeId }],
+    games,
   };
 }
 

--- a/src/dubov-entry.ts
+++ b/src/dubov-entry.ts
@@ -1,12 +1,12 @@
 export { pair } from './dubov.js';
 export type {
   Bye,
+  CompletedRound,
   Game,
   PairOptions,
   Pairing,
-  PairingResult,
+  Pairings,
   Player,
-  Result,
   TraceCallback,
   TraceEvent,
 } from './types.js';

--- a/src/dubov.ts
+++ b/src/dubov.ts
@@ -28,7 +28,7 @@ import {
 } from './utilities.js';
 
 import type { PairOptions } from './trace.js';
-import type { Game, PairingResult, Player } from './types.js';
+import type { CompletedRound, Pairings, Player } from './types.js';
 import type { PlayerState } from './utilities.js';
 import type { BracketContext, Criterion } from './weights.js';
 
@@ -256,18 +256,18 @@ const DUBOV_CRITERIA: Criterion[] = [
 
 function pair(
   players: Player[],
-  games: Game[][],
+  rounds: CompletedRound[],
   options?: PairOptions,
-): PairingResult {
+): Pairings {
   if (players.length < 2) {
     throw new RangeError('at least 2 players are required');
   }
 
   const trace = options?.trace;
 
-  const totalRounds = games.length + 1;
+  const totalRounds = rounds.length + 1;
   const isLastRound = false; // We don't know total rounds ahead of time; conservative
-  const states = buildPlayerStates(players, games);
+  const states = buildPlayerStates(players, rounds);
 
   // Compute ARO for each player
   const aroById = new Map<string, number>();
@@ -301,7 +301,7 @@ function pair(
   // -------------------------------------------------------------------------
   let byeState: PlayerState | undefined;
   if (needsBye) {
-    byeState = assignBye(sorted, games, dubovByeTiebreak);
+    byeState = assignBye(sorted, rounds, dubovByeTiebreak);
   }
 
   const byeId = byeState?.id;
@@ -396,12 +396,12 @@ function pair(
   // -------------------------------------------------------------------------
   // Allocate colours
   // -------------------------------------------------------------------------
-  const pairings = allPairedTuples.map(([a, b]) =>
+  const games = allPairedTuples.map(([a, b]) =>
     allocateColor(a, b, DUBOV_COLOR_RULES, dubovRankCompare),
   );
 
   if (trace) {
-    for (const p of pairings) {
+    for (const p of games) {
       trace({
         black: p.black,
         rule: 'dubov-article-5.2',
@@ -413,8 +413,8 @@ function pair(
   }
 
   return {
-    byes: byeId === undefined ? [] : [{ player: byeId }],
-    pairings,
+    byes: byeId === undefined ? [] : [{ kind: 'pairing', player: byeId }],
+    games,
   };
 }
 

--- a/src/dutch-entry.ts
+++ b/src/dutch-entry.ts
@@ -1,12 +1,12 @@
 export { pair } from './dutch.js';
 export type {
   Bye,
+  CompletedRound,
   Game,
   PairOptions,
   Pairing,
-  PairingResult,
+  Pairings,
   Player,
-  Result,
   TraceCallback,
   TraceEvent,
 } from './types.js';

--- a/src/dutch.ts
+++ b/src/dutch.ts
@@ -29,7 +29,7 @@ import {
 } from './utilities.js';
 
 import type { PairOptions } from './trace.js';
-import type { Game, PairingResult, Player } from './types.js';
+import type { CompletedRound, Pairings, Player } from './types.js';
 import type { PlayerState } from './utilities.js';
 
 // ---------------------------------------------------------------------------
@@ -477,17 +477,17 @@ function finalizePairMC(
 
 function pair(
   players: Player[],
-  games: Game[][],
+  rounds: CompletedRound[],
   options?: PairOptions,
-): PairingResult {
+): Pairings {
   if (players.length < 2) {
     throw new RangeError('at least 2 players are required');
   }
 
   const trace = options?.trace;
-  const playedRounds = games.length;
+  const playedRounds = rounds.length;
   const expectedRounds = options?.expectedRounds ?? playedRounds + 1;
-  const states = buildPlayerStates(players, games);
+  const states = buildPlayerStates(players, rounds);
 
   // Sort: score DESC, TPN ASC
   const sorted = [...states].toSorted((a, b) =>
@@ -600,7 +600,7 @@ function pair(
   const np = pairedSorted.length;
 
   if (np < 2) {
-    return { byes: [], pairings: [] };
+    return { byes: [], games: [] };
   }
 
   // -------------------------------------------------------------------------
@@ -1683,12 +1683,12 @@ function pair(
     result.push(a.tpn < b.tpn ? [a, b] : [b, a]);
   }
 
-  const pairings = result.map(([a, b]) =>
+  const games = result.map(([a, b]) =>
     allocateColor(a, b, FIDE_COLOR_RULES, dutchRankCompare),
   );
 
   if (trace) {
-    for (const p of pairings) {
+    for (const p of games) {
       trace({
         black: p.black,
         rule: 'dutch-article-5.2',
@@ -1700,8 +1700,8 @@ function pair(
   }
 
   return {
-    byes: byeId === undefined ? [] : [{ player: byeId }],
-    pairings,
+    byes: byeId === undefined ? [] : [{ kind: 'pairing', player: byeId }],
+    games,
   };
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,13 +1,12 @@
 export { pair } from './dutch.js';
 export type {
   Bye,
+  CompletedRound,
   Game,
-  GameKind,
   PairOptions,
   Pairing,
-  PairingResult,
+  Pairings,
   Player,
-  Result,
   TraceCallback,
   TraceEvent,
 } from './types.js';

--- a/src/lim-entry.ts
+++ b/src/lim-entry.ts
@@ -1,12 +1,12 @@
 export { pair } from './lim.js';
 export type {
   Bye,
+  CompletedRound,
   Game,
   PairOptions,
   Pairing,
-  PairingResult,
+  Pairings,
   Player,
-  Result,
   TraceCallback,
   TraceEvent,
 } from './types.js';

--- a/src/lim.ts
+++ b/src/lim.ts
@@ -29,12 +29,11 @@ import {
   allocateColor,
   assignBye,
   buildPlayerStates,
-  normaliseGames,
   scoreGroups,
 } from './utilities.js';
 
 import type { PairOptions } from './trace.js';
-import type { Game, PairingResult, Player } from './types.js';
+import type { CompletedRound, Pairings, Player } from './types.js';
 import type { PlayerState } from './utilities.js';
 import type { BracketContext, Criterion } from './weights.js';
 
@@ -263,18 +262,17 @@ const LIM_CRITERIA: Criterion[] = [
 
 function pair(
   players: Player[],
-  games: Game[][],
+  rounds: CompletedRound[],
   options?: PairOptions,
-): PairingResult {
+): Pairings {
   if (players.length < 2) {
     throw new RangeError('at least 2 players are required');
   }
 
   const trace = options?.trace;
 
-  const normalisedGames = normaliseGames(games);
-  const totalRounds = normalisedGames.length + 1;
-  const states = buildPlayerStates(players, normalisedGames);
+  const totalRounds = rounds.length + 1;
+  const states = buildPlayerStates(players, rounds);
 
   // Sort: score DESC, tpn ASC
   const sorted = [...states].toSorted((a, b) =>
@@ -292,7 +290,7 @@ function pair(
   // -------------------------------------------------------------------------
   let byeState: PlayerState | undefined;
   if (needsBye) {
-    byeState = assignBye(sorted, normalisedGames, limByeTiebreak);
+    byeState = assignBye(sorted, rounds, limByeTiebreak);
   }
 
   const byeId = byeState?.id;
@@ -340,7 +338,7 @@ function pair(
     totalRounds,
     tournament: {
       expectedRounds: totalRounds,
-      playedRounds: totalRounds - 1,
+      playedRounds: rounds.length,
     },
   };
 
@@ -375,12 +373,12 @@ function pair(
   // -------------------------------------------------------------------------
   // Allocate colours
   // -------------------------------------------------------------------------
-  const pairings = allPairedTuples.map(([a, b]) =>
+  const games = allPairedTuples.map(([a, b]) =>
     allocateColor(a, b, FIDE_COLOR_RULES, limRankCompare),
   );
 
   if (trace) {
-    for (const p of pairings) {
+    for (const p of games) {
       trace({
         black: p.black,
         rule: 'lim-article-5.2',
@@ -392,8 +390,8 @@ function pair(
   }
 
   return {
-    byes: byeId === undefined ? [] : [{ player: byeId }],
-    pairings,
+    byes: byeId === undefined ? [] : [{ kind: 'pairing', player: byeId }],
+    games,
   };
 }
 

--- a/src/swiss-team.ts
+++ b/src/swiss-team.ts
@@ -10,7 +10,7 @@ import {
 } from './utilities.js';
 
 import type { PairOptions } from './trace.js';
-import type { Game, PairingResult, Player } from './types.js';
+import type { CompletedRound, Pairings, Player } from './types.js';
 import type { PlayerState } from './utilities.js';
 
 /**
@@ -23,7 +23,7 @@ import type { PlayerState } from './utilities.js';
  * Then applies rules 4.3.1 through 4.3.9 in descending priority.
  */
 function makeAllocateTeamColors(
-  games: Game[][],
+  rounds: CompletedRound[],
 ): (a: PlayerState, b: PlayerState) => { black: string; white: string } {
   return function allocateTeamColors(
     a: PlayerState,
@@ -34,8 +34,8 @@ function makeAllocateTeamColors(
       a.score > b.score || (a.score === b.score && a.tpn < b.tpn);
     const [first, other] = firstIsA ? [a, b] : [b, a];
 
-    const firstHistory = matchColorHistory(first.id, games);
-    const otherHistory = matchColorHistory(other.id, games);
+    const firstHistory = matchColorHistory(first.id, rounds);
+    const otherHistory = matchColorHistory(other.id, rounds);
 
     // Helper: give first-team White.
     const firstWhite = (): { black: string; white: string } => ({
@@ -56,8 +56,8 @@ function makeAllocateTeamColors(
     }
 
     // 4.3.2 — Only one team has a Type A color preference → grant it.
-    const firstPref = typeAColorPreference(first.id, games);
-    const otherPref = typeAColorPreference(other.id, games);
+    const firstPref = typeAColorPreference(first.id, rounds);
+    const otherPref = typeAColorPreference(other.id, rounds);
 
     if (firstPref !== undefined && otherPref === undefined) {
       return firstPref === 'white' ? firstWhite() : firstBlack();
@@ -136,16 +136,16 @@ function makeAllocateTeamColors(
  */
 function pair(
   players: Player[],
-  games: Game[][],
+  rounds: CompletedRound[],
   options?: PairOptions,
-): PairingResult {
+): Pairings {
   if (players.length < 2) {
     throw new RangeError('at least 2 players are required');
   }
 
   const trace = options?.trace;
 
-  const states = buildPlayerStates(players, games);
+  const states = buildPlayerStates(players, rounds);
   const ranked = rankByScoreThenTPN(states);
   const byeState = assignLexicographicBye(ranked);
 
@@ -161,10 +161,10 @@ function pair(
   }
 
   const toBePaired = ranked.filter((s) => s.id !== byeId);
-  const pairings = pairAllBrackets(toBePaired, makeAllocateTeamColors(games));
+  const games = pairAllBrackets(toBePaired, makeAllocateTeamColors(rounds));
 
   if (trace) {
-    for (const p of pairings) {
+    for (const p of games) {
       trace({
         phase: 'main',
         playerA: p.white,
@@ -183,8 +183,8 @@ function pair(
   }
 
   return {
-    byes: byeId === undefined ? [] : [{ player: byeId }],
-    pairings,
+    byes: byeId === undefined ? [] : [{ kind: 'pairing', player: byeId }],
+    games,
   };
 }
 

--- a/src/team-entry.ts
+++ b/src/team-entry.ts
@@ -1,12 +1,12 @@
 export { pair } from './swiss-team.js';
 export type {
   Bye,
+  CompletedRound,
   Game,
   PairOptions,
   Pairing,
-  PairingResult,
+  Pairings,
   Player,
-  Result,
   TraceCallback,
   TraceEvent,
 } from './types.js';

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,12 +2,11 @@ type FloatKind = 'down' | 'up' | undefined;
 
 export type {
   Bye,
+  CompletedRound,
   Game,
-  GameKind,
   Pairing,
-  PairingResult,
+  Pairings,
   Player,
-  Result,
 } from '@echecs/tournament';
 
 export type { FloatKind };

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -3,7 +3,7 @@
  * Shared utilities for all FIDE Swiss pairing systems.
  * Provides a precomputed PlayerState struct and related helper functions.
  */
-import type { FloatKind, Game, Player } from './types.js';
+import type { CompletedRound, FloatKind, Game, Player } from './types.js';
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -31,6 +31,23 @@ interface PlayerState {
 }
 
 // ---------------------------------------------------------------------------
+// scoreFor helper
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns the score earned by `player` in a game.
+ * 1 for a win, 0.5 for a draw, 0 for a loss or no-result.
+ */
+function scoreFor(player: string, game: Game): number {
+  if (game.result === 'draw') return 0.5;
+  if (game.result === 'none') return 0;
+  return (game.result === 'white' && game.white === player) ||
+    (game.result === 'black' && game.black === player)
+    ? 1
+    : 0;
+}
+
+// ---------------------------------------------------------------------------
 // New precomputed PlayerState API
 // ---------------------------------------------------------------------------
 
@@ -38,32 +55,42 @@ interface PlayerState {
  * Builds all PlayerState objects from the player list and game history.
  * All per-player data is computed once and cached.
  */
-function buildPlayerStates(players: Player[], games: Game[][]): PlayerState[] {
-  const roundCount = games.length;
+function buildPlayerStates(
+  players: Player[],
+  rounds: CompletedRound[],
+): PlayerState[] {
+  const roundCount = rounds.length;
 
   // Precompute cumulative score table: cumulativeScore[roundIndex] maps
   // player id → score BEFORE that round.
   const cumulativeScore: Map<string, number>[] = [];
   const runningScoreMap = new Map<string, number>();
 
-  for (const round of games) {
+  for (const round of rounds) {
     cumulativeScore.push(new Map(runningScoreMap));
-    for (const game of round) {
-      if (game.black === '') {
-        // Bye: only white receives points
-        runningScoreMap.set(
-          game.white,
-          (runningScoreMap.get(game.white) ?? 0) + game.result,
-        );
-        continue;
-      }
+    // Byes
+    for (const bye of round.byes) {
+      // full and pairing byes award 1 point; half-bye awards 0.5; zero-bye awards 0
+      const byePoints =
+        bye.kind === 'full' || bye.kind === 'pairing'
+          ? 1
+          : bye.kind === 'half'
+            ? 0.5
+            : 0;
+      runningScoreMap.set(
+        bye.player,
+        (runningScoreMap.get(bye.player) ?? 0) + byePoints,
+      );
+    }
+    // Games
+    for (const game of round.games) {
       runningScoreMap.set(
         game.white,
-        (runningScoreMap.get(game.white) ?? 0) + game.result,
+        (runningScoreMap.get(game.white) ?? 0) + scoreFor(game.white, game),
       );
       runningScoreMap.set(
         game.black,
-        (runningScoreMap.get(game.black) ?? 0) + (1 - game.result),
+        (runningScoreMap.get(game.black) ?? 0) + scoreFor(game.black, game),
       );
     }
   }
@@ -79,8 +106,37 @@ function buildPlayerStates(players: Player[], games: Game[][]): PlayerState[] {
     const floatHistory: FloatKind[] = [];
 
     for (let roundIndex = 0; roundIndex < roundCount; roundIndex++) {
-      const round = games[roundIndex] as Game[];
-      const game = round.find((g) => g.white === id || g.black === id);
+      const round = rounds[roundIndex] as CompletedRound;
+
+      // Check for bye first
+      const bye = round.byes.find((b) => b.player === id);
+      if (bye !== undefined) {
+        // C++ eligibleForBye: player is ineligible when an unplayed match
+        // awards >= pointsForWin (1) OR is a pairing bye (participatedInPairing
+        // && opponent == self). Half-byes (0.5 pts) and zero-byes (0 pts) do
+        // NOT make a player ineligible for future byes.
+        const byePoints =
+          bye.kind === 'full' || bye.kind === 'pairing'
+            ? 1
+            : bye.kind === 'half'
+              ? 0.5
+              : 0;
+        if (byePoints >= 1) {
+          byeCount++;
+        }
+        score += byePoints;
+        colorHistory.push(undefined);
+        // C++ gameWasPlayed is false for all bye types, so byes count as
+        // unplayed rounds (same as forfeits). This affects the C9 criterion
+        // (minimize unplayed games of bye assignee).
+        unplayedRounds++;
+        // C++ getFloat: points > pointsForLoss → FLOAT_DOWN, else FLOAT_NONE.
+        // pointsForLoss is 0, so only byes awarding > 0 points get downfloat.
+        floatHistory.push(byePoints > 0 ? 'down' : undefined);
+        continue;
+      }
+
+      const game = round.games.find((g) => g.white === id || g.black === id);
 
       if (game === undefined) {
         colorHistory.push(undefined);
@@ -89,37 +145,16 @@ function buildPlayerStates(players: Player[], games: Game[][]): PlayerState[] {
         continue;
       }
 
-      // Bye sentinel: black === ''
-      if (game.black === '') {
-        // C++ eligibleForBye: player is ineligible when an unplayed match
-        // awards >= pointsForWin (1) OR is a pairing bye (participatedInPairing
-        // && opponent == self). Half-byes (0.5 pts) and zero-byes (0 pts) do
-        // NOT make a player ineligible for future byes.
-        if (game.result >= 1) {
-          byeCount++;
-        }
-        score += game.result;
-        colorHistory.push(undefined);
-        // C++ gameWasPlayed is false for all bye types, so byes count as
-        // unplayed rounds (same as forfeits). This affects the C9 criterion
-        // (minimize unplayed games of bye assignee).
-        unplayedRounds++;
-        // C++ getFloat: points > pointsForLoss → FLOAT_DOWN, else FLOAT_NONE.
-        // pointsForLoss is 0, so only byes awarding > 0 points get downfloat.
-        floatHistory.push(game.result > 0 ? 'down' : undefined);
-        continue;
-      }
-
       // Real game
       const isWhite = game.white === id;
 
       // Forfeit — game was not actually played, no color recorded
       // (matches bbpPairings: gameWasPlayed = false for +/- results)
-      const isForfeit =
-        game.kind === 'forfeit-win' || game.kind === 'forfeit-loss';
+      const isForfeit = game.forfeit !== undefined;
       colorHistory.push(isForfeit ? undefined : isWhite ? 'white' : 'black');
 
-      score += isWhite ? game.result : 1 - game.result;
+      const points = scoreFor(id, game);
+      score += points;
 
       // Forfeit — game was not actually played, opponent not recorded
       // (matches bbpPairings: forbiddenPairs only added when gameWasPlayed)
@@ -129,8 +164,7 @@ function buildPlayerStates(players: Player[], games: Game[][]): PlayerState[] {
         unplayedRounds++;
         // C++ eligibleForBye returns false when any unplayed match gives
         // points >= pointsForWin. A forfeit win gives 1 point = full win.
-        const pointsFromForfeit = isWhite ? game.result : 1 - game.result;
-        if (pointsFromForfeit >= 1) {
+        if (points >= 1) {
           byeCount++;
         }
       } else {
@@ -141,9 +175,12 @@ function buildPlayerStates(players: Player[], games: Game[][]): PlayerState[] {
       // Forfeit: bbpPairings treats unplayed games specially —
       // forfeit win (points > loss) = FLOAT_DOWN, otherwise FLOAT_NONE.
       if (isForfeit) {
+        // forfeit win: the player who won the forfeit floats down
+        // game.forfeit === 'black' means black forfeited, white wins
+        // game.forfeit === 'white' means white forfeited, black wins
         const wonForfeit =
-          (isWhite && game.kind === 'forfeit-win') ||
-          (!isWhite && game.kind === 'forfeit-loss');
+          (isWhite && game.forfeit === 'black') ||
+          (!isWhite && game.forfeit === 'white');
         floatHistory.push(wonForfeit ? 'down' : undefined);
       } else {
         const opponentId = isWhite ? game.black : game.white;
@@ -262,7 +299,7 @@ function scoreGroups(states: PlayerState[]): Map<number, PlayerState[]> {
  */
 function assignBye(
   states: PlayerState[],
-  _games: Game[][],
+  _rounds: CompletedRound[],
   tiebreak: (a: PlayerState, b: PlayerState) => number,
 ): PlayerState | undefined {
   if (states.length % 2 === 0) {
@@ -442,58 +479,39 @@ const FIDE_COLOR_RULES: ColorRule[] = [
 ];
 
 // ---------------------------------------------------------------------------
-// Game normalisation
-// ---------------------------------------------------------------------------
-
-/**
- * Normalise games so that the old `black === white` bye sentinel is converted
- * to the canonical `black === ''` sentinel expected by buildPlayerStates.
- */
-function normaliseGames(games: Game[][]): Game[][] {
-  return games.map((round) =>
-    round.map((g) => (g.black === g.white ? { ...g, black: '' } : g)),
-  );
-}
-
-// ---------------------------------------------------------------------------
 // Legacy API — kept for backward compatibility with modules not yet migrated
-// to the PlayerState-based API. These will be removed in tasks 5–11.
+// to the PlayerState-based API.
 // ---------------------------------------------------------------------------
 
-function gamesForPlayer(player: string, games: Game[][]): Game[] {
-  return games.flat().filter((g) => g.white === player || g.black === player);
+function gamesForPlayer(player: string, rounds: CompletedRound[]): Game[] {
+  return rounds
+    .flatMap((r) => r.games)
+    .filter((g) => g.white === player || g.black === player);
 }
 
-function score(player: string, games: Game[][]): number {
+function score(player: string, rounds: CompletedRound[]): number {
   let sum = 0;
-  for (const g of gamesForPlayer(player, games)) {
-    // Skip byes (black === '' or black === white sentinel)
-    if (g.black === '' || g.black === g.white) continue;
-    sum += g.white === player ? g.result : 1 - g.result;
+  for (const g of gamesForPlayer(player, rounds)) {
+    sum += scoreFor(player, g);
   }
   return sum;
 }
 
-function byeScore(player: string, games: Game[][]): number {
-  return gamesForPlayer(player, games).filter((g) => g.black === g.white)
-    .length;
+function byeScore(player: string, rounds: CompletedRound[]): number {
+  return rounds.filter((r) => r.byes.some((b) => b.player === player)).length;
 }
 
-function colorHistory(player: string, games: Game[][]): Color[] {
+function colorHistory(player: string, rounds: CompletedRound[]): Color[] {
   const colors: Color[] = [];
-  for (const round of games) {
-    for (const g of round) {
-      if (g.black === g.white) {
-        continue;
-      }
-      if (g.white === player) {
-        colors.push('white');
-        break;
-      }
-      if (g.black === player) {
-        colors.push('black');
-        break;
-      }
+  for (const round of rounds) {
+    const game = round.games.find(
+      (g) => g.white === player || g.black === player,
+    );
+    if (game === undefined) continue;
+    if (game.white === player) {
+      colors.push('white');
+    } else {
+      colors.push('black');
     }
   }
   return colors;
@@ -503,9 +521,9 @@ function colorHistory(player: string, games: Game[][]): Color[] {
  * Returns the color difference: positive means player has played more black
  * than white (prefers white next), negative means the opposite.
  */
-function colorPreference(player: string, games: Game[][]): number {
+function colorPreference(player: string, rounds: CompletedRound[]): number {
   let diff = 0;
-  for (const color of colorHistory(player, games)) {
+  for (const color of colorHistory(player, rounds)) {
     diff += color === 'black' ? 1 : -1;
   }
   return diff;
@@ -517,11 +535,11 @@ function colorPreference(player: string, games: Game[][]): number {
  */
 function playerScoreGroups(
   players: Player[],
-  games: Game[][],
+  rounds: CompletedRound[],
 ): Map<number, Player[]> {
   const groups = new Map<number, Player[]>();
   for (const player of players) {
-    const s = score(player.id, games);
+    const s = score(player.id, rounds);
     const group = groups.get(s) ?? [];
     group.push(player);
     groups.set(s, group);
@@ -533,18 +551,13 @@ function playerScoreGroups(
  * Returns the number of matches (unique rounds with a real opponent) played.
  * Bye rounds are not counted.
  */
-function matchCount(player: string, games: Game[][]): number {
+function matchCount(player: string, rounds: CompletedRound[]): number {
   let count = 0;
-  for (const round of games) {
-    for (const g of round) {
-      if (g.black === g.white) {
-        continue;
-      }
-      if (g.white === player || g.black === player) {
-        count++;
-        break;
-      }
-    }
+  for (const round of rounds) {
+    const hasGame = round.games.some(
+      (g) => g.white === player || g.black === player,
+    );
+    if (hasGame) count++;
   }
   return count;
 }
@@ -554,22 +567,14 @@ function matchCount(player: string, games: Game[][]): number {
  * For each match (unique round with a real opponent), the color is determined
  * by the first game in that round. Bye rounds are excluded.
  */
-function matchColorHistory(player: string, games: Game[][]): Color[] {
+function matchColorHistory(player: string, rounds: CompletedRound[]): Color[] {
   const colors: Color[] = [];
-  for (const round of games) {
-    for (const g of round) {
-      if (g.black === g.white) {
-        continue;
-      }
-      if (g.white === player) {
-        colors.push('white');
-        break;
-      }
-      if (g.black === player) {
-        colors.push('black');
-        break;
-      }
-    }
+  for (const round of rounds) {
+    const game = round.games.find(
+      (g) => g.white === player || g.black === player,
+    );
+    if (game === undefined) continue;
+    colors.push(game.white === player ? 'white' : 'black');
   }
   return colors;
 }
@@ -577,9 +582,9 @@ function matchColorHistory(player: string, games: Game[][]): Color[] {
 /**
  * Returns true if players a and b have faced each other in any previous game.
  */
-function hasFaced(a: string, b: string, games: Game[][]): boolean {
-  return games
-    .flat()
+function hasFaced(a: string, b: string, rounds: CompletedRound[]): boolean {
+  return rounds
+    .flatMap((r) => r.games)
     .some(
       (g) =>
         (g.white === a && g.black === b) || (g.white === b && g.black === a),
@@ -593,9 +598,9 @@ function hasFaced(a: string, b: string, games: Game[][]): boolean {
 function assignColors(
   a: Player,
   b: Player,
-  games: Game[][],
+  rounds: CompletedRound[],
 ): { black: string; white: string } {
-  if (colorPreference(a.id, games) > 0) {
+  if (colorPreference(a.id, rounds) > 0) {
     return { black: b.id, white: a.id };
   }
   return { black: a.id, white: b.id };
@@ -605,9 +610,9 @@ function assignColors(
  * Returns players sorted by score descending, then rating descending.
  * This is the standard ranking used by all FIDE Swiss pairing systems.
  */
-function rankPlayers(players: Player[], games: Game[][]): Player[] {
+function rankPlayers(players: Player[], rounds: CompletedRound[]): Player[] {
   return [...players].toSorted((a, b) => {
-    const scoreDiff = score(b.id, games) - score(a.id, games);
+    const scoreDiff = score(b.id, rounds) - score(a.id, rounds);
     if (scoreDiff !== 0) {
       return scoreDiff;
     }
@@ -620,16 +625,16 @@ function rankPlayers(players: Player[], games: Game[][]): Player[] {
  * the player count is even. Prefers the lowest-ranked player who has not
  * already received a bye.
  *
- * @deprecated Use assignBye(states, games, tiebreak) instead.
+ * @deprecated Use assignBye(states, rounds, tiebreak) instead.
  */
 function assignByeLegacy(
   ranked: Player[],
-  games: Game[][],
+  rounds: CompletedRound[],
 ): Player | undefined {
   if (ranked.length % 2 === 0) {
     return undefined;
   }
-  const eligible = ranked.filter((p) => byeScore(p.id, games) === 0);
+  const eligible = ranked.filter((p) => byeScore(p.id, rounds) === 0);
   return eligible.at(-1) ?? ranked.at(-1);
 }
 
@@ -639,9 +644,9 @@ function assignByeLegacy(
  */
 function typeAColorPreference(
   player: string,
-  games: Game[][],
+  rounds: CompletedRound[],
 ): Color | undefined {
-  const history = matchColorHistory(player, games);
+  const history = matchColorHistory(player, rounds);
   const whites = history.filter((c) => c === 'white').length;
   const blacks = history.filter((c) => c === 'black').length;
   const cd = whites - blacks; // color difference
@@ -679,13 +684,16 @@ function isTopscorer(playerScore: number, totalRounds: number): boolean {
 
 /**
  * Returns count of rounds where player had no game at all (not even a bye).
- * A bye (g.black === g.white) counts as played.
+ * A bye counts as played.
  */
-function unplayedRounds(player: string, games: Game[][]): number {
+function unplayedRounds(player: string, rounds: CompletedRound[]): number {
   let count = 0;
-  for (const round of games) {
-    const hasGame = round.some((g) => g.white === player || g.black === player);
-    if (!hasGame) {
+  for (const round of rounds) {
+    const hasBye = round.byes.some((b) => b.player === player);
+    const hasGame = round.games.some(
+      (g) => g.white === player || g.black === player,
+    );
+    if (!hasBye && !hasGame) {
       count++;
     }
   }
@@ -698,26 +706,29 @@ function unplayedRounds(player: string, games: Game[][]): number {
  * 'up' = player floated up (lower score),
  * undefined = equal scores or no game that round.
  */
-function floatHistory(player: string, games: Game[][]): FloatKind[] {
+function floatHistory(player: string, rounds: CompletedRound[]): FloatKind[] {
   const result: FloatKind[] = [];
-  for (const [roundIndex, round] of games.entries()) {
-    const game = round.find((g) => g.white === player || g.black === player);
+  for (const [roundIndex, round] of rounds.entries()) {
+    // Check for bye
+    const bye = round.byes.find((b) => b.player === player);
+    if (bye !== undefined) {
+      result.push('down');
+      continue;
+    }
+
+    const game = round.games.find(
+      (g) => g.white === player || g.black === player,
+    );
 
     if (game === undefined) {
       result.push(undefined);
       continue;
     }
 
-    // Bye sentinel: g.black === g.white
-    if (game.black === game.white) {
-      result.push('down');
-      continue;
-    }
-
     const opponent = game.white === player ? game.black : game.white;
-    const previousGames = games.slice(0, roundIndex);
-    const playerScore = score(player, previousGames);
-    const opponentScore = score(opponent, previousGames);
+    const previousRounds = rounds.slice(0, roundIndex);
+    const playerScore = score(player, previousRounds);
+    const opponentScore = score(opponent, previousRounds);
 
     if (playerScore > opponentScore) {
       result.push('down');
@@ -746,7 +757,6 @@ export {
   isTopscorer,
   matchColorHistory,
   matchCount,
-  normaliseGames,
   playerScoreGroups,
   rankPlayers,
   ROUND_1_COLOR_RULE,


### PR DESCRIPTION
## Summary

- all 6 `pair()` signatures changed from `(Player[], Game[][], PairOptions?)` to `(Player[], CompletedRound[], PairOptions?)` to match `@echecs/tournament` v3's `PairingSystem` type
- return type changed from `PairingResult { pairings, byes }` to `Pairings { games, byes }`
- `buildPlayerStates` rewritten for v3: bye detection via `round.byes[]`, forfeit detection via `game.forfeit`, string results via `scoreFor` helper
- `normaliseGames()` removed — no more bye sentinels to normalise
- `Bye` objects now include required `kind: 'pairing'` field
- peer dependency bumped from `@echecs/tournament@^2.0.0` to `@echecs/tournament@^3.0.0`
- `GameKind`, `Result`, `PairingResult` type re-exports removed

**breaking change** — bumps to v4.0.0