### PR TITLE
fix: resolve unicorn v65 lint violations

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -56,6 +56,13 @@ export default typescript.config(
       'no-console': 'warn',
       'sort-imports': ['error', { ignoreDeclarationSort: true }],
       'sort-keys': 'error',
+      'unicorn/filename-case': [
+        'error',
+        {
+          case: 'kebabCase',
+          ignore: [/^__tests__$/],
+        },
+      ],
     },
   },
   /**

--- a/src/__tests__/matching-computer.spec.ts
+++ b/src/__tests__/matching-computer.spec.ts
@@ -365,7 +365,10 @@ function initializeDuals(graph: Graph): void {
  * and result[i] = i means vertex i is unmatched (self-loop).
  */
 function getMatching(graph: Graph): number[] {
-  const result = Array.from<number>({ length: graph.vertices.length }).fill(-1);
+  const result = Array.from<unknown, number>(
+    { length: graph.vertices.length },
+    () => -1,
+  );
 
   for (const rb of graph.rootBlossomPool) {
     rb.putVerticesInMatchingOrder();

--- a/src/matching-computer.ts
+++ b/src/matching-computer.ts
@@ -52,7 +52,7 @@ class MatchingComputer {
    * Must be called after `computeMatching`.
    */
   getMatching(): number[] {
-    const result = Array.from<number>({ length: this.size }).fill(-1);
+    const result = Array.from<unknown, number>({ length: this.size }, () => -1);
 
     for (const rb of this.graph.rootBlossomPool) {
       const baseIndex = rb.baseVertex.vertexIndex;

--- a/src/matching/graph.ts
+++ b/src/matching/graph.ts
@@ -495,6 +495,7 @@ class Graph implements GraphLike {
         const pathBack: Vertex[] = [vertex1];
 
         // Expand front toward its exposed root.
+
         while (pathFront[0]!.rootBlossom!.baseVertexMatch) {
           const front = pathFront[0]!;
           pathFront.unshift(front.rootBlossom!.baseVertex);


### PR DESCRIPTION
fixes `__tests__` directory name, `Array.from().fill()`, and `prefer-single-call` violations from unicorn v65.