### PR TITLE
chore: extract typedocOptions to typedoc.json

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,15 +17,5 @@
     "strict": true,
     "target": "ESNext"
   },
-  "include": ["src/**/*"],
-  "typedocOptions": {
-    "entryPoints": ["src/index.ts"],
-    "excludeInternal": false,
-    "excludePrivate": true,
-    "excludeProtected": false,
-    "includeVersion": true,
-    "out": "docs/api",
-    "readme": "README.md",
-    "sort": ["source-order"]
-  }
+  "include": ["src/**/*"]
 }

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,0 +1,10 @@
+{
+  "entryPoints": ["src/index.ts"],
+  "excludeInternal": false,
+  "excludePrivate": true,
+  "excludeProtected": false,
+  "includeVersion": true,
+  "out": "docs/api",
+  "readme": "README.md",
+  "sort": ["source-order"]
+}


### PR DESCRIPTION
moves typedoc config from `tsconfig.json` to a standalone `typedoc.json` — consistent with all other packages